### PR TITLE
Service Selection: Conditionally display "show logs" buttons

### DIFF
--- a/src/Components/ServiceSelectionScene/AddLabelToFiltersHeaderActionScene.tsx
+++ b/src/Components/ServiceSelectionScene/AddLabelToFiltersHeaderActionScene.tsx
@@ -72,7 +72,7 @@ export class AddLabelToFiltersHeaderActionScene extends SceneObjectBase<AddLabel
           onClick={() => (included === true ? model.onClick('clear') : model.onClick('include'))}
           data-testid={testIds.exploreServiceDetails.buttonFilterInclude}
         >
-          {included ? 'Exclude' : 'Include'}
+          {included ? 'Remove' : 'Include'}
         </Button>
       </span>
     );

--- a/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
+++ b/src/Components/ServiceSelectionScene/SelectServiceButton.tsx
@@ -15,9 +15,23 @@ import { addToFavorites } from '../../services/favorites';
 export interface SelectServiceButtonState extends SceneObjectState {
   labelValue: string;
   labelName: string;
+  hidden?: boolean;
 }
 
 export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonState> {
+  constructor(state: SelectServiceButtonState) {
+    super(state);
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+  onActivate() {
+    const labelsVar = getLabelsVariable(this);
+    this.setState({ hidden: labelsVar.state.filters.length > 0 });
+    labelsVar.subscribeToState((newState) => {
+      this.setState({ hidden: newState.filters.length > 0 });
+    });
+  }
+
   public getLink = () => {
     if (!this.state.labelValue) {
       return;
@@ -35,6 +49,10 @@ export class SelectServiceButton extends SceneObjectBase<SelectServiceButtonStat
     const labels = getLabelsVariable(model);
     // Re-render links on label filter changes
     labels.useState();
+    const { hidden } = model.useState();
+    if (hidden) {
+      return null;
+    }
     const link = model.getLink();
     return (
       <LinkButton

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -449,6 +449,19 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     if (timeRange.to.diff(timeRange.from, 'hours') >= 4 && timeRange.to.diff(timeRange.from, 'hours') <= 26) {
       splitDuration = '2h';
     }
+    const headerActions = [];
+
+    if (this.isAggregatedMetricsActive()) {
+      headerActions.push(new SelectServiceButton({ labelValue: primaryLabelValue, labelName: primaryLabelName }));
+    } else {
+      headerActions.push(
+        new AddLabelToFiltersHeaderActionScene({
+          name: primaryLabelName,
+          value: primaryLabelValue,
+        })
+      );
+      headerActions.push(new SelectServiceButton({ labelValue: primaryLabelValue, labelName: primaryLabelName }));
+    }
     const panel = PanelBuilders.timeseries()
       // If service was previously selected, we show it in the title
       .setTitle(primaryLabelValue)
@@ -484,12 +497,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
           labelName: primaryLabelName,
           labelValue: primaryLabelValue,
         }),
-        this.isAggregatedMetricsActive()
-          ? new SelectServiceButton({ labelValue: primaryLabelValue, labelName: primaryLabelName })
-          : new AddLabelToFiltersHeaderActionScene({
-              name: primaryLabelName,
-              value: primaryLabelValue,
-            }),
+        ...headerActions,
       ])
       .build();
 


### PR DESCRIPTION
Potential follow-up to https://github.com/grafana/logs-drilldown/pull/1188, where we keep the option of going directly to the details of a single value.

Additionally, "Exclude" has been renamed as "Remove", to better match the clicking outcome.

https://github.com/user-attachments/assets/95881f70-c75d-4ab6-b7d2-bd81049bd39e

