### PR TITLE
Volume queries: Drop errors so panels don't error out

### DIFF
--- a/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
+++ b/src/components/Explore/LogsByService/LogTimeSeriesPanel.tsx
@@ -120,7 +120,7 @@ export class LogTimeSeriesPanel extends SceneObjectBase<LogTimeSeriesPanelState>
 function buildQuery() {
   return {
     refId: 'A',
-    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} [$__auto])) by (level)`,
+    expr: `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (level)`,
     queryType: 'range',
     editorMode: 'code',
   };

--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -298,7 +298,7 @@ function getExpr(field: string) {
       `(${field}) [$__auto]) by ()`
     );
   }
-  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} [$__auto]))`;
+  return `sum by (${field}) (count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__  [$__auto]))`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -252,7 +252,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>) {
 }
 
 function getExpr(tagKey: string) {
-  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} [$__auto])) by (${tagKey})`;
+  return `sum(count_over_time(${LOG_STREAM_SELECTOR_EXPR} | drop __error__ [$__auto])) by (${tagKey})`;
 }
 
 function buildQuery(tagKey: string) {

--- a/src/pages/Explore/SelectStartingPointScene.tsx
+++ b/src/pages/Explore/SelectStartingPointScene.tsx
@@ -348,7 +348,7 @@ function buildVolumeQuery(services: string[]) {
   const stream = `${SERVICE_NAME}=~"${services.join('|')}"`;
   return {
     refId: 'A',
-    expr: `sum by(${SERVICE_NAME}, level) (count_over_time({${stream}} | __error__="" [$__auto]))`,
+    expr: `sum by(${SERVICE_NAME}, level) (count_over_time({${stream}} | drop __error__ [$__auto]))`,
     queryType: 'range',
     legendFormat: '{{level}}',
     maxLines: 100,


### PR DESCRIPTION
Fixes https://github.com/grafana/loki-explore/issues/66 by adding `| drop __error__` to all volume queries, so they don't error out. 