### PR TITLE
chore(release): use new shared workflows for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: grafana/plugin-actions/build-plugin@release
-        # Uncomment to enable plugin signing
-        # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
-#        with:
-        # Make sure to save the token in your repository secrets
-#          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-        # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
-        #grafana_token: $
+      - uses: grafana/plugin-actions/build-plugin@main
+        id: build-release
+        with:
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+      - name: Get plugin metadata
+        id: metadata
+        run: |
+          sudo apt-get install jq
+
+          export GRAFANA_PLUGIN_ID=$(cat src/plugin.json | jq -r .id)
+          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-latest.zip
+
+          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
+          echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
+
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          common_secrets: |
+            GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
+
+      - id: 'create-latest'
+        run: cp ${{ steps.build-release.outputs.archive }} ${{ steps.metadata.outputs.archive }}
+
+      - id: 'upload-to-gcs'
+        name: 'Upload assets to latest'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: ./
+          destination: 'integration-artifacts/grafana-lokiexplore-app/'
+          glob: '*.zip'
+          parent: false


### PR DESCRIPTION
### Description
Use the new `shared-workflows` from @adrapereira [traces](https://github.com/grafana/traces-app/blob/main/.github/workflows/release.yml) 

### Questions
- [x] Does `destination: 'integration-artifacts/grafana-lokiexplore-app/'` upload to https://console.cloud.google.com/storage/browser/grafana-lokiexplore-app;tab=objects?q=search&referrer=search&project=grafanalabs-dev&prefix=&forceOnObjectsSortingFiltering=false
- [x] How do we run git tag locally? `git tag v0.0.2` `git push origin v1.0.3`