### PR TITLE
chore(shardQuerySplitting): start in Streaming state

### DIFF
--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -61,7 +61,7 @@ function splitQueriesByStreamShard(
   splittingTargets: LokiQuery[]
 ) {
   let shouldStop = false;
-  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Loading, key: uuidv4() };
+  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: uuidv4() };
   let subquerySubscription: Subscription | null = null;
   let retriesMap = new Map<number, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
With this change, shard splitting behaves like the original time splitting, which is what we use when sharding is not enabled and one of the main differences between the two modes.

https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/querySplitting.ts#L80