### PR TITLE
Patterns: Percentage in table is relative to current pattern search results

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -7,7 +7,7 @@ import {
   SceneObjectBase,
   SceneObjectState,
 } from '@grafana/scenes';
-import { PatternFrame } from './PatternsBreakdownScene';
+import { PatternFrame, PatternsBreakdownScene } from './PatternsBreakdownScene';
 import React from 'react';
 import { IndexScene } from '../../../IndexScene/IndexScene';
 import { DataFrame, GrafanaTheme2, LoadingState, PanelData, scaledUnits } from '@grafana/data';
@@ -300,8 +300,12 @@ export function PatternTableViewSceneComponent({ model }: SceneComponentProps<Pa
   const { patternFrames: patternFramesRaw, patternsNotMatchingFilters } = model.useState();
   const patternFrames = patternFramesRaw ?? [];
 
+  // Get unfiltered patterns for percentage calculation
+  const patternsBreakdownScene = sceneGraph.getAncestor(model, PatternsBreakdownScene);
+  const unfilteredPatterns = patternsBreakdownScene.state.patternFrames ?? [];
+
   // Calculate total for percentages
-  const total = patternFrames.reduce((previousValue, frame) => {
+  const total = unfilteredPatterns.reduce((previousValue, frame) => {
     return previousValue + frame.sum;
   }, 0);
 


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1185

Before:
![image](https://github.com/user-attachments/assets/3462b25e-d755-4ccb-9f93-51b9e973b51e)

After:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/905b8d56-a096-454d-9c74-dc8ed55909a0" />
