### PR TITLE
remove relref shortcodes

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -74,4 +74,4 @@ Our new experiences are in their early stages, and we'd love to hear your feedba
 
 ## What's next?
 
-Dive into [Get started with Grafana Logs Drilldown]({{< relref "./get-started" >}}) to learn how to set up Grafana Logs Drilldown and take a tour of the feature using your own data.
+Dive into [Get started with Grafana Logs Drilldown](get-started/) to learn how to set up Grafana Logs Drilldown and take a tour of the feature using your own data.

--- a/docs/sources/access/_index.md
+++ b/docs/sources/access/_index.md
@@ -89,7 +89,7 @@ Once the docker container has started, navigate to `http://localhost:3000/a/graf
 
 ## Having trouble?
 
-Refer to the [troubleshooting guide]({{< relref "../troubleshooting" >}}) for tips on how to solve common issues.
+Refer to the [troubleshooting guide](../troubleshooting/) for tips on how to solve common issues.
 
 ## What next?
 


### PR DESCRIPTION
For https://github.com/grafana/website/issues/24017

Removes all relref shortcodes.

Repository: grafana/logs-drilldown
Website-Pull-Request: https://github.com/grafana/website/pull/24501