### PR TITLE
chore: (gh actions) - pin to tag for security

### DIFF
--- a/.github/workflows/build-generator.yml
+++ b/.github/workflows/build-generator.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         name: Build and push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '20'
           cache: 'yarn'
 
       - name: Restore npm cache
         id: restore-npm-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules
@@ -45,7 +45,7 @@ jobs:
       - name: Save npm cache
         id: save-npm-cache
         if: steps.restore-npm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules
@@ -71,7 +71,7 @@ jobs:
         id: run-tests
         run: yarn e2e
       - name: Upload Playwright artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
         with:
           name: playwright-report-${{github.run_id}}
@@ -90,20 +90,20 @@ jobs:
 
       - name: Setup Go environment
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: '1.21'
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           version: latest
           args: coverage
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           version: latest
           args: buildAll
@@ -132,7 +132,7 @@ jobs:
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
 
       - name: Archive Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
           path: ${{ steps.metadata.outputs.plugin-id }}

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -5,16 +5,16 @@ jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '20'
           cache: 'yarn'
 
       - name: Restore npm cache
         id: restore-npm-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules
@@ -27,7 +27,7 @@ jobs:
       - name: Save npm cache
         id: save-npm-cache
         if: steps.restore-npm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             node_modules

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
           website_directory: content/docs/explore-logs/next

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -24,7 +24,7 @@ jobs:
       upload-folder: ${{ steps.metadata.outputs.upload-folder }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: bump package version
         run: npm version --no-git-tag-version patch && npm version --no-git-tag-version `npm version --json | jq -r '."grafana-lokiexplore-app"'`-`git rev-parse --short HEAD`
       - uses: grafana/plugin-actions/package-plugin@main
@@ -39,7 +39,7 @@ jobs:
             GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'
 
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
 
@@ -48,7 +48,7 @@ jobs:
 
       - id: 'upload-to-gcs'
         name: 'Upload assets to latest'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c # v1.0.3
         with:
           path: ./
           destination: 'integration-artifacts/grafana-lokiexplore-app/'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.actor != 'grafanabot' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: grafana/plugin-actions/build-plugin@main
         id: build-release
         with:
@@ -39,7 +39,7 @@ jobs:
           common_secrets: |
             GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
 
@@ -48,7 +48,7 @@ jobs:
 
       - id: 'upload-to-gcs'
         name: 'Upload assets to latest'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: google-github-actions/upload-cloud-storage@e95a15f226403ed658d3e65f40205649f342ba2c # v1.0.3
         with:
           path: ./
           destination: 'integration-artifacts/grafana-lokiexplore-app/'

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -8,5 +8,5 @@ jobs:
     if: github.repository == 'grafana/explore-logs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1


### PR DESCRIPTION
# Description
Update github actions to use sha commits for 🔒 securities! [auto action patcher 🤖 ](https://github.com/grafana/github-action-patcher) from @academo ty.