### PR TITLE
Make service search search in Loki for top 20 services

### DIFF
--- a/src/pages/Explore/SelectStartingPointScene.tsx
+++ b/src/pages/Explore/SelectStartingPointScene.tsx
@@ -112,7 +112,7 @@ export class SelectStartingPointScene extends SceneObjectBase<LogSelectSceneStat
       }
 
       if (newState.searchServicesString !== oldState.searchServicesString) {
-        const services = this.state.topServices?.filter((service) => service.toLowerCase().includes(newState.searchServicesString.toLowerCase() ?? ''))
+        const services = this.state.topServices?.filter((service) => service.toLowerCase().includes(newState.searchServicesString?.toLowerCase() ?? ''))
         this.setState({
           topServicesToBeUsed: services?.slice(0, LIMIT_SERVICES),
         })


### PR DESCRIPTION
To demonstrate the functionality and to show how it works, I am only showing 2 services in this small demo:

https://github.com/grafana/loki-explore/assets/30407135/99b76d4e-eca0-4460-9d7a-9f840cd31235

