### PR TITLE
chore: update version check for controls

### DIFF
--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -339,4 +339,4 @@ export function getQueryRunnerFromProvider(provider: SceneDataProvider): SceneQu
 export const logsControlsSupported =
   // @ts-expect-error Requires Grafana 12.1
   config.featureToggles.logsPanelControls &&
-  (config.buildInfo.version > '12' || config.buildInfo.version.includes('12.1'));
+  (config.buildInfo.version > '12.1' || config.buildInfo.version.includes('12.1'));


### PR DESCRIPTION
This is causing that the controls attempt to appear when they're not yet supported, with an underlying Grafana 12.0.0-86995