### PR TITLE
fix(filters) - visibility hidden and double live tail bug

### DIFF
--- a/src/pages/Explore/LogExploration.tsx
+++ b/src/pages/Explore/LogExploration.tsx
@@ -191,9 +191,12 @@ export class LogExploration extends SceneObjectBase<LogExplorationState> {
       hide: VariableHide.dontHide,
     });
 
-    this.setState({
-      controls: [...this.state.controls, new LiveTailControl({})],
-    });
+    const isLiveTailEnabled = this.state.controls.some((control) => control instanceof LiveTailControl === true);
+    if (!isLiveTailEnabled) {
+      this.setState({
+        controls: [...this.state.controls, new LiveTailControl({})],
+      });
+    }
     locationService.partial({ mode: 'logs' });
   }
 
@@ -400,10 +403,15 @@ function getStyles(theme: GrafanaTheme2) {
       width: 'calc(100% - 450)',
       flexWrap: 'wrap',
       alignItems: 'flex-end',
-      
-      ['label[for="var-adhoc_service_filter"] + div >[title="Add filter"]']: {
-        display: "none"
-      }
+      '& + div[data-testid="data-testid Dashboard template variables submenu Label Filters"]:empty': {
+        visibility: 'hidden',
+      },
+      ['div >[title="Add filter"]']: {
+        visibility: 'hidden',
+        width: 0,
+        padding: 0,
+        margin: 0,
+      },
     }),
     controls: css({
       display: 'flex',


### PR DESCRIPTION
### Description

### Fixed Double live tail in the upper right
![Screenshot 2024-04-02 at 1 38 07 PM](https://github.com/grafana/loki-explore/assets/114438185/0a62cdf3-b9bc-4903-9af2-290f0d03051a)
To recreate add services + filters then remove and _handleStartingPointSelected() was called again.

### CSS Filters Hide
Continuing on the incredible work by @svennergr. I hid the filters `+` icon because those dropdowns were empty.

Filters empty before
![Screenshot 2024-04-02 at 11 26 57 AM](https://github.com/grafana/loki-explore/assets/114438185/c7ebcf36-81b9-4f75-85e1-fdef9a828f85)

Filters empty now
![Screenshot 2024-04-02 at 1 37 44 PM](https://github.com/grafana/loki-explore/assets/114438185/14b0b5fd-bec7-4802-b44f-ff3341ce5ab9)

Filter dropdowns show no data so we wanted to remove the plus icon here. The service drop down + was actually okay so I could put that back if we want.
![Screenshot 2024-04-02 at 11 26 32 AM](https://github.com/grafana/loki-explore/assets/114438185/3c0c019c-c8e2-47ac-880c-2bea635a37a1)
