### PR TITLE
feat(service-selection): disable log details

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -248,6 +248,7 @@ export class ServiceSelectionComponent extends SceneObjectBase<ServiceSelectionC
           })
         )
         .setOption('showTime', true)
+        .setOption('enableLogDetails', false)
         .build(),
     });
   }


### PR DESCRIPTION
Disable log details on service selection screen. Given the small size of the logs panel, I don't believe it's useful and rather misleading, as scrolling in the logs panel is difficult with it being enabled.