### PR TITLE
chore: remove `ToolbarExtensionsRenderer`

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -78,10 +78,6 @@
     "extensionPoints": [
       {
         "id": "grafana-lokiexplore-app/investigation/v1"
-      },
-      {
-        "id": "grafana-lokiexplore-app/toolbar-open-related/v1",
-        "title": "Open related signals like metrics/traces/profiles"
       }
     ]
   }


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/103786 removes `appSidecar` and it's implementation. Followup to remove code that was relying on that.