### PR TITLE
fix(logs exploration): refactor timepicker to be always top right

### DIFF
--- a/src/pages/Explore/LogExploration.tsx
+++ b/src/pages/Explore/LogExploration.tsx
@@ -309,14 +309,15 @@ function getStyles(theme: GrafanaTheme2) {
     filters: css({
       display: 'flex',
       gap: theme.spacing(2),
-      width: 'calc(100% - 360)',
+      width: 'calc(100% - 400)',
       flexWrap: 'wrap',
       alignItems: 'flex-end',
     }),
     controls: css({
       display: 'flex',
-      maxWidth: 360,
+      maxWidth: 400,
       paddingTop: theme.spacing(3),
+      gap: theme.spacing(2),
     }),
     rotateIcon: css({
       svg: { transform: 'rotate(180deg)' },


### PR DESCRIPTION
We can customize how we render the controls.

Fixes https://github.com/grafana/loki-explore/issues/16

Before:

![Before](https://github.com/grafana/loki-explore/assets/1069378/2b8b329d-987c-486d-96d8-4197db14909c)

After:

![After](https://github.com/grafana/loki-explore/assets/1069378/9d67f07a-f324-4540-95ec-73be3a5ba8d6)

Demo:

https://github.com/grafana/loki-explore/assets/1069378/fab42309-1230-4b98-b7d4-ad457838ea5d