### PR TITLE
feat: add critical/fatal log level

### DIFF
--- a/src/services/panel.test.ts
+++ b/src/services/panel.test.ts
@@ -1,31 +1,38 @@
 import { FieldType, createDataFrame } from '@grafana/data';
-import { setLevelColorOverrides, sortLevelTransformation } from './panel';
+import {
+  CRITICAL_LEVEL_FIELD_NAME_REGEX,
+  DEBUG_LEVEL_FIELD_NAME_REGEX,
+  ERROR_LEVEL_FIELD_NAME_REGEX,
+  INFO_LEVEL_FIELD_NAME_REGEX,
+  setLevelColorOverrides,
+  sortLevelTransformation,
+  UNKNOWN_LEVEL_FIELD_NAME_REGEX,
+  WARNING_LEVEL_FIELD_NAME_REGEX,
+} from './panel';
 import { lastValueFrom, of } from 'rxjs';
 
 describe('setLevelColorOverrides', () => {
   test('Sets the color overrides for log levels', () => {
     const overrideColorMock = jest.fn();
-    const matchFieldsWithNameMock = jest.fn().mockImplementation(() => ({ overrideColor: overrideColorMock }));
     const matchFieldsWithNameByRegexMock = jest.fn().mockImplementation(() => ({ overrideColor: overrideColorMock }));
 
     const overrides = {
-      matchFieldsWithName: matchFieldsWithNameMock,
       matchFieldsWithNameByRegex: matchFieldsWithNameByRegexMock,
     };
     // @ts-expect-error
     setLevelColorOverrides(overrides);
 
     // Ensure the correct number of calls
-    expect(matchFieldsWithNameMock).toHaveBeenCalledTimes(1);
-    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledTimes(4);
-    expect(overrideColorMock).toHaveBeenCalledTimes(5);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledTimes(6);
+    expect(overrideColorMock).toHaveBeenCalledTimes(6);
 
     // Check that regex is called correctly for each field
-    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith('/^info$/i');
-    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith('/^debug$/i');
-    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith('/^error$/i');
-    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith('/^(warn|warning)$/i');
-    expect(matchFieldsWithNameMock).toHaveBeenCalledWith('logs');
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX).source);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX).source);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX).source);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX).source);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX).source);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(UNKNOWN_LEVEL_FIELD_NAME_REGEX).source);
   });
 });
 

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -228,27 +228,27 @@ export function sortLevelTransformation() {
               return 0;
             }
             const aName: string | undefined = a.fields[1].config.displayNameFromDS;
-            const aVal = aName?.match(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX))
+            const aVal = aName?.match(CRITICAL_LEVEL_FIELD_NAME_REGEX)
               ? 5
-              : aName?.match(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX))
+              : aName?.match(ERROR_LEVEL_FIELD_NAME_REGEX)
               ? 4
-              : aName?.match(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX))
+              : aName?.match(WARNING_LEVEL_FIELD_NAME_REGEX)
               ? 3
-              : aName?.match(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX))
+              : aName?.match(DEBUG_LEVEL_FIELD_NAME_REGEX)
               ? 2
-              : aName?.match(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX))
+              : aName?.match(INFO_LEVEL_FIELD_NAME_REGEX)
               ? 2
               : 1;
             const bName: string | undefined = b.fields[1].config.displayNameFromDS;
-            const bVal = bName?.match(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX))
+            const bVal = bName?.match(CRITICAL_LEVEL_FIELD_NAME_REGEX)
               ? 5
-              : bName?.match(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX))
+              : bName?.match(ERROR_LEVEL_FIELD_NAME_REGEX)
               ? 4
-              : bName?.match(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX))
+              : bName?.match(WARNING_LEVEL_FIELD_NAME_REGEX)
               ? 3
-              : bName?.match(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX))
+              : bName?.match(DEBUG_LEVEL_FIELD_NAME_REGEX)
               ? 2
