### PR TITLE
Release branch for v0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-lokiexplore-app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Query less exploration of log data stored in Loki",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
### Description
I believe the release job failed because https://github.com/grafana/loki-explore/actions/runs/8544080798 the version number was incorrect.  I will try again once this merges. 

`npm version patch` - this worked
`git push --tags origin main` - this failed because we protect the main branch


The flow in the future should probably be: 
1. `npm version patch` 
2. Create a PR to update the package.json - merge PR
3. `git push --tags`