### PR TITLE
Line filters: Client regex validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@lezer/common": "^1.2.1",
     "@lezer/lr": "^1.4.1",
     "@types/react-table": "^7.7.20",
+    "re2js": "^1.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^5.2.0",

--- a/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
@@ -1,41 +1,95 @@
 import { css } from '@emotion/css';
-import { Icon, IconButton, Input, useStyles2 } from '@grafana/ui';
-import React, { HTMLProps } from 'react';
+import { Icon, IconButton, Input, Tooltip, useStyles2 } from '@grafana/ui';
+import React, { ChangeEvent, HTMLProps, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { narrowErrorMessage } from '../../../services/narrowing';
 
-interface Props extends Omit<HTMLProps<HTMLInputElement>, 'width' | 'prefix'> {
+interface Props extends Omit<HTMLProps<HTMLInputElement>, 'width' | 'prefix' | 'invalid' | 'onInvalid'> {
   onClear?: () => void;
   suffix?: React.ReactNode;
   prefix?: React.ReactNode;
   width?: number;
+  regex: boolean;
+  value: string;
 }
 
-export const LineFilterInput = ({ value, onChange, placeholder, onClear, suffix, width, ...rest }: Props) => {
+let re2JS: typeof import('re2js').RE2JS | undefined | null = undefined;
+
+export const LineFilterInput = ({ value, onChange, placeholder, onClear, suffix, width, regex, ...rest }: Props) => {
   const styles = useStyles2(getStyles);
-  return (
-    <Input
-      rows={2}
-      width={width}
-      value={value}
-      onChange={onChange}
-      suffix={
-        <span className={styles.suffixWrapper}>
-          {onClear && value ? (
-            <IconButton
-              aria-label={'Clear line filter'}
-              tooltip={'Clear line filter'}
-              onClick={onClear}
-              name="times"
-              className={styles.clearIcon}
-            />
-          ) : undefined}
-          {suffix && suffix}
-        </span>
+  const [invalid, setInvalid] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const load = async () => {
+    re2JS = null;
+    re2JS = (await import('re2js')).RE2JS;
+  };
+
+  const initValidation = (value: string) => {
+    if (re2JS === undefined && regex) {
+      load().then(() => validate(value));
+    } else if (regex && re2JS) {
+      validate(value);
+    }
+  };
+
+  const validate = (value: string) => {
+    if (value) {
+      try {
+        re2JS?.compile(value);
+        if (invalid) {
+          setInvalid(false);
+          setErrorMessage('');
+        }
+      } catch (e) {
+        const msg = narrowErrorMessage(e);
+        if (!invalid) {
+          setInvalid(true);
+        }
+
+        if (msg && msg !== errorMessage) {
+          setErrorMessage(msg);
+        }
       }
-      prefix={<Icon name="search" />}
-      placeholder={placeholder}
-      {...rest}
-    />
+    } else if (invalid) {
+      setInvalid(false);
+    }
+  };
+
+  initValidation(value);
+
+  return (
+    <Tooltip placement={'auto-start'} show={!!errorMessage && invalid} content={errorMessage}>
+      <Input
+        invalid={invalid}
+        rows={2}
+        width={width}
+        value={value}
+        onChange={async (e: ChangeEvent<HTMLInputElement>) => {
+          if (onChange) {
+            onChange(e);
+          }
+          initValidation(value);
+        }}
+        suffix={
+          <span className={styles.suffixWrapper}>
+            {onClear && value ? (
+              <IconButton
+                aria-label={'Clear line filter'}
+                tooltip={'Clear line filter'}
+                onClick={onClear}
+                name="times"
+                className={styles.clearIcon}
+              />
+            ) : undefined}
+            {suffix && suffix}
+          </span>
+        }
+        prefix={<Icon name="search" />}
+        placeholder={placeholder}
+        {...rest}
+      />
+    </Tooltip>
   );
 };
 

--- a/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
@@ -62,6 +62,7 @@ export const LineFilterInput = ({ value, onChange, placeholder, onClear, suffix,
     <Tooltip placement={'auto-start'} show={!!errorMessage && invalid} content={errorMessage}>
       <Input
         invalid={invalid}
+        aria-invalid={invalid}
         rows={2}
         width={width}
         value={value}

--- a/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Icon, IconButton, Input, Tooltip, useStyles2 } from '@grafana/ui';
-import React, { ChangeEvent, HTMLProps, useCallback, useEffect, useState } from 'react';
+import React, { HTMLProps, useCallback, useEffect, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { narrowErrorMessage } from '../../../services/narrowing';
 
@@ -64,13 +64,19 @@ export const LineFilterInput = ({ value, onChange, placeholder, onClear, suffix,
   );
 
   useEffect(() => {
+    if (value) {
+      initValidation(value);
+    } else {
+      setInvalid(false);
+      setErrorMessage('');
+      return;
+    }
+
     if (!regex) {
       setInvalid(false);
       setErrorMessage('');
     }
-  }, [regex]);
-
-  initValidation(value);
+  }, [regex, value, initValidation]);
 
   return (
     <Tooltip placement={'auto-start'} show={!!errorMessage && invalid} content={errorMessage}>
@@ -80,12 +86,7 @@ export const LineFilterInput = ({ value, onChange, placeholder, onClear, suffix,
         rows={2}
         width={width}
         value={value}
-        onChange={async (e: ChangeEvent<HTMLInputElement>) => {
-          if (onChange) {
-            onChange(e);
-          }
-          initValidation(value);
-        }}
+        onChange={onChange}
         suffix={
           <span className={styles.suffixWrapper}>
             {onClear && value ? (

--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -68,10 +68,10 @@ export function LineFilterEditor({
       )}
       <Field className={styles.field}>
         <LineFilterInput
+          regex={regex}
           // Only set width if focused
           width={focus ? width : undefined}
           onFocus={() => setFocus(true)}
-          // onBlur={() => setFocus(false)}
           data-testid={testIds.exploreServiceDetails.searchLogs}
           value={lineFilter}
           className={cx(onSubmitLineFilter ? styles.inputNoBorderRight : undefined, styles.input)}

--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -73,7 +73,7 @@ export function LineFilterEditor({
           width={focus ? width : undefined}
           onFocus={() => setFocus(true)}
           data-testid={testIds.exploreServiceDetails.searchLogs}
-          value={lineFilter}
+          value={lineFilter ?? ''}
           className={cx(onSubmitLineFilter ? styles.inputNoBorderRight : undefined, styles.input)}
           onChange={onInputChange}
           suffix={

--- a/src/Components/ServiceScene/LineFilter/LineFilterScene.test.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterScene.test.tsx
@@ -214,4 +214,33 @@ describe('LineFilter', () => {
       expect(await screen.findByDisplayValue(string)).toBeInTheDocument();
     });
   });
+  describe('regex validation', () => {
+    beforeEach(() => {
+      lineFilterVariable = new AdHocFiltersVariable({
+        name: VAR_LINE_FILTER,
+        expressionBuilder: renderLogQLLineFilter,
+      });
+      lineFiltersVariable = new AdHocFiltersVariable({
+        name: VAR_LINE_FILTERS,
+        expressionBuilder: renderLogQLLineFilter,
+      });
+      scene = new LineFilterScene({
+        caseSensitive: true,
+        regex: true,
+        lineFilter: '(',
+        $variables: new SceneVariableSet({
+          variables: [lineFilterVariable, lineFiltersVariable],
+        }),
+      });
+    });
+
+    test('Shows error when invalid', async () => {
+      render(<scene.Component model={scene} />);
+      await setTimeout(() => {}, 1);
+      expect(await screen.findByText('missing closing )')).toBeInTheDocument();
+      const input: HTMLInputElement = await screen.findByTestId('data-testid search-logs');
+      expect(input).toBeInTheDocument();
+      expect(input.attributes.getNamedItem('aria-invalid')?.value).toEqual('true');
+    });
+  });
 });

--- a/src/Components/ServiceScene/LineFilter/LineFilterScene.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterScene.tsx
@@ -34,7 +34,7 @@ export class LineFilterScene extends SceneObjectBase<LineFilterState> {
    */
   constructor(state?: Partial<LineFilterState>) {
     super({
-      lineFilter: state?.lineFilter || '',
+      lineFilter: state?.lineFilter ?? '',
       caseSensitive: state?.caseSensitive ?? getLineFilterCase(false),
       regex: state?.regex ?? getLineFilterRegex(false),
       exclusive: state?.exclusive ?? getLineFilterExclusive(false),

--- a/src/services/narrowing.ts
+++ b/src/services/narrowing.ts
@@ -107,6 +107,14 @@ export function narrowTimeRange(unknownRange: unknown): RawTimeRange | undefined
   return undefined;
 }
 
+export function narrowErrorMessage(e: unknown): string | undefined {
+  const msg = isObj(e) && hasProp(e, 'error') && isString(e.error);
+  if (msg) {
+    return msg;
+  }
+  return undefined;
+}
+
 export function narrowFilterOperator(op: string): LabelFilterOp | NumericFilterOp {
   switch (op) {
     case LabelFilterOp.Equal:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7572,6 +7572,11 @@ rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
     rc-resize-observer "^1.0.0"
     rc-util "^5.36.0"
 
+re2js@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-1.1.0.tgz#8da02a05f16e51388659c74fc92ad6dc27565769"
+  integrity sha512-ovDCIb2ZQR7Do3NzH2XEuXOzqd1q8srvkeaOVMf+EZNt1Z4JoUVvNKCR9qf8EbqoPhvLknkoyiiBzoQtmuzIbQ==
+
 react-calendar@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-5.1.0.tgz#f5d3342a872cbb8907099ca5651bc936046033b8"
@@ -8567,16 +8572,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8658,14 +8654,7 @@ string_decoder@0.10:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9511,16 +9500,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/989

Asynchronously loads re2JS package when regex is toggled on line filter inputs in an effort to keep load times down for users that will not add regex line filters.

Displays error message from re2JS in tooltip under the input.
<img width="862" alt="image" src="https://github.com/user-attachments/assets/f3ac1426-dc47-4170-9c7b-b1effebedea2" />
<img width="456" alt="image" src="https://github.com/user-attachments/assets/fca0c1e7-8f77-4d04-a4c2-5786c9dac8e1" />

Follow ups:
We could potentially prevent the query from executing when an invalid regex is detected, but this would add a bunch of complexity to this PR, and I wasn't certain that the version of re2 used in Loki would exactly map to the frontend library, and didn't want to risk a regression preventing a user from submitting a query that might work on the backend, but throws an error in the client.

Since Loki will validate the query before executing, preventing queries with invalid regex shouldn't impact billing or have significant performance impact, so the benefits of preventing queries with invalid regex line filters are mostly limited to keeping the frontend clean:

<img width="864" alt="image" src="https://github.com/user-attachments/assets/fc590adf-dc9d-4cbb-8680-baaceba64acf" />
