### PR TITLE
add `appSubUrl` in go to explore link

### DIFF
--- a/src/components/Explore/LogsByService/GoToExploreButton.tsx
+++ b/src/components/Explore/LogsByService/GoToExploreButton.tsx
@@ -7,6 +7,7 @@ import { getDataSource, getQueryExpr } from '../../../utils/utils';
 import { sceneGraph } from '@grafana/scenes';
 import { toURLRange, urlUtil } from '@grafana/data';
 import { VAR_LOGS_FORMAT_EXPR } from 'utils/shared';
+import { config } from '@grafana/runtime';
 
 interface ShareExplorationButtonState {
   exploration: LogExploration;
@@ -14,15 +15,24 @@ interface ShareExplorationButtonState {
 
 export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) => {
   const onClick = () => {
-    const datasource = getDataSource(exploration)
-    const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '')
-    const timeRange = sceneGraph.getTimeRange(exploration).state.value
+    const datasource = getDataSource(exploration);
+    const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '');
+    const timeRange = sceneGraph.getTimeRange(exploration).state.value;
     const exploreState = JSON.stringify({
-      ['loki-explore']: { range: toURLRange(timeRange.raw), queries: [{refId: 'logs',expr, datasource}], datasource}
-    })
-    const link = urlUtil.renderUrl('/explore', { panes: exploreState, schemaVersion: 1 });
+      ['loki-explore']: {
+        range: toURLRange(timeRange.raw),
+        queries: [{ refId: 'logs', expr, datasource }],
+        datasource,
+      },
+    });
+    const subUrl = config.appSubUrl ?? '';
+    const link = urlUtil.renderUrl(`${subUrl}/explore`, { panes: exploreState, schemaVersion: 1 });
     window.open(link, '_blank');
   };
 
-  return <ToolbarButton variant={'canvas'} icon={'compass'} onClick={onClick}>Open in Explore</ToolbarButton>;
+  return (
+    <ToolbarButton variant={'canvas'} icon={'compass'} onClick={onClick}>
+      Open in Explore
+    </ToolbarButton>
+  );
 };


### PR DESCRIPTION
Some Grafana instances, such as the admin-* instances, run with an `appSubUrl` configured. Meaning, Grafana does not run on the root url, but some "sub directory".

Actually this PR only adds 
```
const subUrl = config.appSubUrl ?? '';
...
`${subUrl}/explore`
```

The rest is missing formatting.