### PR TITLE
fix(JSON): logs and table panel adding JSON parsers making fields disappear 

### DIFF
--- a/src/Components/ServiceScene/LogsJsonScene.tsx
+++ b/src/Components/ServiceScene/LogsJsonScene.tsx
@@ -29,15 +29,20 @@ import {
 import { Alert, Badge, Button, Icon, PanelChrome, useStyles2 } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
+import { areArraysEqual } from '../../services/comparison';
 import {
   clearJsonParserFields,
+  extractParserFromString,
   getDetectedFieldsJsonPathField,
   getDetectedFieldsParserField,
+  getJsonPathArraySyntax,
+  getParserAndPathForField,
   isLogLineField,
 } from '../../services/fields';
 import {
   addJsonParserFieldValue,
   EMPTY_AD_HOC_FILTER_VALUE,
+  filterUnusedJSONFilters,
   getJsonKey,
   removeLineFormatFilters,
 } from '../../services/filters';
@@ -180,17 +185,125 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
         serviceScene.state?.$detectedFieldsData?.runQueries();
       } else {
         this.setVizFlags(detectedFieldFrame);
+        this.syncFieldsAndJsonProps(detectedFieldFrame);
       }
     }
 
+    // Subscribe to detected fields
     this._subs.add(
       serviceScene.state.$detectedFieldsData?.subscribeToState((newState) => {
         const detectedFieldFrame = getDetectedFieldsFrameFromQueryRunnerState(newState);
         if (detectedFieldFrame) {
           this.setVizFlags(detectedFieldFrame);
+          if (newState.data?.state === LoadingState.Done) {
+            this.syncFieldsAndJsonProps(detectedFieldFrame);
+          }
         }
       })
     );
