### PR TITLE
docs: Updating screenshots and docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -33,7 +33,7 @@ cards:
       href: ./troubleshooting/
       description: Find solutions to common issues you might encounter when using Grafana Logs Drilldown.
       height: 24
-    - title: Engage with your  JSON log lines
+    - title: Engage with your JSON log lines
       href: ./viewing-json-logs/
       description: Drill down into your JSON log lines to better understand your log line data.
       height: 24

--- a/docs/sources/access/_index.md
+++ b/docs/sources/access/_index.md
@@ -13,7 +13,7 @@ weight: 200
 
 # Access or install Grafana Logs Drilldown
 
-To use Grafana Logs Drilldown on your own data, you can either access it in Grafana Cloud or install it in your own Grafana instance.
+To use Grafana Logs Drilldown to view your logs data, you can either access it in Grafana Cloud or install it in your own Grafana instance.
 
 {{< docs/play title="the Grafana Play site" url="https://play.grafana.org/a/grafana-lokiexplore-app/explore?var-ds=ddhr3fttaw8aod&var-patterns=&var-lineFilter=&var-logsFormat=" >}}
 
@@ -22,7 +22,7 @@ To use Grafana Logs Drilldown on your own data, you can either access it in Graf
 To access Grafana Logs Drilldown:
 
 1. Open your Grafana stack in a web browser.
-1. In the main menu, select **Explore** > **Logs**.
+1. In the main menu, select **Drilldown** > **Logs**.
 
 ## Installation
 
