### PR TITLE
docs: update the versions in the README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,8 @@ The Grafana Logs Drilldown app offers a queryless experience for browsing Loki l
 
 ## Requirements
 
-Requires Grafana 11.3.0 or newer.
+Requires Grafana 11.6.0 or newer.
+Requires Loki 3.2 or newer.
 
 ## Getting Started
 


### PR DESCRIPTION
Updates the Grafana version listed in the README
Adds the requirement for Loki version to the README

This is to update what is displayed on the Plugins Page.
![PluginsPage](https://github.com/user-attachments/assets/1a10eb24-965a-44ff-b11d-e48f8c7f150e)
