### PR TITLE
Revert "Logs panel min-height"

### DIFF
--- a/src/components/Explore/LogsByService/Tabs/LogsListScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LogsListScene.tsx
@@ -41,7 +41,6 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
           ySizing: 'content',
         }),
         new SceneFlexItem({
-          minHeight: 'calc(100vh - 220px)',
           body: getLogsPanel(),
         }),
       ],


### PR DESCRIPTION
Reverts grafana/explore-logs#173

This is breaking the logs panel in firefox