+
+    // subscribe to fields changes
+    const fieldsVar = getFieldsVariable(this);
+    this._subs.add(
+      fieldsVar.subscribeToState((newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          this.manageJsonParserProps(newState, prevState);
+        }
+      })
+    );
+  }
+
+  private syncFieldsAndJsonProps(detectedFieldsFrame: DataFrame | undefined) {
+    const detectedFieldsNamesField = detectedFieldsFrame?.fields[0];
+    const detectedFieldsParsersField = detectedFieldsFrame?.fields[2];
+    const detectedFieldsJsonPathField: Field<string[]> | undefined = detectedFieldsFrame?.fields[4];
+
+    // Sync any fields that are missing json parser props if we have them (loki 3.5.0+)
+    if (detectedFieldsFrame && detectedFieldsJsonPathField?.values.some((v) => v)) {
+      const fieldsVar = getFieldsVariable(this);
+      const jsonPathVar = getJsonFieldsVariable(this);
+
+      let jsonFieldsToAdd: AdHocFilterWithLabels[] = [];
+      for (let i = 0; i < detectedFieldsFrame.length; i++) {
+        const parser = extractParserFromString(detectedFieldsParsersField?.values[i]);
+        const jsonPath = detectedFieldsJsonPathField.values[i];
+        const fieldName = detectedFieldsNamesField?.values[i];
+
+        // If there is a json field that doesn't have a json parser prop
+        if (
+          (parser === 'json' || parser === 'mixed') &&
+          fieldsVar.state.filters.some((f) => f.key === fieldName) &&
+          !jsonPathVar.state.filters.some((f) => f.key === fieldName)
+        ) {
+          const path = getJsonPathArraySyntax(jsonPath);
+          jsonFieldsToAdd.push({
+            key: fieldName,
+            operator: FilterOp.Equal,
+            value: path,
+          });
+        }
+      }
+
+      if (jsonFieldsToAdd.length) {
+        jsonPathVar.setState({
+          filters: [...jsonPathVar.state.filters, ...jsonFieldsToAdd],
+        });
+      }
+    }
+  }
+
+  /**
+   * If we removed a filter from the ad-hoc variables, we need to remove old json parser props
+   */
+  private manageJsonParserProps(newState: AdHocFiltersVariable['state'], prevState: AdHocFiltersVariable['state']) {
+    const lineFormatVariable = getLineFormatVariable(this);
+    if (!newState.filters.length && !lineFormatVariable.state.filters.length) {
+      clearJsonParserFields(this);
+
+      // A field was removed
+    } else if (newState.filters.length < prevState.filters.length) {
+      // If no other field filter has the same key, then we can remove the json parser
+      const filterDiff = prevState.filters.filter(
+        (prevFilter) => !newState.filters.find((newFilter) => newFilter.key === prevFilter.key)
+      );
+
+      if (filterDiff.length) {
+        filterUnusedJSONFilters(this);
+      }
+
+      // A field was added
+    } else if (newState.filters.length > prevState.filters.length) {
+      const jsonVar = getJsonFieldsVariable(this);
+
+      // Gets any new filters that were added
+      const newFilters = newState.filters.filter(
+        (newFilter) => !prevState.filters.find((prevFilter) => newFilter.key === prevFilter.key)
+      );
+
+      const jsonParserPropsToAdd: AdHocFilterWithLabels[] = [];
+
+      newFilters.forEach((filter) => {
+        const hasJsonFilters = jsonVar.state.filters.some((jsonFilter) => jsonFilter.key === filter.key);
+
+        // If there isn't an associated JSON parser prop, we can assume the filter was added outside the JSON viz, let's check the detected_fields and add the json parser
+        if (!hasJsonFilters) {
+          const { parser, path } = getParserAndPathForField(filter.key, this);
+          if ((parser === 'json' || parser === 'mixed') && path) {
+            jsonParserPropsToAdd.push({
+              key: filter.key,
+              operator: FilterOp.Equal,
+              value: path,
+            });
+          }
+        }
+      });
+
+      if (jsonParserPropsToAdd.length) {
+        jsonVar.setState({
+          filters: [...jsonVar.state.filters, ...jsonParserPropsToAdd],
+        });
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Some fallout from https://github.com/grafana/logs-drilldown/pull/1122

The bug:
When adding field filters in the logs or table panel, this adds the field as a prop to the logQL JSON parser, which has the consequence of removing any non-specified fields.

In the JSON panel this doesn't impact much, as the fields are parsed directly from the resultant JSON, but logs and table panel. But in the logs/table panel this has the consequence of making fields (other then those in active filters) disappear when adding filters.

To reproduce:
In the table panel, [visualize two fields as columns](https://play.grafana.org/a/grafana-lokiexplore-app/explore/service/grafanacon-json-otel/logs?patterns=%5B%5D&from=now-15m&to=now&var-lineFormat=&var-ds=ddhr3fttaw8aod&var-filters=service_name%7C%3D%7Cgrafanacon-json-otel&var-fields=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=utc&var-all-fields=&urlColumns=%5B%22Time%22,%22Line%22,%22nested_object_deeplyNestedObject_extraDeeplyNestedObject_url%22,%22nested_object_deeplyNestedObject_url%22%5D&visualizationType=%22table%22&displayedFields=%5B%22nested_object_deeplyNestedObject_extraDeeplyNestedObject_url%22,%22nested_object_deeplyNestedObject_url%22%5D&sortOrder=%22Descending%22)

Then click on a cell in either column and include or exclude. You'll notice that the other column is removed. 


This fix:
This PR simply removes the assumption that every JSON field added anywhere in the application needs a JSON parser, and instead adds them when the user switches to the JSON viz. However since filters added in the JSON viz may not be valid queries without the json parser props (e.g. parent node filters), we cannot remove JSON prop filters when switching back to other parts of the application, so the behavior in this bug will continue to exhibit if users switch to JSON and then back to another viz or the fields tab.

The long-term fix:
I think we'll need to either change the behavior of the json parser in Loki, or add a wildcard parser argument so we return the default set of fields in addition to whatever has been specified in the json parser props. This way the logs and table panels will continue to see a consistent set of fields in addition to whatever fields have been "created" via the JSON panel.
