### PR TITLE
fix: clone children to prevent incorrect parent references

### DIFF
--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -206,7 +206,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         new SceneCSSGridLayout({
           templateColumns: '1fr',
           autoRows: '200px',
-          children: children,
+          children: children.map(child => child.clone()),
         }),
       ],
     });

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -254,7 +254,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>) {
       new SceneCSSGridLayout({
         templateColumns: '1fr',
         autoRows: '200px',
-        children: children,
+        children: children.map(child => child.clone()),
       }),
     ],
   });

--- a/src/components/Explore/LogsByService/Tabs/PatternsScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/PatternsScene.tsx
@@ -165,7 +165,7 @@ export class PatternsScene extends SceneObjectBase<PatternsSceneState> {
           new SceneCSSGridLayout({
             templateColumns: '1fr',
             autoRows: '200px',
-            children: children,
+            children: children.map(child => child.clone()),
           }),
         ],
       }),


### PR DESCRIPTION
From https://github.com/grafana/loki-explore/pull/129

Fixes the issues with Scenes having the wrong parent references.