### PR TITLE
Service selection: Simplify panel buttons

### DIFF
--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -11,6 +11,7 @@ import { logger } from '../../services/logger';
 import { LineFilterVariablesScene } from './LineFilterVariablesScene';
 import { VariableLayoutScene } from './VariableLayoutScene';
 import { LevelsVariableScene } from './LevelsVariableScene';
+import { getDrilldownSlug, PageSlugs } from '../../services/routing';
 
 interface LayoutSceneState extends SceneObjectState {
   interceptDismissed: boolean;
@@ -74,10 +75,11 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
   };
 
   public onActivate() {
+    const slug = getDrilldownSlug();
     this.setState({
       lineFilterRenderer: new LineFilterVariablesScene({}),
       levelsRenderer: new LevelsVariableScene({}),
-      variableLayout: new VariableLayoutScene({}),
+      variableLayout: new VariableLayoutScene({ position: slug === PageSlugs.explore ? 'sticky' : 'relative' }),
     });
   }
 
@@ -102,7 +104,6 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       minHeight: '100%',
       flexDirection: 'column',
-      padding: theme.spacing(2),
       maxWidth: '100vw',
     }),
     body: css({
@@ -111,6 +112,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),
+      padding: `0 ${theme.spacing(2)} ${theme.spacing(2)}`,
     }),
     controlsContainer: css({
       label: 'controlsContainer',

--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -10,7 +10,10 @@ import { useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { AppliedPattern } from '../../services/variables';
 
-interface VariableLayoutSceneState extends SceneObjectState {}
+type HeaderPosition = 'sticky' | 'relative';
+interface VariableLayoutSceneState extends SceneObjectState {
+  position: HeaderPosition;
+}
 export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneState> {
   static Component = ({ model }: SceneComponentProps<VariableLayoutScene>) => {
     const indexScene = sceneGraph.getAncestor(model, IndexScene);
@@ -19,10 +22,15 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
     const layoutScene = sceneGraph.getAncestor(model, LayoutScene);
     const { lineFilterRenderer, levelsRenderer } = layoutScene.useState();
 
-    const styles = useStyles2(getStyles);
+    const styles = useStyles2((theme) => getStyles(theme, model.state.position));
 
     return (
-      <div className={styles.controlsContainer}>
+      <div
+        className={cx(
+          styles.controlsContainer,
+          model.state.position === 'sticky' ? styles.stickyControlsContainer : undefined
+        )}
+      >
         <>
           {/* First row - datasource, timepicker, refresh, labels, button */}
           {controls && (
@@ -93,7 +101,9 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
   };
 }
 
-function getStyles(theme: GrafanaTheme2) {
+// @todo remove hardcoded height: https://github.com/grafana/grafana/issues/103795
+const grafanaTopBarHeight = 40;
+function getStyles(theme: GrafanaTheme2, position: HeaderPosition) {
   return {
     firstRowWrapper: css({
       '& > div > div': {
@@ -104,26 +114,6 @@ function getStyles(theme: GrafanaTheme2) {
           flexDirection: 'column',
         },
       },
-    }),
-    bodyContainer: css({
-      flexGrow: 1,
-      display: 'flex',
-      minHeight: '100%',
-      flexDirection: 'column',
-    }),
-    container: css({
-      flexGrow: 1,
-      display: 'flex',
-      minHeight: '100%',
-      flexDirection: 'column',
-      padding: theme.spacing(2),
-      maxWidth: '100vw',
-    }),
-    body: css({
-      flexGrow: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      gap: theme.spacing(1),
     }),
     controlsFirstRowContainer: css({
       label: 'controls-first-row',
@@ -148,11 +138,21 @@ function getStyles(theme: GrafanaTheme2) {
         flexDirection: 'column',
       },
     }),
+    stickyControlsContainer: css({
+      position: 'sticky',
+      top: grafanaTopBarHeight,
+      left: 0,
+      background: theme.colors.background.canvas,
+      zIndex: theme.zIndex.navbarFixed,
+      gap: theme.spacing(0),
+      boxShadow: theme.shadows.z1,
+    }),
     controlsContainer: css({
       label: 'controlsContainer',
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),
+      padding: theme.spacing(2),
     }),
     filters: css({
       label: 'filters',
@@ -184,16 +184,6 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       flexDirection: 'row',
       gap: theme.spacing(1),
-    }),
-    controls: css({
-      display: 'flex',
-      gap: theme.spacing(1),
-    }),
-    feedback: css({
-      textAlign: 'end',
-    }),
-    rotateIcon: css({
-      svg: { transform: 'rotate(180deg)' },
     }),
   };
 }

--- a/src/Components/ServiceSelectionScene/AddLabelToFiltersHeaderActionScene.tsx
+++ b/src/Components/ServiceSelectionScene/AddLabelToFiltersHeaderActionScene.tsx
@@ -12,7 +12,6 @@ import { FilterOp } from '../../services/filterTypes';
 export interface AddLabelToFiltersHeaderActionSceneState extends SceneObjectState {
   name: string;
   value: string;
-  hidden?: boolean;
   included: boolean | null;
 }
 
@@ -58,11 +57,7 @@ export class AddLabelToFiltersHeaderActionScene extends SceneObjectBase<AddLabel
   };
 
   public static Component = ({ model }: SceneComponentProps<AddLabelToFiltersHeaderActionScene>) => {
-    const { value, hidden, included } = model.useState();
-
-    if (hidden) {
-      return <></>;
-    }
+    const { value, included } = model.useState();
 
     const styles = useStyles2(getStyles);
     return (
@@ -71,13 +66,14 @@ export class AddLabelToFiltersHeaderActionScene extends SceneObjectBase<AddLabel
           tooltip={included === true ? `Remove ${value} from filters` : `Add ${value} to filters`}
           variant={'secondary'}
           fill={'outline'}
-          icon={included === true ? 'minus' : 'plus'}
           size="sm"
           aria-selected={included === true}
           className={styles.includeButton}
           onClick={() => (included === true ? model.onClick('clear') : model.onClick('include'))}
           data-testid={testIds.exploreServiceDetails.buttonFilterInclude}
-        />
+        >
+          {included ? 'Exclude' : 'Include'}
+        </Button>
       </span>
     );
   };

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -41,7 +41,8 @@ export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonStat
         data-testid={testIds.index.showLogsButton}
         tooltip={`View logs for ${model.state.labelValue}`}
         className={styles.button}
-        variant="secondary"
+        variant={'secondary'}
+        fill={'outline'}
         size="sm"
         disabled={!link}
         href={model.getLink()}

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -963,7 +963,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       this.state.body.setState({
         children: newChildren,
         isLazy: true,
-        templateColumns: 'repeat(auto-fit, minmax(300px, 1fr) minmax(300px, 70vw))',
+        templateColumns: 'repeat(auto-fit, minmax(350px, 1fr) minmax(300px, calc(70vw - 100px)))',
         autoRows: '200px',
         md: {
           templateColumns: '1fr',

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -480,16 +480,16 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       })
       .setHeaderActions([
         new FavoriteServiceHeaderActionScene({
-          ds: datasourceVar.getValue()?.toString(),
+          ds: datasourceVar.getValue()?.toString() ?? '',
           labelName: primaryLabelName,
           labelValue: primaryLabelValue,
         }),
-        new AddLabelToFiltersHeaderActionScene({
-          name: primaryLabelName,
-          value: primaryLabelValue,
-          hidden: this.isAggregatedMetricsActive(),
-        }),
-        new SelectServiceButton({ labelValue: primaryLabelValue, labelName: primaryLabelName }),
+        this.isAggregatedMetricsActive()
+          ? new SelectServiceButton({ labelValue: primaryLabelValue, labelName: primaryLabelName })
+          : new AddLabelToFiltersHeaderActionScene({
+              name: primaryLabelName,
+              value: primaryLabelValue,
+            }),
       ])
       .build();
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -963,7 +963,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       this.state.body.setState({
         children: newChildren,
         isLazy: true,
-        templateColumns: 'repeat(auto-fit, minmax(500px, 1fr) minmax(300px, 70vw))',
+        templateColumns: 'repeat(auto-fit, minmax(300px, 1fr) minmax(300px, 70vw))',
         autoRows: '200px',
         md: {
           templateColumns: '1fr',

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -48,7 +48,7 @@ export const testIds = {
   },
 
   index: {
-    showLogsButton: 'data-testid Show logs',
+    showLogsButton: 'data-testid button-filter-include',
     addNewLabelTab: 'data-testid Tab Add label',
     searchLabelValueInput: 'data-testid search-services-input',
     aggregatedMetricsMenu: 'data-testid aggregated-metrics-menu',

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -21,7 +21,7 @@ test.describe('navigating app', () => {
     await page.getByTestId('data-testid navigation mega-menu').getByRole('link', { name: 'Logs' }).click();
     await expect(page).toHaveURL(/a\/grafana\-lokiexplore\-app\/explore\?patterns\=%5B%5D/);
     await expect(page).toHaveURL(/var-primary_label=service_name/);
-    await expect(page.getByTestId('data-testid Show logs').first()).toHaveCount(1);
+    await expect(page.getByTestId('data-testid button-filter-include').first()).toHaveCount(1);
 
     // assert panels are showing
     const actualSearchParams = new URLSearchParams(page.url().split('?')[1]);
@@ -46,15 +46,16 @@ test.describe('navigating app', () => {
     await expect(page.getByRole('heading', { name: 'tempo-distributor' })).not.toBeVisible();
 
     await explorePage.addServiceName();
+    await explorePage.clickShowLogs();
     await page.getByLabel('Open menu').click();
     await page.getByTestId('data-testid navigation mega-menu').getByRole('link', { name: 'Logs' }).click();
     await expect(page).toHaveURL(/a\/grafana\-lokiexplore\-app\/explore\?patterns\=%5B%5D/);
 
     // assert panels are showing
-    await expect(page.getByTestId('data-testid Show logs').first()).toHaveCount(1);
+    await expect(page.getByTestId('data-testid button-filter-include').first()).toHaveCount(1);
     const actualSearchParams = new URLSearchParams(page.url().split('?')[1]);
     const expectedSearchParams = new URLSearchParams(
-      '?patterns=%5B%5D&from=now-15m&to=now&var-all-fields=&var-ds=gdev-loki&var-filters=&var-fields=&var-filters_replica=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C%28%3Fi%29.%2ATempo-i.%2A'
+      '?patterns=%5B%5D&from=now-15m&to=now&var-all-fields=&var-ds=gdev-loki&var-filters=service_name%7C%3D%7Ctempo-ingester&var-fields=&var-filters_replica=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C%28%3Fi%29.%2ATempo-i.%2A'
     );
     actualSearchParams.sort();
     expectedSearchParams.sort();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -41,8 +41,9 @@ test.describe('explore services page', () => {
       await page.keyboard.press('Escape');
 
       // Assert the first is nginx, or we might click before it's done loading
-      await expect(page.getByTestId('header-container').first()).toHaveText('nginxShow logs');
+      await expect(page.getByTestId('header-container').first()).toHaveText('nginxInclude');
       await explorePage.addServiceName();
+      await explorePage.clickShowLogs();
 
       // Assert we made it to the breakdown, and nginx is selected
       await expect(page.getByLabel('Edit filter with key')).toHaveText('service_name = nginx');
@@ -57,7 +58,7 @@ test.describe('explore services page', () => {
       await expect(page.getByTestId('header-container').nth(1)).toBeVisible();
 
       // Assert that the first element is nginx now
-      await expect(page.getByTestId('header-container').first()).toHaveText('nginxShow logs');
+      await expect(page.getByTestId('header-container').first()).toHaveText('nginxExclude');
       await explorePage.servicesSearch.click();
 
       // Assert there is more than one element in the dropdown
@@ -132,6 +133,7 @@ test.describe('explore services page', () => {
     test('should select a service label value and navigate to log view', async ({ page }) => {
       await explorePage.gotoServices();
       await explorePage.addServiceName();
+      await explorePage.clickShowLogs();
       await expect(explorePage.logVolumeGraph).toBeVisible();
     });
 
@@ -153,6 +155,7 @@ test.describe('explore services page', () => {
     test('should clear filters and levels when navigating back to previously activated service', async ({ page }) => {
       await explorePage.gotoServices();
       await explorePage.addServiceName();
+      await explorePage.clickShowLogs();
       // Add detected_level filter
       await page.getByTestId(testIds.exploreServiceDetails.tabLabels).click();
       await page.getByLabel('Select detected_level').click();
@@ -184,6 +187,7 @@ test.describe('explore services page', () => {
       await expect(page.getByText(serviceSelectionPaginationTextMatch)).toBeVisible();
 
       await explorePage.addServiceName();
+      await explorePage.clickShowLogs();
 
       await expect(page.getByTestId(testIds.variables.levels.inputWrap)).toBeVisible();
       await expect(page.getByTestId(testIds.variables.levels.inputWrap)).not.toContainText(levelTextMatch);
@@ -342,6 +346,7 @@ test.describe('explore services page', () => {
 
         // Click on first service
         await explorePage.addServiceName();
+        await explorePage.clickShowLogs();
         await explorePage.assertTabsNotLoading();
 
         // Clear variable
@@ -357,6 +362,7 @@ test.describe('explore services page', () => {
 
         // Click on first service
         await explorePage.addServiceName();
+        await explorePage.clickShowLogs();
         await explorePage.assertTabsNotLoading();
 
         // Clear variable
@@ -392,6 +398,7 @@ test.describe('explore services page', () => {
       test('should re-execute volume query after being redirected back to service selection', async ({ page }) => {
         await explorePage.assertPanelsNotLoading();
         await explorePage.addServiceName();
+        await explorePage.clickShowLogs();
         await expect(explorePage.logVolumeGraph).toBeVisible();
         await explorePage.changeDatasource();
         expect(logsVolumeCount).toBe(2);
@@ -456,6 +463,7 @@ test.describe('explore services page', () => {
         }) => {
           // Select the first service
           await explorePage.addServiceName();
+          await explorePage.clickShowLogs();
 
           const serviceNameVariableLoc = page.getByTestId(testIds.variables.serviceName.label);
           await expect(serviceNameVariableLoc).toHaveCount(1);
@@ -613,6 +621,7 @@ test.describe('explore services page', () => {
 
         // Select the first and only result
         await explorePage.addServiceName();
+        await explorePage.clickShowLogs();
         await explorePage.assertTabsNotLoading();
 
         // Logs tab should be visible and selected

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -123,6 +123,10 @@ export class ExplorePage {
     await this.firstServicePageSelect.click();
   }
 
+  async clickShowLogs() {
+    await this.page.getByTestId('data-testid Show logs header').click();
+  }
+
   /**
    * Changes the datasource from gdev-loki to gdev-loki-copy
    */


### PR DESCRIPTION
Currently it's a bit confusing why there are two buttons in the time series panel, and a "show logs" button in the header.
This PR removes the "show logs" button in the service/label row, and replaces it with an "Include" button that matches the buttons used in the breakdown views.

The header is now "sticky" on the service selection, so the "show logs" CTA is always visible.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0a70f990-8066-426c-b1a4-627c53e365c3" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/08f7559e-db9c-4f2b-9f46-eb5b0cfaca46" />


Fixes: https://github.com/grafana/logs-drilldown/issues/1161

Note:
Aggregated metrics does not support an entry point with multiple labels, so the old style "show logs" button is still used when active:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/11554c97-7292-42d0-814a-339c55943014" />