-              : bName?.match(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX).source)
+              : bName?.match(INFO_LEVEL_FIELD_NAME_REGEX)
               ? 2
               : 1;
 

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -31,24 +31,35 @@ import { getLabelsFromSeries, getVisibleFields, getVisibleLabels, getVisibleMeta
 import { getParserForField } from './fields';
 
 const UNKNOWN_LEVEL_LOGS = 'logs';
+export const INFO_LEVEL_FIELD_NAME_REGEX = /^info$/i;
+export const DEBUG_LEVEL_FIELD_NAME_REGEX = /^debug$/i;
+export const WARNING_LEVEL_FIELD_NAME_REGEX = /^(warn|warning)$/i;
+export const ERROR_LEVEL_FIELD_NAME_REGEX = /^error$/i;
+export const CRITICAL_LEVEL_FIELD_NAME_REGEX = /^(crit|critical|fatal)$/i;
+export const UNKNOWN_LEVEL_FIELD_NAME_REGEX = /^(logs|unknown)$/i;
+
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
-  overrides.matchFieldsWithNameByRegex('/^info$/i').overrideColor({
+  overrides.matchFieldsWithNameByRegex(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-green',
   });
-  overrides.matchFieldsWithNameByRegex('/^debug$/i').overrideColor({
+  overrides.matchFieldsWithNameByRegex(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-blue',
   });
-  overrides.matchFieldsWithNameByRegex('/^error$/i').overrideColor({
-    mode: 'fixed',
-    fixedColor: 'semi-dark-red',
-  });
-  overrides.matchFieldsWithNameByRegex('/^(warn|warning)$/i').overrideColor({
+  overrides.matchFieldsWithNameByRegex(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-orange',
   });
-  overrides.matchFieldsWithName('logs').overrideColor({
+  overrides.matchFieldsWithNameByRegex(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+    mode: 'fixed',
+    fixedColor: 'semi-dark-red',
+  });
+  overrides.matchFieldsWithNameByRegex(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+    mode: 'fixed',
+    fixedColor: '#705da0',
+  });
+  overrides.matchFieldsWithNameByRegex(new RegExp(UNKNOWN_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
     mode: 'fixed',
     fixedColor: 'darkgray',
   });
@@ -217,9 +228,30 @@ export function sortLevelTransformation() {
               return 0;
             }
             const aName: string | undefined = a.fields[1].config.displayNameFromDS;
-            const aVal = aName?.includes('error') ? 4 : aName?.includes('warn') ? 3 : aName?.includes('info') ? 2 : 1;
+            const aVal = aName?.match(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX))
+              ? 5
+              : aName?.match(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX))
+              ? 4
+              : aName?.match(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX))
+              ? 3
+              : aName?.match(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX))
+              ? 2
+              : aName?.match(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX))
+              ? 2
+              : 1;
             const bName: string | undefined = b.fields[1].config.displayNameFromDS;
-            const bVal = bName?.includes('error') ? 4 : bName?.includes('warn') ? 3 : bName?.includes('info') ? 2 : 1;
+            const bVal = bName?.match(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX))
+              ? 5
+              : bName?.match(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX))
+              ? 4
+              : bName?.match(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX))
+              ? 3
+              : bName?.match(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX))
+              ? 2
+              : bName?.match(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX).source)
+              ? 2
+              : 1;
+
             return aVal - bVal;
           });
       })

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -39,27 +39,27 @@ export const CRITICAL_LEVEL_FIELD_NAME_REGEX = /^(crit|critical|fatal)$/i;
 export const UNKNOWN_LEVEL_FIELD_NAME_REGEX = /^(logs|unknown)$/i;
 
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
-  overrides.matchFieldsWithNameByRegex(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+  overrides.matchFieldsWithNameByRegex(INFO_LEVEL_FIELD_NAME_REGEX.source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-green',
   });
-  overrides.matchFieldsWithNameByRegex(new RegExp(DEBUG_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+  overrides.matchFieldsWithNameByRegex(DEBUG_LEVEL_FIELD_NAME_REGEX.source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-blue',
   });
-  overrides.matchFieldsWithNameByRegex(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+  overrides.matchFieldsWithNameByRegex(WARNING_LEVEL_FIELD_NAME_REGEX.source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-orange',
   });
-  overrides.matchFieldsWithNameByRegex(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+  overrides.matchFieldsWithNameByRegex(ERROR_LEVEL_FIELD_NAME_REGEX.source).overrideColor({
     mode: 'fixed',
     fixedColor: 'semi-dark-red',
   });
-  overrides.matchFieldsWithNameByRegex(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+  overrides.matchFieldsWithNameByRegex(CRITICAL_LEVEL_FIELD_NAME_REGEX.source).overrideColor({
     mode: 'fixed',
     fixedColor: '#705da0',
   });
-  overrides.matchFieldsWithNameByRegex(new RegExp(UNKNOWN_LEVEL_FIELD_NAME_REGEX).source).overrideColor({
+  overrides.matchFieldsWithNameByRegex(UNKNOWN_LEVEL_FIELD_NAME_REGEX.source).overrideColor({
     mode: 'fixed',
     fixedColor: 'darkgray',
   });


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1144

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b837db8f-20ac-4d74-99de-ff465e45fd3b" />

Also displays "unknown" as the same sort/color as "logs" level