### PR TITLE
fix(table): missing line filter

### DIFF
--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -257,6 +257,10 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
           ]
         : [
             new SceneFlexItem({
+              body: new LineFilterScene({ lineFilter: this.state.lineFilter }),
+              xSizing: 'fill',
+            }),
+            new SceneFlexItem({
               height: 'calc(100vh - 220px)',
               body: new LogsTableScene({}),
             }),


### PR DESCRIPTION
Looks like we removed the line filter accidentally from above the table. Let's add it back!