### PR TITLE
Browser history on filter change

### DIFF
--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -1,4 +1,10 @@
-import { ControlsLabel, SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import {
+  ControlsLabel,
+  SceneComponentProps,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneVariableValueChangedEvent,
+} from '@grafana/scenes';
 import React from 'react';
 import { getLevelsVariable } from '../../services/variableGetters';
 import { GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
@@ -7,6 +13,7 @@ import { Icon, MultiSelect, useStyles2 } from '@grafana/ui';
 import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
 import { FilterOp } from '../../services/filterTypes';
 import { testIds } from '../../services/testIds';
+import { addCurrentUrlToHistory } from '../../services/navigate';
 
 type ChipOption = MetricFindValue & { selected?: boolean };
 export interface LevelsVariableSceneState extends SceneObjectState {
@@ -25,6 +32,12 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
 
   onActivate() {
     this.onFilterChange();
+
+    this._subs.add(
+      getLevelsVariable(this).subscribeToEvent(SceneVariableValueChangedEvent, () => {
+        this.onFilterChange();
+      })
+    );
   }
 
   public onFilterChange() {
@@ -76,6 +89,9 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
   };
 
   onChangeOptions = (options: SelectableValue[]) => {
+    // Save current url to history before the filter change
+    addCurrentUrlToHistory();
+
     this.setState({
       options: this.state.options?.map((value) => {
         if (options.some((opt) => opt.value === value.value)) {
@@ -105,6 +121,8 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
   static Component = ({ model }: SceneComponentProps<LevelsVariableScene>) => {
     const { options, isLoading, visible, isOpen } = model.useState();
     const styles = useStyles2(getStyles);
+    const levelsVar = getLevelsVariable(model);
+    levelsVar.useState();
 
     if (!visible) {
       return null;

--- a/src/Components/IndexScene/LineFilterVariablesScene.tsx
+++ b/src/Components/IndexScene/LineFilterVariablesScene.tsx
@@ -8,6 +8,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import { LineFilterEditor, LineFilterEditorProps } from '../ServiceScene/LineFilter/LineFilterEditor';
+import { addCurrentUrlToHistory } from '../../services/navigate';
 
 interface LineFilterRendererState extends SceneObjectState {}
 
@@ -72,6 +73,8 @@ export class LineFilterVariablesScene extends SceneObjectBase<LineFilterRenderer
    */
   handleEnter = (e: KeyboardEvent<HTMLInputElement>, lineFilter: string, filter: AdHocFilterWithLabels) => {
     if (e.key === 'Enter') {
+      // Add the current url to browser history before the state is changed so the user can revert their change.
+      addCurrentUrlToHistory();
       this.updateVariableLineFilter(filter, { ...filter, value: lineFilter });
     }
   };
@@ -177,6 +180,7 @@ export class LineFilterVariablesScene extends SceneObjectBase<LineFilterRenderer
    * Remove a filter, will trigger query
    */
   removeFilter = (filter: AdHocFilterWithLabels) => {
+    addCurrentUrlToHistory();
     const variable = getLineFiltersVariable(this);
     const otherFilters = variable.state.filters.filter(
       (f) => f.keyLabel !== undefined && f.keyLabel !== filter.keyLabel

--- a/src/Components/IndexScene/PatternControls.tsx
+++ b/src/Components/IndexScene/PatternControls.tsx
@@ -6,6 +6,7 @@ import { useStyles2, Text } from '@grafana/ui';
 import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from 'services/analytics';
 import { testIds } from 'services/testIds';
 import { AppliedPattern } from '../../services/variables';
+import { addCurrentUrlToHistory } from '../../services/navigate';
 
 type Props = {
   patterns: AppliedPattern[] | undefined;
@@ -22,6 +23,7 @@ export const PatternControls = ({ patterns, onRemove }: Props) => {
   const excludePatterns = patterns.filter((pattern) => pattern.type !== 'include');
 
   const onRemovePattern = (pattern: AppliedPattern) => {
+    addCurrentUrlToHistory();
     onRemove(patterns.filter((pat) => pat !== pattern));
     reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.pattern_removed, {
       includePatternsLength: includePatterns.length - (pattern?.type === 'include' ? 1 : 0),

--- a/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/AddToFiltersButton.tsx
@@ -33,6 +33,7 @@ import { addToFavorites } from '../../../services/favorites';
 import { areArraysEqual } from '../../../services/comparison';
 import { logger } from '../../../services/logger';
 import { isFilterMetadata } from '../../../services/filters';
+import { addCurrentUrlToHistory } from '../../../services/navigate';
 
 export interface AddToFiltersButtonState extends SceneObjectState {
   frame: DataFrame;
@@ -192,6 +193,10 @@ export function addNumericFilter(
   scene.publishEvent(new AddFilterEvent('filterButton', operator, key, value), true);
 }
 
+/**
+ * Helper for buttons in the UI
+ * toggles an ad hoc filter to a given variable type
+ */
 export function addToFilters(
   key: string,
   value: string,
@@ -199,6 +204,9 @@ export function addToFilters(
   scene: SceneObject,
   variableType: InterpolatedFilterType
 ) {
+  // Add the current url to browser history before the state is changed so the user can revert their change.
+  addCurrentUrlToHistory();
+
   if (variableType === VAR_LABELS) {
     addToFavorites(key, value, scene);
   }

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -48,7 +48,6 @@ import { EmptyLayoutScene } from './EmptyLayoutScene';
 import { IndexScene } from '../../IndexScene/IndexScene';
 import { clearVariables, getVariablesThatCanBeCleared } from '../../../services/variableHelpers';
 import { ValueSummaryPanelScene } from './Panels/ValueSummary';
-import { syncLevelsVariable } from '../../IndexScene/LevelsVariableScene';
 import { renderLevelsFilter, renderLogQLLabelFilters } from '../../../services/query';
 import { logger } from '../../../services/logger';
 import { areArraysEqual } from '../../../services/comparison';

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../../services/variables';
 import React from 'react';
 import { LabelBreakdownScene } from './LabelBreakdownScene';
-import { AddFilterEvent } from './AddToFiltersButton';
 import { DEFAULT_SORT_BY } from '../../../services/sorting';
 import { buildLabelsQuery, LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS } from '../../../services/labels';
 import { getAppEvents } from '@grafana/runtime';
@@ -49,7 +48,6 @@ import { EmptyLayoutScene } from './EmptyLayoutScene';
 import { IndexScene } from '../../IndexScene/IndexScene';
 import { clearVariables, getVariablesThatCanBeCleared } from '../../../services/variableHelpers';
 import { ValueSummaryPanelScene } from './Panels/ValueSummary';
-import { LevelsVariableScene } from '../../IndexScene/LevelsVariableScene';
 import { renderLevelsFilter, renderLogQLLabelFilters } from '../../../services/query';
 import { logger } from '../../../services/logger';
 import { areArraysEqual } from '../../../services/comparison';
@@ -101,17 +99,6 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
    * Set variable & event subscriptions
    */
   private setSubscriptions() {
-    // EVENT SUBS
-    // Subscribe to AddFilterEvent to sync button filters with variable state
-    this._subs.add(
-      this.subscribeToEvent(AddFilterEvent, (event) => {
-        const levelsVariableScene = sceneGraph.findObject(this, (obj) => obj instanceof LevelsVariableScene);
-        if (levelsVariableScene instanceof LevelsVariableScene) {
-          levelsVariableScene.onFilterChange();
-        }
-      })
-    );
-
     // QUERY RUNNER SUBS
     // Subscribe to value breakdown state
     this._subs.add(

--- a/src/Components/ServiceScene/Breakdowns/Patterns/FilterByPatternsButton.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/FilterByPatternsButton.tsx
@@ -2,6 +2,7 @@ import { sceneGraph, SceneObjectState } from '@grafana/scenes';
 import { IndexScene } from '../../../IndexScene/IndexScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { logger } from '../../../../services/logger';
+import { addCurrentUrlToHistory } from '../../../../services/navigate';
 
 export interface FilterByPatternsButtonState extends SceneObjectState {
   pattern: string;
@@ -22,6 +23,7 @@ export function onPatternClick(props: FilterByPatternsState) {
     return;
   }
 
+  addCurrentUrlToHistory();
   const { patterns = [] } = indexScene.state;
 
   // Remove the pattern if it's already there

--- a/src/Components/ServiceScene/LineFilter/LineFilterScene.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterScene.tsx
@@ -14,6 +14,7 @@ import {
 import { RegexInputValue } from './RegexIconButton';
 import { LineFilterCaseSensitive, LineFilterOp } from '../../../services/filterTypes';
 import { LineFilterEditor } from './LineFilterEditor';
+import { addCurrentUrlToHistory } from '../../../services/navigate';
 
 interface LineFilterState extends SceneObjectState {
   lineFilter: string;
@@ -160,6 +161,7 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
    * Clears the state of the local ad-hoc variable.
    */
   onSubmitLineFilter = () => {
+    addCurrentUrlToHistory();
     this.updateFilter(this.state.lineFilter, false);
     // Flush any debounced updates before grabbing the filter. Important that this happens before getFilter is called!
     this.updateVariableDebounced.flush();

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -17,7 +17,7 @@ import { LogsListScene } from './LogsListScene';
 import { LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { addToFilters, FilterType } from './Breakdowns/AddToFiltersButton';
 import { getVariableForLabel } from '../../services/fields';
-import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from '../../services/variables';
+import { VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from '../../services/variables';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
 import {
   getAdHocFiltersVariable,
@@ -39,7 +39,6 @@ import { LogsSortOrder } from '@grafana/schema';
 import { getPrettyQueryExpr } from 'services/scenes';
 import { LogsPanelError } from './LogsPanelError';
 import { clearVariables } from 'services/variableHelpers';
-import { LevelsVariableScene } from '../IndexScene/LevelsVariableScene';
 
 interface LogsPanelSceneState extends SceneObjectState {
   body?: VizPanel<Options>;
@@ -420,13 +419,6 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   private handleLabelFilter(key: string, value: string, frame: DataFrame | undefined, operator: FilterType) {
     const variableType = getVariableForLabel(frame, key, this);
     addToFilters(key, value, operator, this, variableType);
-
-    if (key === LEVEL_VARIABLE_VALUE) {
-      const levelsVariableScene = sceneGraph.findObject(this, (obj) => obj instanceof LevelsVariableScene);
-      if (levelsVariableScene instanceof LevelsVariableScene) {
-        levelsVariableScene.onFilterChange();
-      }
-    }
 
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,

--- a/src/Components/ServiceScene/LogsTableScene.tsx
+++ b/src/Components/ServiceScene/LogsTableScene.tsx
@@ -12,8 +12,6 @@ import { getLogsPanelFrame } from './ServiceScene';
 import { getVariableForLabel } from '../../services/fields';
 import { PanelMenu } from '../Panels/PanelMenu';
 import { LogLineState } from '../Table/Context/TableColumnsContext';
-import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
-import { LevelsVariableScene } from '../IndexScene/LevelsVariableScene';
 
 interface LogsTableSceneState extends SceneObjectState {
   menu?: PanelMenu;
@@ -55,14 +53,6 @@ export class LogsTableScene extends SceneObjectBase<LogsTableSceneState> {
     const addFilter = (filter: AdHocVariableFilter) => {
       const variableType = getVariableForLabel(dataFrame, filter.key, model);
       addAdHocFilter(filter, parentModel, variableType);
-
-      // Update levels variable when adding filter from table
-      if (filter.key === LEVEL_VARIABLE_VALUE) {
-        const levelsVariableScene = sceneGraph.findObject(model, (obj) => obj instanceof LevelsVariableScene);
-        if (levelsVariableScene instanceof LevelsVariableScene) {
-          levelsVariableScene.onFilterChange();
-        }
-      }
     };
 
     // Get reference to panel wrapper so table knows how much space it can use to render

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -84,8 +84,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         if (event.key === LEVEL_VARIABLE_VALUE) {
           const levelsVariableScene = sceneGraph.findObject(this, (obj) => obj instanceof LevelsVariableScene);
           if (levelsVariableScene instanceof LevelsVariableScene) {
-            levelsVariableScene.onFilterChange();
-
             const levelsVar = getLevelsVariable(this);
             levelsVar.setState({ filters: levelsVar.state.filters });
           }

--- a/src/services/navigate.ts
+++ b/src/services/navigate.ts
@@ -117,6 +117,12 @@ export function pushUrlHandler(newUrl: string) {
   locationService.push(newUrl);
 }
 
+export function addCurrentUrlToHistory() {
+  // Add the current url to browser history before the state is changed so the user can revert their change.
+  const location = locationService.getLocation();
+  locationService.push(location.pathname + location.search);
+}
+
 /**
  * Navigate to the services selection url
  */


### PR DESCRIPTION
Adding browser history events before setting filters to state, when triggered by a user action.
Note: This doesn't catch changes made directly in the combobox variables, but should cover everything? else: patterns, line filters, ([levels in another PR](https://github.com/grafana/logs-drilldown/pull/1108)), and panel filter buttons.

Related: https://github.com/grafana/logs-drilldown/issues/1109