### PR TITLE
E2E: Address flakey test

### DIFF
--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -297,7 +297,7 @@ test.describe('explore services breakdown page', () => {
   test(`should select label ${labelName}, update filters, open in explore`, async ({ page, browser }) => {
     await explorePage.assertTabsNotLoading();
     explorePage.blockAllQueriesExcept({
-      refIds: [],
+      refIds: ['logsPanelQuery'],
       legendFormats: [`{{${labelName}}}`],
     });
     const valueName = 'eu-west-1';


### PR DESCRIPTION
Looks like https://github.com/grafana/logs-drilldown/pull/1127 introduced some flake in this e2e test, although I'm confused as to how it ever worked, but in all of the failures locally and in CI the new empty logs view was being rendered.

Telling the test to run the logs panel query seems to have fixed it locally.