@@ -33,15 +33,19 @@ If you are not using Grafana Cloud, you can install Grafana Logs Drilldown in yo
 For Enterprise and OSS Grafana users, you can install Grafana Logs Drilldown via the [Grafana Plugins catalog](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/).
 
 1. Open [https://grafana.com/grafana/plugins/grafana-lokiexplore-app/](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/) in a web browser
-1. Open the **Installation** tab.
+1. Click the **Installation** tab.
 1. Follow the instructions to install the app.
 
 ### Install in Loki
 
 The following Loki and Grafana version and configuration are required:
 
-- Grafana v11.2.0 or later
+- Grafana v11.6.0 or later
 - Loki v3.2.0 or later
+
+   {{< admonition type="note" >}}
+   To get the most recent features, including experimental features, upgrade to Loki 3.5.0 or later.
+   {{< /admonition >}}
 
   - Enable pattern ingestion by setting `pattern-ingester.enabled` to `true`in your Loki configuration file.
   - Enable structured metadata by setting `allow_structured_metadata` to `true` within your Loki config file.

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -13,12 +13,13 @@ weight: 300
 
 # Get started with Grafana Logs Drilldown
 
-The best way to see what Grafana Logs Drilldown can do for you is to use it to explore your own data.
-If you have a Grafana Cloud account, you can access Grafana Logs Drilldown by selecting **Explore** > **Logs**, or you can [install Grafana Logs Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/) in your own Grafana instance.
+The best way to see what Grafana Logs Drilldown can do for you is to use it to explore your own log data.
+If you have a Grafana Cloud account, you can access Grafana Logs Drilldown by selecting **Drilldown** > **Logs**, or you can [install Grafana Logs Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/) in your own Grafana instance.
 
+<!-- Comment - NEEDS TO BE REPLACED WITH UPDATED VIDEO
 To learn more, check out our overview video:
 
-{{< youtube id="iH0Ufv2bD1U" >}}
+{{< youtube id="iH0Ufv2bD1U" >}}-->
 
 ## Guided tour
 
@@ -26,26 +27,25 @@ We will walk through a simple step-by-step guided tour of Grafana Logs Drilldown
 
 While you are browsing your log data in Grafana Logs Drilldown, watch for any unexpected spikes in your logs. Or perhaps one of your services is down and has stopped logging. Maybe you're seeing an increase in errors after a recent release.
 
-{{< figure alt="Grafana Logs Drilldown Service overview page" width="900px" align="center" src="/media/docs/explore-logs/landing_page_index.png" caption="Overview page" >}}
+<!-- Make updating the screenshots easier by putting the Logs Drilldown version in the file name. This lets everyone know the last time the screenshots were updated.-->
+
+{{< figure alt="Grafana Logs Drilldown Service overview page" width="900px" align="center" src="/media/docs/explore-logs/landing_page_index_V1.0.14.png" caption="Overview page" >}}
 
 To take a tour of Grafana Logs Drilldown, follow these steps:
 
-1. From the Grafana main menu, select **Explore** > **Logs**.
-1. This opens the **Overview page** showing time series and log visualizations for all the services in your selected Loki instance. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
-1. Change your **Data source** from the menu on the top left, then select a recent time range. You can modify your time range in two ways:
+1. Open your Grafana stack in a web browser.
+1. From the Grafana main menu, select **Drilldown** > **Logs**.
+   This opens the **Overview page** showing time series and log visualizations for all the services in your selected Loki instance. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
+1. If you have multiple Loki data sources, you can change your **Data source** from the menu on the top left. Note that Logs Drilldown only supports Loki data sources.
+1. Select a recent time range. You can modify your time range in two ways:
    - With the standard time range picker on the top right.
    - By clicking and dragging the time range on any time series visualization.
 1. Services are shown based on the volume of logs, or you can use the **Search Services** field to search for the service by name.
-1. To explore logs for a service, click the **Select** button on the service graph. _New for version 1.0.2_: You can now begin a workflow with any label, not just service, by clicking **Add Label**.
-1. On the service details page, click the **Labels** tab to see visualizations of the log volume for each label. ([No labels?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-labels))
-1. On the **Labels** tab, select a label to see the log volume for each value of that label.
-   Grafana Logs Drilldown shows you the volume of logs with specific labels and fields. Learn more about [Labels and Fields](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/labels-and-fields/).
-1. Select the **Fields** tab to see visualizations of the log volume for each field. You can select fields to drill down into the details in the same way as labels.
+1. If you want to view services by label instead of by service name, click **(+) Add label** and either select a label from the menu or search for a label.
+1. To explore logs for a service, click the **Show logs** button on the service graph. Grafana displays the **Logs** tab of the service details page.
+1. On the service details page, click the **Labels** tab to see visualizations of the log volume for each label. ([No labels?](../troubleshooting/#there-are-no-labels))
+1. On the **Labels** tab, to select a label to see the log volume for each value of that label, click the **Select** button.
+   Grafana Logs Drilldown shows you the volume of logs with specific labels and fields. Learn more about [Labels and Fields](../labels-and-fields/).
+1. Select the **Fields** tab to see visualizations of the log volume for each field. To drill down into the details in the same way as labels, click the **Select** button for one of the fields.
 1. Click the **Patterns** tab to see the log volume for each automatically detected pattern.
-   Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful. Learn more about [Log Patterns](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/patterns/).
-
-If you're having trouble using Logs Drilldown, refer to the [troubleshooting page](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/).
-
-## What do you think?
-
-Please [share your feedback](https://forms.gle/1sYWCTPvD72T1dPH9) and help make Logs Drilldown better.
+   Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful. Learn more about [Log Patterns](../patterns/).

--- a/docs/sources/labels-and-fields/_index.md
+++ b/docs/sources/labels-and-fields/_index.md
@@ -8,48 +8,92 @@ keywords:
   - Analysis
 menuTitle: Labels and Fields
 title: Labels and Fields
-weight: 500
+weight: 600
 ---
 
 # Labels and Fields
 
 Grafana Logs Drilldown visualises log volumes for the labels attached to your log lines, and fields automatically extracted from the text of the line itself.
 
-{{< figure alt="Grafana Logs Drilldown Labels tab" width="900px" align="center" src="/media/docs/explore-logs/labels.png" caption="Labels tab" >}}
-
-Grafana Logs Drilldown adds a special `detected_level` label to all log lines where Loki assigns a level of the log line, including `debug`, `info`, `warn`, `error`, `fatal`, `critical`, `trace`, or `unknown` if no level could be determined.
-
-You can click **Select** on a Label or Field to access a breakdown of its values, seeing the log volumes visualized along the way.
-This can be useful for understanding the traits of your system, and for spotting spikes or other changes.
-
 {{< admonition type="note" >}}
 The type of data being expressed in a label or field may require different treatments. For example, fields expressing `bytes` are visualized differently than other types of data. Please [share your feedback](https://forms.gle/1sYWCTPvD72T1dPH9) if you have suggestions for how to improve this experience.
 {{< /admonition >}}
 
-## Guided tour of labels and fields
+Grafana Logs Drilldown adds a special `detected_level` label to all log lines where Loki assigns a level of the log line, including `debug`, `info`, `warn`, `error`, `fatal`, `critical`, `trace`, or `unknown` if no level could be determined.
 
-To explore labels with your own data, follow these steps:
-
-1. From the Grafana main menu, select **Explore** > **Logs**.
-1. Click the **Select** button for the **Service** you want to explore. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
-1. Click the **Labels** tab.
-1. Browse the labels detected for this service. ([No labels?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-labels))
-1. Look for an interesting label and click the **Select** button.
-
-You will see a selection of visualizations showing the volume of each label.
-
-These visualizations are great for:
+The `detected_labels` visualizations are helpful for:
 
 - Spotting unexpected spikes in log volume.
 - Noticing dips or outages in your services.
 - Understanding the distribution of log lines across your labels.
 - Identifying labels that might be useful for filtering or grouping your logs.
 
-You also have a range of [sorting and ordering options](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/ordering/) to help you focus on the most important areas.
+You can click the **Select** button on a Label or Field graph to access a breakdown of its values, seeing the log volumes visualized along the way.
+This can be useful for understanding the traits of your system, and for spotting spikes or other changes.
 
-You can repeat the same steps in the **Fields** tab to see fields that were extracted from your log lines.
+## Labels tab user interface overview
 
-{{< figure alt="Grafana Logs Drilldown Fields tab" width="900px" align="center" src="/media/docs/explore-logs/fields.png" caption="Fields tab" >}}
+Let's take a closer look at what you can do on the Labels tab.
+
+The top navigation bar is common across the Grafana interface.
+The next section is common across all the Logs Drilldown pages.
+
+<!-- Make updating the screenshots easier by putting the Logs Drilldown version in the file name. This lets everyone know the last time the screenshots were updated.-->
+{{< figure alt="Grafana Logs Drilldown Labels tab" caption="Labels tab" width="900px" align="center" src="/media/docs/explore-logs/labels_v1.0.14.png" >}}
+
+Labels tab user interface:
+
+- **Label** filter: Lets you search for or select label names from the menu.
+- **Single / Grid / Rows**: Lets you select how the labels are displayed, in a grid or in rows.
+- **Select** button: Click to access a breakdown of the label's values, seeing the log volumes visualized along the way.
+- **Menu** (three dots): Click to navigate to [Grafana Explore](https://grafana.com/docs/grafana-cloud/visualizations/explore/).
+
+## Filtering logs by label
+
+To explore labels with your own data, follow these steps:
+
+1. From the Grafana main menu, select **Drilldown** > **Logs**.
+1. Click the **Select** button for the **Service** you want to explore.
+1. Click the **Labels** tab.
+1. Browse the labels detected for this service.
+1. Look for an interesting label and click the **Select** button.
+
+You will see a selection of visualizations showing the volume of each label.
+
+To remove the filter, select **All** from the **Label** search menu or click the **x** next to the selection in the Filter fields at the top of the page.
+
+## Fields tab user interface overview
+
+Let's take a closer look at what you can do on the Fields tab.
+
+The top navigation bar is common across the Grafana interface.
+The next section is common across all the Logs Drilldown pages.
+
+<!-- Lets make updating the screenshots easier by putting the Logs Drilldown version in the file name. This lets you know the last time the screenshots were updated.-->
+{{< figure alt="Grafana Logs Drilldown Fields tab" caption="Fields tab" width="900px" align="center" src="/media/docs/explore-logs/fields_v1.0.14.png" >}}
+
+Fields tab user interface:
+
+- **Field** filter: Lets you search for or select field names from the menu.
+- **Single / Grid / Rows**: Lets you select how the fields are displayed, in a grid or in rows.
+- **Add to filter** menu:
+  - **Add to filter** option: Lets you add an expression to further filter the field values.
+  - **Include** and **Exclude** buttons: Lets you include or exclude the field from the log view.
+- **Menu** (three dots): Click to navigate to [Grafana Explore](https://grafana.com/docs/grafana-cloud/visualizations/explore/).
+
+## Filtering logs by field
+
+To explore fields with your own data, follow these steps:
+
+1. From the Grafana main menu, select **Drilldown** > **Logs**.
+1. Click the **Select** button for the **Service** you want to explore.
+1. Click the **Fields** tab.
+1. Browse the fields detected for this service.
+1. Look for an interesting field and click the **Select** button.
+
+You will see a selection of visualizations showing the volume of each field.
+
+To remove the filter, select **All** from the **Filter** search menu or click the **x** next to the selection in the Filter fields at the top of the page.
 
 ## What next?
 

--- a/docs/sources/ordering/_index.md
+++ b/docs/sources/ordering/_index.md
@@ -11,29 +11,34 @@ keywords:
   - Analysis
 menuTitle: Sorting and ordering
 title: Sorting and ordering
-weight: 400
+weight: 700
 ---
 
 # Sorting and ordering
 
-Some pages in Grafana Logs Drilldown can display a large number of graphs. You may want to sort the graphs differently, depending on what you're looking for. These pages let you modify the default sort oder using the **Sort by** menu in the top right toolbar.
+By default the graphs are sorted by most relevant, where we prioritise graphs with more volatile data or the largest volume of data. For example, the graphs with the most spikes or dips will be shown first.
 
-You can use the **Asc/Desc** menu to change the direction of the sort.
+Some pages in Grafana Logs Drilldown can display a large number of graphs. You may want to sort the graphs differently, depending on what you're looking for.
 
-## Sorting algorithms
+On the **Label** tab, you can use the **Newest first** and **Oldest first** buttons to change the direction of the sort in the Logs view.
 
-{{< figure alt="Sort by many" width="900px" align="center" src="/media/docs/explore-logs/sort-by-dropdown.png" caption="Sort by menu" >}}
+<!-- Make updating the screenshots easier by putting the Logs Drilldown version in the file name. This lets everyone know the last time the screenshots were updated.-->
+{{< figure alt="Sort by many" caption="Sort by menu" width="900px" align="center" src="/media/docs/explore-logs/sort-by-menu_v1.0.14.png" >}}
 
-By default the graphs are sorted by **Most relevant** where we prioritise graphs with more volatile data. For example, the graphs with the most spikes or dips will be shown first.
+When there is an option to sort the graphs, there are several different ways you can sort your log data.
 
-| Sort by option | Description                                               |
-| -------------- | --------------------------------------------------------- |
-| Most relevant  | Sorts graphs by the most volatile data.                   |
-| Widest spread  | Sorts graphs that contain the largest standard deviation. |
-| Name           | Sorts graphs alphabetically by name.                      |
-| Highest spike  | Sorts graphs by the highest peaks.                        |
-| Lowest dip     | Sorts graphs by the lowest dips.                          |
-| Percentiles    | Sorts graphs by the nth percentile.                       |
+Some pages let you modify the default sort order using the **Sort by** menu in the top right toolbar.
+
+| Sort by option  | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| Most relevant   | Sorts graphs based on the most significant spikes in data. |
+| Outlying values | Sorts graphs by the amount of outlying values in the data. |
+| Widest spread   | Sorts graphs by deviation from the average value.          |
+| Name            | Sorts graphs alphabetically by name.                       |
+| Count           | Sorts graphs by total number of logs.                      |
+| Highest spike   | Sorts graphs by the highest values (max).                  |
+| Lowest dip      | Sorts graphs by the smallest values (min).                 |
+| Percentiles     | Sorts graphs by the nth percentile.                        |
 
 {{< admonition type="note" >}}
 We are keen to improve this feature, so please [contact us](https://forms.gle/1sYWCTPvD72T1dPH9) if there is something that would help you find the signal in the noise.

--- a/docs/sources/patterns/_index.md
+++ b/docs/sources/patterns/_index.md
@@ -11,7 +11,7 @@ keywords:
   - Analysis
 menuTitle: Log patterns
 title: Log patterns
-weight: 600
+weight: 800
 ---
 
 # Log patterns
@@ -20,61 +20,9 @@ Log patterns let you work with groups of similar log lines. You can hide log pat
 
 Loki automatically extracts patterns when your logs are ingested. Patterns are ephemeral and are only mined from the previous three hours of your logs.
 
-{{< figure alt="Grafana Logs Drilldown Patterns tab" width="900px" align="center" src="/media/docs/explore-logs/patterns.png" caption="Patterns tab" >}}
-
 The Grafana Logs Drilldown app shows you the patterns alongside their log volumes. From this view, you can investigate spikes and include or exclude specific log lines from your view.
 
 Patterns can change over time as your logging evolves.
-
-## Use cases
-
-Log patterns let you:
-
-- Browse the log volume over time of different types of logs.
-- Simplify log management by grouping similar log entries.
-- Enhance log searches by focusing on relevant patterns.
-- Improve troubleshooting efficiency by highlighting critical log lines.
-- Reduce storage requirements by minimizing log data.
-- Filter out noisy log lines during exploration.
-- Identify specific log lines for targeted analysis.
-
-## Guided tour of log patterns
-
-We've outlined the steps you'll need to take to perform some common use cases.
-
-### Browse log volumes by type
-
-Grafana Logs Drilldown proactively visualizes your log volume data per detected pattern, broken down in various ways. At a glance you can immediately spot spikes or other changes.
-
-For example, if your HTTP service is suffering from a DDoS attack, the relevant graphs will clearly show the spikes. From here you can drill down to discover enough details about the attack to counter it.
-
-### Target your analysis
-
-If you know the kind of log line you're looking for, log patterns are an easy way to remove unwanted log lines from the view.
-
-To view only a specific set of patterns, perform the following steps:
-
-1. From the Grafana main menu, select **Explore** > **Logs**.
-1. Select the relevant **Service**. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
-1. On the service details page, click the **Patterns** tab.
-1. Identify a pattern that matches the type of logs you're interested in viewing. ([No patterns?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-patterns))
-1. Click the **Include** button for the pattern.
-1. Return to the **Logs** tab and notice the filtered view.
-
-You can repeat steps 4 and 5 to include multiple patterns.
-
-### Hide noisy log lines
-
-To hide noisy log lines, perform the following steps:
-
-1. From the Grafana main menu, select **Explore** > **Logs**.
-1. Select the relevant **Service**. ([No services?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-services))
-1. On the service details page, click the **Patterns** tab.
-1. Identify a pattern that represents noise in the logs that you want to remove. ([No patterns?](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/troubleshooting/#there-are-no-patterns))
-1. Click the **Exclude** button to exclude that pattern.
-1. Return to the **Logs** tab and notice the noisy pattern has been removed.
-
-You can repeat steps 4 and 5 to exclude multiple patterns.
 
 ## Pattern extraction
 
@@ -107,6 +55,74 @@ Pattern 2: `user loaded: <_>`
 Since Loki 3.0, you can make queries using this simplified [pattern match filter operator](https://grafana.com/docs/loki/latest/query/#pattern-match-filter-operators) which is much faster than using regex.
 {{< /admonition >}}
 
-## What next?
+## Pattern use cases
 
-See how Grafana Logs Drilldown works on your own data by following our [Get started guide](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/get-started/).
+Using log patterns you can:
+
+- Browse the log volume over time of different types of logs.
+- Simplify log management by grouping similar log entries.
+- Enhance log searches by focusing on relevant patterns.
+- Improve troubleshooting efficiency by highlighting critical log lines.
+- Reduce storage requirements by minimizing log data.
+- Filter out noisy log lines during exploration.
+- Identify specific log lines for targeted analysis.
+
+## Patterns tab user interface overview
+
+Let's take a closer look at what you can do on the Patterns tab.
+
+The top navigation bar is common across the Grafana interface.
+The next section is common across all the Logs Drilldown pages.
+
+<!-- Make updating the screenshots easier by putting the Logs Drilldown version in the file name. This lets everyone know the last time the screenshots were updated.-->
+{{< figure alt="Grafana Logs Drilldown Patterns tab" caption="Patterns tab" width="900px" align="center" src="/media/docs/explore-logs/patterns_v1.0.14.png" >}}
+
+Patterns tab user interface:
+
+- **Search** patterns field:
+- **>** : Expand or collapse the pattern row to view log lines with that pattern.
+- **Patterns** graph: The graph shows you the patterns alongside their log volumes.
+- **Include** and **Exclude** buttons: Lets you include or exclude the log pattern from the log view.
+
+In addition, in the expanded view, each log line has a menu that is displayed when you hover over the log line:
+
+- **Show context**: Lets you view the log line in the context of the logs that occurred before and after that specific log.
+- **Copy to clipboard**: Copies the log line to the clipboard.
+
+## Guided tour of log patterns
+
+We've outlined the steps you'll need to take to perform some common use cases.
+
+### Browse log volumes by type
+
+Grafana Logs Drilldown proactively visualizes your log volume data per detected pattern, broken down in various ways. At a glance you can immediately spot spikes or other changes.
+
+For example, if your HTTP service is suffering from a DDoS attack, the relevant graphs will clearly show the spikes. From here you can drill down to discover enough details about the attack to counter it.
+
+### Target your analysis
+
+If you know the kind of log line you're looking for, log patterns are an easy way to remove unwanted log lines from the view.
+
+To view only a specific set of patterns, perform the following steps:
+
+1. From the Grafana main menu, select **Drilldown** > **Logs**.
+1. Select the relevant **Service**.
+1. On the service details page, click the **Patterns** tab.
+1. Identify a pattern that matches the type of logs you're interested in viewing.
+1. Click the **Include** button for the pattern.
+1. Return to the **Logs** tab and note the view only shows log lines that match your selected pattern.
+
+You can repeat steps 4 and 5 to include multiple patterns.
+
+### Hide noisy log lines
+
+To hide noisy log lines, perform the following steps:
+
+1. From the Grafana main menu, select **Drilldown** > **Logs**.
+1. Select the relevant **Service**.
+1. On the service details page, click the **Patterns** tab.
+1. Identify a pattern that represents noise in the logs that you want to remove.
+1. Click the **Exclude** button to exclude that pattern.
+1. Return to the **Logs** tab and notice the noisy pattern has been removed.
+
+You can repeat steps 4 and 5 to exclude multiple patterns.

--- a/docs/sources/troubleshooting/_index.md
+++ b/docs/sources/troubleshooting/_index.md
@@ -8,7 +8,7 @@ keywords:
   - Analysis
 menuTitle: Troubleshooting
 title: Troubleshooting Grafana Logs Drilldown
-weight: 700
+weight: 900
 ---
 
 # Troubleshooting
@@ -48,6 +48,12 @@ If you aren't getting any patterns, you can try the following fixes:
 
 1. Ensure pattern extraction is enabled by setting `--pattern-ingester.enabled=true` in your Loki config. [Learn about other necessary config](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/).
 1. It is possible that no patterns were detected, although this is rare - please [open an issue on GitHub](https://github.com/grafana/explore-logs/issues/new) or [get in touch privately](https://forms.gle/1sYWCTPvD72T1dPH9) so we can see what's going on.
+
+## There is no JSON button
+
+If there is no **JSON** button available in the Logs format menu on the **Logs** tab:
+
+1. Ensure that you are on Loki version 3.5. Users running older versions of Loki can view JSON, but cannot filter in the JSON panel as it is an experimental feature introduced in Loki version 3.5.
 
 ## I cannot find something
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -11,8 +11,8 @@ weight: 550
 ---
 
 # Logs Drilldown JSON viewer
-You can easily view and interact with your JSON formatted logs  using the Logs Drilldown JSON viewer. This view will help you read your JSON style logs, and filter through them to make your related dashboards more relevant and focused.
 
+You can easily view and interact with your JSON formatted logs using the Logs Drilldown JSON viewer. This view will help you read your JSON style logs, and filter through them to make your related dashboards more relevant and focused.
 
 {{< admonition type="note" >}}
 Logs Drilldown JSON Viewer is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To use this feature, you must be running Loki 3.5.0 or later.
@@ -20,7 +20,7 @@ Logs Drilldown JSON Viewer is an experimental feature. Engineering and on-call s
 
 ## Viewing JSON logs
 
-To interact with the JSON view, select the **Show Logs** button for your service in Logs Drilldown. 
+To interact with the JSON view, select the **Show Logs** button for your service in Logs Drilldown.
 
 {{< figure alt="JSON Table viewer with selector and include exclude highlighted" width="500px" align="center" src="/media/docs/explore-logs/show-logs.png" caption="Select the 'Show Logs' button on your service" >}}
 
@@ -30,15 +30,15 @@ From there, select **JSON** in the Logs format menu. This will show your logs in
 
 ## Filtering log lines with the JSON view
 
-You can include and exclude specific log data from your visualizations by selecting the **Include/Exclude** icons next to a given label. 
+You can include and exclude specific log data from your visualizations by selecting the **Include/Exclude** icons next to a given label.
 
-For example: Given a set of logs from am API request service, you can select the **Exclude** button next the `method` field with status "GET". This  will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
+For example: Given a set of logs from am API request service, you can select the **Exclude** button next the `method` field with status "GET". This will result in the Log Volume dashboard showing only requests of other method types (DELETE/PATCH/POST/PUT).
 
-To include filtered log data again, remove the excluded data from the **Fields** filter above the Logs Volume visualization. 
-
+To include filtered log data again, remove the excluded data from the **Fields** filter above the Logs Volume visualization.
 
 ## Supported JSON log types
-Log lines entirely formatted as JSON are supported. 
+
+Log lines entirely formatted as JSON are supported.
 
 Log lines with only certain fields or metadata structured as JSON not currently supported.
 


### PR DESCRIPTION
This PR:
Hides the video on the Get Started page as it no longer matches the UI and needs to be updated
Updates the Grafana and Loki minimum requirements
Updates the screenshots (Stored online [here](https://admin.grafana.com/upload/media/docs/explore-logs/))
Updates the navigation (there were still a few instances of Explore > Logs)
Adds more description of the user interface to point out some new features
Reorganizes content on some of the pages.
Removes most of the inline troubleshooting, since Logs Drilldown is now GA.
Fixes assorted typos, formatting errors, etc.
Updates the page weights in preparation for new content that will come in the next PR.