### PR TITLE
chore: increase loki max log length

### DIFF
--- a/config/loki-config.yaml
+++ b/config/loki-config.yaml
@@ -3,7 +3,8 @@ auth_enabled: false
 server:
   http_listen_port: 3100
   grpc_listen_port: 9096
-
+  grpc_server_max_recv_msg_size: 8194304
+  grpc_server_max_send_msg_size: 8194304
 common:
   instance_addr: 127.0.0.1
   path_prefix: /tmp/loki


### PR DESCRIPTION
Getting this error locally:

```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6050583 vs. 4194304)
```

Looks like I attempted to add some Faro logs that were too big for the dev loki. Bumping that up a bit here to ~8MB.