### PR TITLE
chore(plugin-ci-workflows): playwright skip dev image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       attestation: true
       # Same settings as PR-CI
+      run-playwright-with-skip-grafana-dev-image: true
       run-playwright-with-grafana-dependency: '>=12.0.0'
       upload-playwright-artifacts: true
       playwright-docker-compose-file: docker-compose.dev.yaml


### PR DESCRIPTION
Match the pr-ci.yml and skip the dev image on release.