### PR TITLE
Browser history on filter change: Levels variable

### DIFF
--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -33,9 +33,11 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
   onActivate() {
     this.onFilterChange();
 
-    getLevelsVariable(this).subscribeToEvent(SceneVariableValueChangedEvent, () => {
-      this.onFilterChange();
-    });
+    this._subs.add(
+      getLevelsVariable(this).subscribeToEvent(SceneVariableValueChangedEvent, () => {
+        this.onFilterChange();
+      })
+    );
   }
 
   public onFilterChange() {

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -1,4 +1,10 @@
-import { ControlsLabel, SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import {
+  ControlsLabel,
+  SceneComponentProps,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneVariableValueChangedEvent,
+} from '@grafana/scenes';
 import React from 'react';
 import { getLevelsVariable } from '../../services/variableGetters';
 import { GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
@@ -7,6 +13,7 @@ import { Icon, MultiSelect, useStyles2 } from '@grafana/ui';
 import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
 import { FilterOp } from '../../services/filterTypes';
 import { testIds } from '../../services/testIds';
+import { addCurrentUrlToHistory } from '../../services/navigate';
 
 type ChipOption = MetricFindValue & { selected?: boolean };
 export interface LevelsVariableSceneState extends SceneObjectState {
@@ -25,6 +32,10 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
 
   onActivate() {
     this.onFilterChange();
+
+    getLevelsVariable(this).subscribeToEvent(SceneVariableValueChangedEvent, () => {
+      this.onFilterChange();
+    });
   }
 
   public onFilterChange() {
@@ -76,6 +87,9 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
   };
 
   onChangeOptions = (options: SelectableValue[]) => {
+    // Save current url to history before the filter change
+    addCurrentUrlToHistory();
+
     this.setState({
       options: this.state.options?.map((value) => {
         if (options.some((opt) => opt.value === value.value)) {
@@ -105,6 +119,8 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
   static Component = ({ model }: SceneComponentProps<LevelsVariableScene>) => {
     const { options, isLoading, visible, isOpen } = model.useState();
     const styles = useStyles2(getStyles);
+    const levelsVar = getLevelsVariable(model);
+    levelsVar.useState();
 
     if (!visible) {
       return null;

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../../services/variables';
 import React from 'react';
 import { LabelBreakdownScene } from './LabelBreakdownScene';
-import { AddFilterEvent } from './AddToFiltersButton';
 import { DEFAULT_SORT_BY } from '../../../services/sorting';
 import { buildLabelsQuery, LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS } from '../../../services/labels';
 import { getAppEvents } from '@grafana/runtime';
@@ -49,7 +48,6 @@ import { EmptyLayoutScene } from './EmptyLayoutScene';
 import { IndexScene } from '../../IndexScene/IndexScene';
 import { clearVariables, getVariablesThatCanBeCleared } from '../../../services/variableHelpers';
 import { ValueSummaryPanelScene } from './Panels/ValueSummary';
-import { LevelsVariableScene } from '../../IndexScene/LevelsVariableScene';
 import { renderLevelsFilter, renderLogQLLabelFilters } from '../../../services/query';
 import { logger } from '../../../services/logger';
 import { areArraysEqual } from '../../../services/comparison';
@@ -101,17 +99,6 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
    * Set variable & event subscriptions
    */
   private setSubscriptions() {
-    // EVENT SUBS
-    // Subscribe to AddFilterEvent to sync button filters with variable state
-    this._subs.add(
-      this.subscribeToEvent(AddFilterEvent, (event) => {
-        const levelsVariableScene = sceneGraph.findObject(this, (obj) => obj instanceof LevelsVariableScene);
-        if (levelsVariableScene instanceof LevelsVariableScene) {
-          levelsVariableScene.onFilterChange();
-        }
-      })
-    );
-
     // QUERY RUNNER SUBS
     // Subscribe to value breakdown state
     this._subs.add(

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -17,7 +17,7 @@ import { LogsListScene } from './LogsListScene';
 import { LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { addToFilters, FilterType } from './Breakdowns/AddToFiltersButton';
 import { getVariableForLabel } from '../../services/fields';
-import { LEVEL_VARIABLE_VALUE, VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from '../../services/variables';
+import { VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from '../../services/variables';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
 import {
   getAdHocFiltersVariable,
@@ -39,7 +39,6 @@ import { LogsSortOrder } from '@grafana/schema';
 import { getPrettyQueryExpr } from 'services/scenes';
 import { LogsPanelError } from './LogsPanelError';
 import { clearVariables } from 'services/variableHelpers';
-import { LevelsVariableScene } from '../IndexScene/LevelsVariableScene';
 
 interface LogsPanelSceneState extends SceneObjectState {
   body?: VizPanel<Options>;
@@ -420,13 +419,6 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   private handleLabelFilter(key: string, value: string, frame: DataFrame | undefined, operator: FilterType) {
     const variableType = getVariableForLabel(frame, key, this);
     addToFilters(key, value, operator, this, variableType);
-
-    if (key === LEVEL_VARIABLE_VALUE) {
-      const levelsVariableScene = sceneGraph.findObject(this, (obj) => obj instanceof LevelsVariableScene);
-      if (levelsVariableScene instanceof LevelsVariableScene) {
-        levelsVariableScene.onFilterChange();
-      }
-    }
 
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,

--- a/src/Components/ServiceScene/LogsTableScene.tsx
+++ b/src/Components/ServiceScene/LogsTableScene.tsx
@@ -12,8 +12,6 @@ import { getLogsPanelFrame } from './ServiceScene';
 import { getVariableForLabel } from '../../services/fields';
 import { PanelMenu } from '../Panels/PanelMenu';
 import { LogLineState } from '../Table/Context/TableColumnsContext';
-import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
-import { LevelsVariableScene } from '../IndexScene/LevelsVariableScene';
 
 interface LogsTableSceneState extends SceneObjectState {
   menu?: PanelMenu;
@@ -55,14 +53,6 @@ export class LogsTableScene extends SceneObjectBase<LogsTableSceneState> {
     const addFilter = (filter: AdHocVariableFilter) => {
       const variableType = getVariableForLabel(dataFrame, filter.key, model);
       addAdHocFilter(filter, parentModel, variableType);
-
-      // Update levels variable when adding filter from table
-      if (filter.key === LEVEL_VARIABLE_VALUE) {
-        const levelsVariableScene = sceneGraph.findObject(model, (obj) => obj instanceof LevelsVariableScene);
-        if (levelsVariableScene instanceof LevelsVariableScene) {
-          levelsVariableScene.onFilterChange();
-        }
-      }
     };
 
     // Get reference to panel wrapper so table knows how much space it can use to render

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -84,8 +84,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         if (event.key === LEVEL_VARIABLE_VALUE) {
           const levelsVariableScene = sceneGraph.findObject(this, (obj) => obj instanceof LevelsVariableScene);
           if (levelsVariableScene instanceof LevelsVariableScene) {
-            levelsVariableScene.onFilterChange();
-
             const levelsVar = getLevelsVariable(this);
             levelsVar.setState({ filters: levelsVar.state.filters });
           }


### PR DESCRIPTION
Just adding browser history for levels variable, and cleaning things up by subscribing to the filter state change instead of having each upstream trigger the re-render on filter change.
