### PR TITLE
fix: remove rendered length from screen

### DIFF
--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -148,7 +148,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       <div className={styles.container}>
         <StatusWrapper {...{ isLoading: loading, blockingMessage }}>
           <div className={styles.controls}>
-            {!loading && labels.length && (
+            {!loading && labels.length > 0 && (
               <div className={styles.controlsLeft}>
                 <Field label="By label">
                   <BreakdownLabelSelector options={labels} value={value} onChange={model.onChange} />


### PR DESCRIPTION
Fixes a "0" that gets rendered.

![imagen](https://github.com/grafana/loki-explore/assets/1069378/77394916-d0eb-4d8c-8d75-96bd84d3cb38)
