### PR TITLE
Simplify naming and add loading state for labels and fields

### DIFF
--- a/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/FieldsBreakdownScene.tsx
@@ -16,10 +16,11 @@ import {
   SceneObjectBase,
   SceneObjectState,
   SceneQueryRunner,
+  SceneReactObject,
   SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Button, DrawStyle, Field, StackingMode, useStyles2 } from '@grafana/ui';
+import { Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 
 import { BreakdownLabelSelector } from './BreakdownLabelSelector';
 import { StatusWrapper } from '../../StatusWrapper';
@@ -207,7 +208,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         new SceneCSSGridLayout({
           templateColumns: '1fr',
           autoRows: '200px',
-          children: children.map((child) => child.clone()),
+          children: children.map(child => child.clone()),
         }),
       ],
     });
@@ -238,6 +239,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
                 </Field>
               </div>
             )}
+            {loading && <div>Loading...</div>}
             {body instanceof LayoutSwitcher && (
               <div className={styles.controlsRight}>
                 <body.Selector model={body} />
@@ -310,6 +312,7 @@ function buildQuery(tagKey: string) {
     editorMode: 'code',
     maxLines: 1000,
     intervalMs: 2000,
+    legendFormat: `{{${tagKey}}}`
   };
 }
 
@@ -336,7 +339,7 @@ function buildNormalLayout(variable: CustomVariable) {
         children: [
           new SceneFlexItem({
             minHeight: 300,
-            body: PanelBuilders.timeseries().setTitle('$metric').build(),
+            body: PanelBuilders.timeseries().setTitle(variable.getValueText()).build(),
           }),
         ],
       }),
@@ -344,7 +347,13 @@ function buildNormalLayout(variable: CustomVariable) {
         body: new SceneCSSGridLayout({
           templateColumns: GRID_TEMPLATE_COLUMNS,
           autoRows: '200px',
-          children: [],
+          children: [
+            new SceneFlexItem({
+              body: new SceneReactObject({
+                reactNode: <LoadingPlaceholder text="Loading..." />,
+              }),
+            })
+          ],
           isLazy: true,
         }),
         getLayoutChild: getLayoutChild(
@@ -356,7 +365,13 @@ function buildNormalLayout(variable: CustomVariable) {
         body: new SceneCSSGridLayout({
           templateColumns: '1fr',
           autoRows: '200px',
-          children: [],
+          children: [
+            new SceneFlexItem({
+              body: new SceneReactObject({
+                reactNode: <LoadingPlaceholder text="Loading..." />,
+              }),
+            })            
+          ],
           isLazy: true,
         }),
         getLayoutChild: getLayoutChild(

--- a/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
+++ b/src/components/Explore/LogsByService/Tabs/LabelBreakdownScene.tsx
@@ -17,10 +17,11 @@ import {
   SceneObjectBase,
   SceneObjectState,
   SceneQueryRunner,
+  SceneReactObject,
   SceneVariableSet,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Button, DrawStyle, Field, StackingMode, useStyles2 } from '@grafana/ui';
+import { Button, DrawStyle, Field, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 
 import { BreakdownLabelSelector } from './BreakdownLabelSelector';
 import { StatusWrapper } from '../../StatusWrapper';
@@ -280,6 +281,7 @@ function buildQuery(tagKey: string) {
     editorMode: 'code',
     maxLines: 1000,
     intervalMs: 2000,
+    legendFormat: `{{${tagKey}}}`,
   };
 }
 
@@ -295,7 +297,7 @@ function buildNormalLayout(variable: CustomVariable) {
     .setCustomFieldConfig('lineWidth', 0)
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-    .setTitle('$metric');
+    .setTitle(variable.getValueText())
 
   const body = bodyOpts.build();
 
@@ -325,7 +327,13 @@ function buildNormalLayout(variable: CustomVariable) {
         body: new SceneCSSGridLayout({
           templateColumns: GRID_TEMPLATE_COLUMNS,
           autoRows: '200px',
-          children: [],
+          children: [
+            new SceneFlexItem({
+              body: new SceneReactObject({
+                reactNode: <LoadingPlaceholder text="Loading..." />,
+              }),
+            })
+          ]
         }),
         getLayoutChild: getLayoutChild(
           getLabelValue,
@@ -336,7 +344,13 @@ function buildNormalLayout(variable: CustomVariable) {
         body: new SceneCSSGridLayout({
           templateColumns: '1fr',
           autoRows: '200px',
-          children: [],
+          children: [
+            new SceneFlexItem({
+              body: new SceneReactObject({
+                reactNode: <LoadingPlaceholder text="Loading..." />,
+              }),
+            })
+          ],
         }),
         getLayoutChild: getLayoutChild(
           getLabelValue,

--- a/src/utils/fields.ts
+++ b/src/utils/fields.ts
@@ -26,7 +26,7 @@ export function extractFields(data: DataFrame) {
 export function getLayoutChild(getTitle: (df: DataFrame) => string, style: DrawStyle) {
   return (data: PanelData, frame: DataFrame, frameIndex: number) => {
     const panel = PanelBuilders.timeseries() //
-      .setOption('legend', { showLegend: true })
+      .setOption('legend', { showLegend: false })
       .setCustomFieldConfig('fillOpacity', 9)
       .setTitle(getTitle(frame))
       .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))


### PR DESCRIPTION
This PR:
1. Fixes https://github.com/grafana/explore-logs/issues/102 by adding loading state for when you select specific Label/Field. Currently, there is no indication that anything is loading , but here it is fixed for both labels and fields.

Fixed:

https://github.com/grafana/explore-logs/assets/30407135/7f6567ad-c33f-405a-9bba-5aaf6bfafde3

Broken:

https://github.com/grafana/explore-logs/assets/30407135/df2de27c-0e9a-4451-ba3a-5dff00f40299

2. Replaces `$metric` with the name of label/field

Fixed:
<img width="1496" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/3353bc63-1b73-4c4f-87cf-0495e783478e">

Before:

<img width="1508" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/85f98363-2427-4332-9fe6-0aa2ea96f61d">


3. Adds correct legend formats - so we see the value instead of stream selector and  removes legends that are not needed - if we are showing in labels/fields 1 value, it is the same as title of the panel (this is the same as in patterns) (fixes https://github.com/grafana/explore-logs/issues/160)

Fixed: 

<img width="1498" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/5b8bf246-d413-4016-893f-778f752e23b1">


Before:

<img width="1496" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/255a5051-9731-4206-93f5-acef0b03d819">

Patterns for comparison:

<img width="1477" alt="image" src="https://github.com/grafana/explore-logs/assets/30407135/c3ade987-8c4b-4e94-ba57-9c3667e1a8f5">

