### PR TITLE
chore(plugin-ci-workflows): temporarily disable release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ name: Release
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*' # Run workflow on version tags, e.g. v1.0.0.
+  # push:
+  #   tags:
+  #     - 'v*' # Run workflow on version tags, e.g. v1.0.0.
 
 permissions:
   contents: write


### PR DESCRIPTION
Preparing to try the new plugin-ci-workflows for release. This disables our old release flow from running by commenting out the release.yml trigger on tag push.