### PR TITLE
chore: (plugin-ci-workflows) - init vanilla plugin-ci-workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - master
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - master
+  #     - main
 
 jobs:
   build:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,19 @@
+name: Plugins Platform PR - CI
+
+on:
+  push:
+    branches:
+      - l2d2/1202-use-plugin-ci-workflows
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    with:
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      # Same settings as publish
+      run-playwright-with-skip-grafana-dev-image: true
+      run-playwright-with-grafana-dependency: '>=12.0.0'
+      upload-playwright-artifacts: true
+      playwright-docker-compose-file: docker-compose.dev.yaml
+      playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,4 +15,5 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
+      playwright-docker-compose-file: docker-compose.dev.yaml
       playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,5 +15,3 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
-      playwright-docker-compose-file: docker-compose.dev.yaml
-      playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,7 +3,10 @@ name: Plugins Platform PR - CI
 on:
   push:
     branches:
-      - l2d2/1202-use-plugin-ci-workflows
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   ci:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,3 +15,4 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
+      playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,4 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
+      playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Plugins Platform Publish - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - 'dev'
+          - 'ops'
+          - 'prod'
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+jobs:
+  cd:
+    name: CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      environment: ${{ github.event.inputs.environment }}
+      docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      attestation: true
+      # Same settings as PR-CI
+      run-playwright-with-skip-grafana-dev-image: true
+      run-playwright-with-grafana-dependency: '>=12.0.0'
+      upload-playwright-artifacts: true
+      playwright-docker-compose-file: docker-compose.dev.yaml
+      playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,5 +33,3 @@ jobs:
       run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
-      playwright-docker-compose-file: docker-compose.dev.yaml
-      playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       attestation: true
       # Same settings as PR-CI
-      run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
+      playwright-docker-compose-file: docker-compose.dev.yaml
       playwright-grafana-url: http://localhost:3001/grafana

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   grafana:
     container_name: 'grafana-logsapp'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,7 +46,6 @@ export default defineConfig<PluginOptions>({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: `http://localhost:3001${E2ESubPath}`,
-
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     // Turn on when debugging local tests

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -254,7 +254,7 @@ test.describe('explore services page', () => {
 
       // assert we navigated
       await expect(
-        page.getByTestId('data-testid Panel header Log volume').getByTestId('header-container')
+        page.getByTestId(/data-testid Panel header Log volume/).getByTestId('header-container')
       ).toBeVisible();
 
       // assert the filters are still visible in the combobox


### PR DESCRIPTION
This PR is officially ready for merging 🥳 

# pr-ci.yml
- Here's a successful [job](https://github.com/grafana/logs-drilldown/actions/runs/14886934571?pr=1215) running in 15min. 
- On playwright test failures playwright reports are showing up [example](https://github.com/grafana/logs-drilldown/actions/runs/14886416107)

# publish.yml
- Mostly the same as pr-ci.yml
- We still need to create a branch, npm run version, generate changelog
- Trigger is pushing a git tag
- Right now the plugin will be uploaded to GCS for backwards compatibility. Eventually it will just be uploaded to the plugin catalogue and deployment_tools should be updated to provision from the catalog rather than GCS.


# Future
- Merge this PR
- Remove old release.yml, ci.yml, drone 
- Delete all old jobs from those pipelines to full delete the files
- Create a gha for creating a branch, npm run version, generate changelog