### PR TITLE
docs: JSON viewer documentation

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -33,6 +33,10 @@ cards:
       href: ./troubleshooting/
       description: Find solutions to common issues you might encounter when using Grafana Logs Drilldown.
       height: 24
+    - title: Engage with your  JSON log lines
+      href: ./viewing-json-logs/
+      description: Drill down into your JSON log lines to better understand your log line data.
+      height: 24
     - title: Give feedback
       href: https://forms.gle/1sYWCTPvD72T1dPH9
       description: Share your thoughts on Grafana Logs Drilldown and help us improve the experience.

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -1,0 +1,43 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/viewing-json-logs/
+description: Learn how to view JSON formatted logs in Logs Drilldown.
+keywords:
+  - Logs
+  - JSON
+  - Formatting
+  - Drain
+  - Categorization
+  - Analysis
+menuTitle: Viewing JSON logs
+title: Viewing JSON logs
+weight: 400
+---
+
+# Viewing JSON Logs
+
+If your log lines are formatted in the JSON format, you can view them more easily using Grafana's JSON viewer in the Logs table.
+
+
+{{< admonition type="note" >}}
+You must be running Loki 3.5.0 or later to use the JSON viewer
+{{< /admonition >}}
+
+To interact with the JSON view, select the **Show Logs** button for your service in Logs Drilldown. 
+
+{{< figure alt="JSON Table viewer with selector and include exclude highlighted" width="900px" align="center" src="/media/docs/explore-logs/show-logs.png" caption="The JSON log line viewer" >}}
+
+From there, select **JSON** in the format menu in the top right toolbar. This will show your logs in a structured, collapsable way, enabling you to sort, filter, and otherwise adjust your log data in the visualisations for your logs.
+
+{{< figure alt="Show Logs button on a JSON logging service" width="300px" align="center" src="/media/docs/explore-logs/json-viewer.png" caption="Show Logs button on a service which logs JSON" >}}
+
+## Filtering log lines with the JSON view
+
+Users can include and exclude specific log data from their visualizations by selecting the **Include/Exclude** icons next to a given label. 
+
+For example, given a set of logs of API requests, selecting the **exclude** button next to a method field with status "GET" will result in the Log Volume dashboard showing only requests of other types (DELETE/PATCH/POST/PUT).
+
+To include them again, simply remove them from the **Fields** filter above the Logs Volume visualization. 
+
+{{< admonition type="note" >}}
+We are keen to improve this feature, so please [contact us](https://forms.gle/1sYWCTPvD72T1dPH9) if there is something that would help you find the signal in the noise.
+{{< /admonition >}}

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -5,17 +5,13 @@ keywords:
   - Logs
   - JSON
   - Formatting
-  - Drain
-  - Categorization
-  - Analysis
 menuTitle: Viewing JSON logs
 title: Viewing JSON logs
 weight: 400
 ---
 
-# JSON log line viewer
-
-If your log lines are formatted in the JSON format, you can view them more easily using Grafana's JSON viewer in the Logs table. This view will help you more easily read your JSON style logs, and filter through them to make your related dashboards more relevant and focused.
+# Logs Drilldown JSON viewer
+You can easily view and interact with your JSON formatted logs  using the Logs Drilldown JSON viewer. This view will help you read your JSON style logs, and filter through them to make your related dashboards more relevant and focused.
 
 
 {{< admonition type="note" >}}
@@ -26,19 +22,23 @@ Logs Drilldown JSON Viewer is an experimental feature. Engineering and on-call s
 
 To interact with the JSON view, select the **Show Logs** button for your service in Logs Drilldown. 
 
-{{< figure alt="JSON Table viewer with selector and include exclude highlighted" width="900px" align="center" src="/media/docs/explore-logs/show-logs.png" caption="The JSON log line viewer" >}}
+{{< figure alt="JSON Table viewer with selector and include exclude highlighted" width="500px" align="center" src="/media/docs/explore-logs/show-logs.png" caption="Select the 'Show Logs' button on your service" >}}
 
 From there, select **JSON** in the format menu in the top right toolbar. This will show your logs in a structured, collapsable way, enabling you to sort, filter, and otherwise adjust your log data in the visualisations for your logs.
 
-{{< figure alt="Show Logs button on a JSON logging service" width="300px" align="center" src="/media/docs/explore-logs/json-viewer.png" caption="Show Logs button on a service which logs JSON" >}}
+{{< figure alt="Show Logs button on a JSON logging service" width="900px" align="center" src="/media/docs/explore-logs/json-viewer.png" caption="The JSON viewer" >}}
 
 ## Filtering log lines with the JSON view
 
 Users can include and exclude specific log data from their visualizations by selecting the **Include/Exclude** icons next to a given label. 
 
-For example, given a set of logs of API requests, selecting the **exclude** button next to a method field with status "GET" will result in the Log Volume dashboard showing only requests of other types (DELETE/PATCH/POST/PUT).
+For example: Given a set of logs from am API request service, One can select the **exclude** button next the "method" field with status "GET". This  will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
 
 To include them again, simply remove them from the **Fields** filter above the Logs Volume visualization. 
+
+
+## Supported log types
+Log lines entirely formatted as JSON are supported. 
 
 Log lines with only certain fields or metadata structured as JSON not currently supported.
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -24,7 +24,7 @@ To interact with the JSON view, select the **Show Logs** button for your service
 
 {{< figure alt="JSON Table viewer with selector and include exclude highlighted" width="500px" align="center" src="/media/docs/explore-logs/show-logs.png" caption="Select the 'Show Logs' button on your service" >}}
 
-From there, select **JSON** in the format menu in the top right toolbar. This will show your logs in a structured, collapsible way, enabling you to sort, filter, and otherwise adjust your log data in the visualizations for your logs.
+From there, select **JSON** in the Logs format menu. This will show your logs in a structured, collapsible way, enabling you to sort, filter, and otherwise adjust your log data in the visualizations for your logs.
 
 {{< figure alt="Show Logs button on a JSON logging service" width="900px" align="center" src="/media/docs/explore-logs/json-viewer.png" caption="The JSON viewer" >}}
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -37,7 +37,7 @@ For example: Given a set of logs from am API request service, One can select the
 To include them again, simply remove them from the **Fields** filter above the Logs Volume visualization. 
 
 
-## Supported log types
+## Supported JSON log types
 Log lines entirely formatted as JSON are supported. 
 
 Log lines with only certain fields or metadata structured as JSON not currently supported.

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -24,7 +24,7 @@ To interact with the JSON view, select the **Show Logs** button for your service
 
 {{< figure alt="JSON Table viewer with selector and include exclude highlighted" width="500px" align="center" src="/media/docs/explore-logs/show-logs.png" caption="Select the 'Show Logs' button on your service" >}}
 
-From there, select **JSON** in the format menu in the top right toolbar. This will show your logs in a structured, collapsable way, enabling you to sort, filter, and otherwise adjust your log data in the visualisations for your logs.
+From there, select **JSON** in the format menu in the top right toolbar. This will show your logs in a structured, collapsible way, enabling you to sort, filter, and otherwise adjust your log data in the visualizations for your logs.
 
 {{< figure alt="Show Logs button on a JSON logging service" width="900px" align="center" src="/media/docs/explore-logs/json-viewer.png" caption="The JSON viewer" >}}
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -30,7 +30,7 @@ From there, select **JSON** in the format menu in the top right toolbar. This wi
 
 ## Filtering log lines with the JSON view
 
-Users can include and exclude specific log data from their visualizations by selecting the **Include/Exclude** icons next to a given label. 
+You can include and exclude specific log data from your visualizations by selecting the **Include/Exclude** icons next to a given label. 
 
 For example: Given a set of logs from am API request service, One can select the **exclude** button next the "method" field with status "GET". This  will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -32,7 +32,7 @@ From there, select **JSON** in the format menu in the top right toolbar. This wi
 
 You can include and exclude specific log data from your visualizations by selecting the **Include/Exclude** icons next to a given label. 
 
-For example: Given a set of logs from am API request service, One can select the **exclude** button next the "method" field with status "GET". This  will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
+For example: Given a set of logs from am API request service, you can select the **Exclude** button next the `method` field with status "GET". This  will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
 
 To include filtered log data again, remove the excluded data from the **Fields** filter above the Logs Volume visualization. 
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -6,7 +6,7 @@ keywords:
   - JSON
   - Formatting
 menuTitle: Viewing JSON logs
-title: Viewing JSON logs
+title: Logs Drilldown JSON viewer
 weight: 550
 ---
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -7,7 +7,7 @@ keywords:
   - Formatting
 menuTitle: Viewing JSON logs
 title: Viewing JSON logs
-weight: 400
+weight: 550
 ---
 
 # Logs Drilldown JSON viewer

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -34,7 +34,7 @@ You can include and exclude specific log data from your visualizations by select
 
 For example: Given a set of logs from am API request service, One can select the **exclude** button next the "method" field with status "GET". This  will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
 
-To include them again, simply remove them from the **Fields** filter above the Logs Volume visualization. 
+To include filtered log data again, remove the excluded data from the **Fields** filter above the Logs Volume visualization. 
 
 
 ## Supported JSON log types

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -13,14 +13,16 @@ title: Viewing JSON logs
 weight: 400
 ---
 
-# Viewing JSON Logs
+# JSON log line viewer
 
-If your log lines are formatted in the JSON format, you can view them more easily using Grafana's JSON viewer in the Logs table.
+If your log lines are formatted in the JSON format, you can view them more easily using Grafana's JSON viewer in the Logs table. This view will help you more easily read your JSON style logs, and filter through them to make your related dashboards more relevant and focused.
 
 
 {{< admonition type="note" >}}
-You must be running Loki 3.5.0 or later to use the JSON viewer
+Logs Drilldown JSON Viewer is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To use this feature, you must be running Loki 3.5.0 or later.
 {{< /admonition >}}
+
+## Viewing JSON logs
 
 To interact with the JSON view, select the **Show Logs** button for your service in Logs Drilldown. 
 
@@ -37,6 +39,8 @@ Users can include and exclude specific log data from their visualizations by sel
 For example, given a set of logs of API requests, selecting the **exclude** button next to a method field with status "GET" will result in the Log Volume dashboard showing only requests of other types (DELETE/PATCH/POST/PUT).
 
 To include them again, simply remove them from the **Fields** filter above the Logs Volume visualization. 
+
+Log lines with only certain fields or metadata structured as JSON not currently supported.
 
 {{< admonition type="note" >}}
 We are keen to improve this feature, so please [contact us](https://forms.gle/1sYWCTPvD72T1dPH9) if there is something that would help you find the signal in the noise.


### PR DESCRIPTION
Created JSON viewer documentation for Logs Drilldown

What this PR does / why we need it:
Documents the new JSON viewer feature of Logs Drilldown

Which issue(s) this PR fixes:
N/A

Special notes for your reviewer:

Checklist

[x] Reviewed the [CONTRIBUTING.md](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (required)
[x] Documentation added
[x] Tests updated
[x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)