### PR TITLE
feat: add support for uppercase log level and color warning as a warn

### DIFF
--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -32,19 +32,19 @@ import { getParserForField } from './fields';
 
 const UNKNOWN_LEVEL_LOGS = 'logs';
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
-  overrides.matchFieldsWithName('info').overrideColor({
+  overrides.matchFieldsWithNameByRegex('(?i)^info$').overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-green',
   });
-  overrides.matchFieldsWithName('debug').overrideColor({
+  overrides.matchFieldsWithNameByRegex('(?i)^debug$').overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-blue',
   });
-  overrides.matchFieldsWithName('error').overrideColor({
+  overrides.matchFieldsWithNameByRegex('(?i)^error$').overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-red',
   });
-  overrides.matchFieldsWithName('warn').overrideColor({
+  overrides.matchFieldsWithNameByRegex('(?i)^(warn|warning)$').overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-orange',
   });


### PR DESCRIPTION
Hello,

Please let me know if this isn't the correct way to contribute.

The purpose of this change is to ensure consistent coloring for uppercase log levels. For example, here’s a screenshot from [play.grafana.com](https://play.grafana.org/a/grafana-lokiexplore-app/explore), where the `ERROR` log level is mistakenly colored green, which could lead to confusion:
![image](https://github.com/user-attachments/assets/63baa0c9-80f5-437a-8c6b-b0920990691d)

Additionally, I've added support to handle both `WARN` and `WARNING` log levels in the same way, ensuring they receive consistent treatment.

Thank you