### PR TITLE
feat(goToExplore): clean up extra spaces from query

### DIFF
--- a/src/components/Explore/LogsByService/GoToExploreButton.tsx
+++ b/src/components/Explore/LogsByService/GoToExploreButton.tsx
@@ -16,7 +16,7 @@ interface ShareExplorationButtonState {
 export const GoToExploreButton = ({ exploration }: ShareExplorationButtonState) => {
   const onClick = () => {
     const datasource = getDataSource(exploration);
-    const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '').trimEnd();
+    const expr = getQueryExpr(exploration).replace(VAR_LOGS_FORMAT_EXPR, '').replace(/\s+/g, ' ').trimEnd();
     const timeRange = sceneGraph.getTimeRange(exploration).state.value;
     const exploreState = JSON.stringify({
       ['loki-explore']: {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -37,7 +37,7 @@ export function getDataSource(exploration: LogExploration) {
 }
 
 export function getQueryExpr(exploration: LogExploration) {
-  return sceneGraph.interpolate(exploration, LOG_STREAM_SELECTOR_EXPR).replace(/\s+/, ' ');
+  return sceneGraph.interpolate(exploration, LOG_STREAM_SELECTOR_EXPR).replace(/\s+/g, ' ');
 }
 
 export function getDataSourceName(dataSourceUid: string) {


### PR DESCRIPTION
Removing extra spaces from the query.

Before: 

![imagen](https://github.com/grafana/loki-explore/assets/1069378/7797703b-494b-404c-a1b9-d6b319ccd140)

After:

![imagen](https://github.com/grafana/loki-explore/assets/1069378/6422208f-9055-47f8-8ba4-ac53118950b4)
