### PR TITLE
Logs errors: improve error messages

### DIFF
--- a/src/Components/ServiceScene/LogsPanelError.tsx
+++ b/src/Components/ServiceScene/LogsPanelError.tsx
@@ -11,10 +11,7 @@ export const LogsPanelError = ({ clearFilters, error }: Props) => {
   return (
     <GrotError>
       <div>
-        <p>
-          <strong>No logs found.</strong>
-        </p>
-        <p>{getMessageFromError(error)}</p>
+        <p>{error}</p>
         <Button variant="secondary" onClick={clearFilters}>
           Clear filters
         </Button>
@@ -22,11 +19,3 @@ export const LogsPanelError = ({ clearFilters, error }: Props) => {
     </GrotError>
   );
 };
-
-function getMessageFromError(error: string) {
-  if (error.includes('parse error')) {
-    return 'Logs could not be retrieved due to invalid filter parameters. Please review your filters and try again.';
-  }
-
-  return 'Logs could not be retrieved. Please review your filters or try a different time range.';
-}

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -127,7 +127,6 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this._subs.add(
       serviceScene.subscribeToState((newState, prevState) => {
-        console.log(newState.$data?.state.data);
         if (newState.$data?.state.data?.state === LoadingState.Error) {
           this.handleLogsError(newState.$data?.state.data);
         } else if (

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -39,6 +39,7 @@ import { LogsSortOrder } from '@grafana/schema';
 import { getPrettyQueryExpr } from 'services/scenes';
 import { LogsPanelError } from './LogsPanelError';
 import { clearVariables } from 'services/variableHelpers';
+import { isEmptyLogsResult } from 'services/logsFrame';
 
 interface LogsPanelSceneState extends SceneObjectState {
   body?: VizPanel<Options>;
@@ -126,8 +127,14 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this._subs.add(
       serviceScene.subscribeToState((newState, prevState) => {
+        console.log(newState.$data?.state.data);
         if (newState.$data?.state.data?.state === LoadingState.Error) {
           this.handleLogsError(newState.$data?.state.data);
+        } else if (
+          newState.$data?.state.data?.state === LoadingState.Done &&
+          isEmptyLogsResult(newState.$data?.state.data.series)
+        ) {
+          this.handleNoData();
         } else if (this.state.error) {
           this.clearLogsError();
         }
@@ -151,9 +158,26 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   }
 
   handleLogsError(data: PanelData) {
+    const errorResponse = data.errors?.length ? data.errors[0].message : data.error?.message;
+    let error = 'Unexpected error response. Please review your filters or try a different time range.';
+
+    if (errorResponse?.includes('parse error')) {
+      error = 'Logs could not be retrieved due to invalid filter parameters. Please review your filters and try again.';
+    } else if (errorResponse?.includes('response larger than the max message size')) {
+      error =
+        'The response is too large to process. Try narrowing your search or using filters to reduce the data size.';
+    }
+
+    this.showLogsError(error);
+  }
+
+  handleNoData() {
+    this.showLogsError('No logs match your search. Please review your filters or try a different time range.');
+  }
+
+  showLogsError(error: string) {
     const logsVolumeCollapsedByError = this.state.logsVolumeCollapsedByError ?? !getLogsVolumeOption('collapsed');
 
-    const error = data.errors?.length ? data.errors[0].message : data.error?.message;
     this.setState({ error, logsVolumeCollapsedByError });
 
     if (logsVolumeCollapsedByError) {

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -223,3 +223,7 @@ export function getVisibleRangeFrame(start: number, end: number) {
 
   return frame;
 }
+
+export function isEmptyLogsResult(series: DataFrame[]) {
+  return series.length === 0 || series[0].fields[0].values.length === 0;
+}


### PR DESCRIPTION
The current error state can be potentially confusing to the users by not being clear of the underlying situation. With these changes we're making a difference between:

- General query errors
- Response too large
- No data returned.

Error:

![no data](https://github.com/user-attachments/assets/f274af85-671f-47d5-843d-0fffbe9cdc18)

No data:

![query error](https://github.com/user-attachments/assets/3be07651-b4f6-46ab-859e-cc7b95bd5535)

Fixes #1121