### PR TITLE
Align styling and copy with data trails

### DIFF
--- a/src/components/Explore/AddToFiltersGraphAction.tsx
+++ b/src/components/Explore/AddToFiltersGraphAction.tsx
@@ -43,8 +43,8 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {
     return (
-      <Button variant="primary" size="sm" fill="text" onClick={model.onClick}>
-        Add to search
+      <Button variant="secondary" size="sm" onClick={model.onClick}>
+        Add to filters
       </Button>
     );
   };

--- a/src/components/Explore/LogsByService/Tabs/AddToPatternsGraphAction.tsx
+++ b/src/components/Explore/LogsByService/Tabs/AddToPatternsGraphAction.tsx
@@ -32,8 +32,8 @@ export class AddToPatternsGraphAction extends SceneObjectBase<AddToPatternsGraph
   public static Component = ({ model }: SceneComponentProps<AddToPatternsGraphAction>) => {
     const { type } = model.useState();
     return (
-      <Button variant="primary" size="sm" fill="text" onClick={model.onClick}>
-        {type === 'include' ? 'Add to search' : 'Exclude from search'}
+      <Button variant="secondary" size="sm" onClick={model.onClick}>
+        {type === 'include' ? 'Add to filters' : 'Exclude from filters'}
       </Button>
     );
   };

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -383,7 +383,7 @@ export class SelectLabelAction extends SceneObjectBase<SelectLabelActionState> {
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {
     return (
-      <Button variant="primary" size="sm" fill="text" onClick={model.onClick}>
+      <Button variant="primary" size="sm" onClick={model.onClick}>
         Select
       </Button>
     );

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -350,7 +350,7 @@ export class SelectLabelAction extends SceneObjectBase<SelectLabelActionState> {
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {
     return (
-      <Button variant="primary" size="sm" fill="text" onClick={model.onClick}>
+      <Button variant="secondary" size="sm" onClick={model.onClick}>
         Select
       </Button>
     );

--- a/src/components/Explore/LogsByService/Tabs/PatternsScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/PatternsScene.tsx
@@ -243,7 +243,7 @@ export class SelectLabelAction extends SceneObjectBase<SelectLabelActionState> {
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {
     return (
-      <Button variant="primary" size="sm" fill="text" onClick={model.onClick}>
+      <Button variant="secondary" size="sm" fill="text" onClick={model.onClick}>
         Select
       </Button>
     );

--- a/src/pages/Explore/SelectAttributeWithValueAction.tsx
+++ b/src/pages/Explore/SelectAttributeWithValueAction.tsx
@@ -41,7 +41,7 @@ export class SelectAttributeWithValueAction extends SceneObjectBase<SelectAttrib
 
   public static Component = ({ model }: SceneComponentProps<SelectAttributeWithValueAction>) => {
     return (
-      <Button variant="primary" size="sm" fill="text" onClick={model.onClick}>
+      <Button variant="secondary" size="sm" onClick={model.onClick}>
         Select
       </Button>
     );


### PR DESCRIPTION
Continues on https://github.com/grafana/loki-explore/issues/21

The styling and copy should be consistent with data trails, so I updated styling to match following in the data trails

<img width="498" alt="image" src="https://github.com/grafana/loki-explore/assets/30407135/e3b9883f-1e11-4e25-9e0b-9654c74f5ea9">
<img width="661" alt="image" src="https://github.com/grafana/loki-explore/assets/30407135/faada088-637a-405e-a07c-fb1639551ca1">
