### PR TITLE
chore(zizmor): update for template-injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,12 @@ jobs:
 
       - name: Package plugin
         id: package-plugin
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         run: |
-          mv dist ${{ steps.metadata.outputs.plugin-id }}
-          zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
+          mv "dist" "$PLUGIN_ID"
+          zip "$PLUGIN_ARCHIVE" "$PLUGIN_ID" -r
 
       - name: Archive Build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -33,7 +33,7 @@ jobs:
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
         with:
           common_secrets: |
             GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'
@@ -44,7 +44,11 @@ jobs:
           credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
 
       - name: 'rename versioned archive to main-archive'
-        run: mv ${{ steps.package-plugin.outputs.archive }} ${{ steps.package-plugin.outputs.plugin-id }}-main.zip
+        env:
+          ARCHIVE_PATH: ${{ steps.package-plugin.outputs.archive }}
+          PLUGIN_ID: ${{ steps.package-plugin.outputs.plugin-id }}
+        run: |
+          mv "$ARCHIVE_PATH" "${PLUGIN_ID}-main.zip"
 
       - id: 'upload-to-gcs'
         name: 'Upload assets to latest'

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -33,7 +33,7 @@ jobs:
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760
         with:
           common_secrets: |
             GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760
         with:
           common_secrets: |
             GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
         with:
           common_secrets: |
             GCP_UPLOAD_ARTIFACTS_KEY=grafana/integration-artifacts-uploader-service-account:'credentials.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,11 @@ jobs:
           credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
 
       - id: 'create-latest'
-        run: cp ${{ steps.build-release.outputs.archive }} ${{ steps.metadata.outputs.archive }}
+        env:
+          SOURCE_ARCHIVE: ${{ steps.build-release.outputs.archive }}
+          TARGET_ARCHIVE: ${{ steps.metadata.outputs.archive }}
+        run: |
+          cp "$SOURCE_ARCHIVE" "$TARGET_ARCHIVE"
 
       - id: 'upload-to-gcs'
         name: 'Upload assets to latest'


### PR DESCRIPTION
Fixing template injection errors `zizmor --collect=workflows-only .github/workflows`
```
info[template-injection]: code injection via template expansion
  --> .github/workflows/release.yml:46:9
   |
46 |         - id: 'create-latest'
   |  _________-
47 | |         run: cp ${{ steps.build-release.outputs.archive }} ${{ steps.metadata.outputs.archive }}
   | |         ----------------------------------------------------------------------------------------
   | |_________|______________________________________________________________________________________|
   |           |                                                                                      info: this step
   |           info: steps.metadata.outputs.archive may expand into attacker-controllable code
   |
   = note: audit confidence → Low
```