### PR TITLE
Set max width for inputs

### DIFF
--- a/src/pages/Explore/LogExploration.tsx
+++ b/src/pages/Explore/LogExploration.tsx
@@ -413,10 +413,11 @@ function getStyles(theme: GrafanaTheme2) {
         '& > div': {
           // The actual inputs container
           '& > div': {
+            flexWrap: 'wrap',
             // wrapper around all inputs
             '& > div': {
               maxWidth: '380px',
-              flex: '1 0 auto',
+              
               // Wrapper around each input: i.e. label name, binary operator, value
               '& > div': {
                 // These inputs need to flex, otherwise the value takes all of available space and they look broken


### PR DESCRIPTION
Fixes https://github.com/grafana/loki-explore/issues/134

I bet this is a bug in scenes as well for inputs with long values. Datatrails doesn't appear to use this style of input, so I wasn't able to reproduce there.
Flagging with scenes label so we remember to figure out if this should be submitted upstream when we have more capacity.

<img width="1728" alt="image" src="https://github.com/grafana/loki-explore/assets/109082771/ec132bea-9e00-4795-b4d4-2090bf286884">

<img width="765" alt="image" src="https://github.com/grafana/loki-explore/assets/109082771/70ed9a3f-879f-4cc1-a8ab-b002771e721d">

