### PR TITLE
fix(line-filters): Expand no longer working.

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LineFilterInput.tsx
@@ -60,6 +60,11 @@ export const LineFilterInput = ({ value, onChange, placeholder, onClear, suffix,
         aria-invalid={invalid}
         rows={2}
         width={width}
+        onFocusCapture={(e) => {
+          if (rest.onFocus) {
+            rest.onFocus(e);
+          }
+        }}
         value={value}
         onChange={onChange}
         suffix={

--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -32,6 +32,7 @@ export function LineFilterEditor({
   setFocus,
   type,
 }: LineFilterEditorProps) {
+  console.log('LineFilterEditor', focus);
   const styles = useStyles2((theme) => getStyles(theme, type));
   const [width, setWidth] = useState(INITIAL_INPUT_WIDTH);
 

--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -32,7 +32,6 @@ export function LineFilterEditor({
   setFocus,
   type,
 }: LineFilterEditorProps) {
-  console.log('LineFilterEditor', focus);
   const styles = useStyles2((theme) => getStyles(theme, type));
   const [width, setWidth] = useState(INITIAL_INPUT_WIDTH);
 


### PR DESCRIPTION
Looks like with latest Grafana onFocus of the `<Input />` component is no longer firing on focus. 
`onFocusCapture` seems to work