### PR TITLE
hardcode `level` label

### DIFF
--- a/src/components/Explore/LogsByService/LogsByServiceScene.tsx
+++ b/src/components/Explore/LogsByService/LogsByServiceScene.tsx
@@ -117,8 +117,8 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
     const fields = sceneGraph.lookupVariable(VAR_FIELDS, this)! as AdHocFiltersVariable;
     fields.setState({ filters: [] });
 
-    // Use locationService to do the redirect and allow the users to start afresh, 
-    // potentially getting them unstuck of any leakage produced by subscribers, listeners, 
+    // Use locationService to do the redirect and allow the users to start afresh,
+    // potentially getting them unstuck of any leakage produced by subscribers, listeners,
     // variables, etc.,  without having to do a full reload.
     const params = locationService.getSearch();
     const newParams = new URLSearchParams();
@@ -180,9 +180,9 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
 
   private onReferencedVariableValueChanged(variable: SceneVariable) {
     if (variable.state.name === VAR_DATASOURCE) {
-      this.redirectToStart()
+      this.redirectToStart();
       return;
-    } 
+    }
     const filterVariable = this.getFiltersVariable();
     if (filterVariable.state.filters.length === 0) {
       return;
@@ -282,7 +282,13 @@ export class LogsByServiceScene extends SceneObjectBase<LogSceneState> {
       return;
     }
 
-    const labels = detectedLabels.filter((a) => a.cardinality > 1).sort((a, b) => a.cardinality - b.cardinality).map((l) => l.label);
+    const labels = detectedLabels
+    .filter((a) => a.cardinality > 1)
+    .sort((a, b) => a.cardinality - b.cardinality)
+    .map((l) => l.label);
+    if (!labels.includes('level')) {
+      labels.unshift('level');
+    }
     if (JSON.stringify(labels) !== JSON.stringify(this.state.labels)) {
       this.setState({ labels });
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -10,7 +10,13 @@ import {
 } from '@grafana/scenes';
 
 import { LogExploration } from '../pages/Explore';
-import { ALL_VARIABLE_VALUE, EXPLORATIONS_ROUTE, LOG_STREAM_SELECTOR_EXPR, VAR_DATASOURCE_EXPR, VAR_FILTERS } from './shared';
+import {
+  ALL_VARIABLE_VALUE,
+  EXPLORATIONS_ROUTE,
+  LOG_STREAM_SELECTOR_EXPR,
+  VAR_DATASOURCE_EXPR,
+  VAR_FILTERS,
+} from './shared';
 
 export function getExplorationFor(model: SceneObject): LogExploration {
   return sceneGraph.getAncestor(model, LogExploration);
@@ -74,10 +80,17 @@ export function getLabelOptions(scenObject: SceneObject, allOptions: string[]) {
     }
   }
 
-  return [{ label: 'All', value: ALL_VARIABLE_VALUE }, ...labelOptions];
+  const levelOption = [];
+  if (!allOptions.includes('level')) {
+    levelOption.push({ label: 'level', value: 'level' });
+  }
+
+  return [{ label: 'All', value: ALL_VARIABLE_VALUE }, ...levelOption, ...labelOptions];
 }
 
 export async function getDatasource(sceneObject: SceneObject) {
-  const ds = await getDataSourceSrv().get(VAR_DATASOURCE_EXPR, { __sceneObject: { value: sceneObject } }) as DataSourceWithBackend | undefined;
+  const ds = (await getDataSourceSrv().get(VAR_DATASOURCE_EXPR, { __sceneObject: { value: sceneObject } })) as
+    | DataSourceWithBackend
+    | undefined;
   return ds;
 }


### PR DESCRIPTION
We are adding the hardcoded `level` label for now. Unfortunately we don't get this via the `/detected_labels` API, since `level` is structured metadata, but it is super helpful to filter based on the `level` label.