### PR TITLE
chore(release): update github action permissions id-token: write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
### Description
Copy paste is hard, I missed this `id-token: write` 
https://github.com/grafana/traces-app/blob/main/.github/workflows/release.yml
https://github.com/google-github-actions/auth#usage