### PR TITLE
chore(release): 1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+#### 1.0.16
+
+##### Chores
+
+*  Call interpolateExpression (#1276) (796cacee)
+*  Run lint (#1274) (fa1d3b7d)
+*  Update Grafana assets to 11.6.1 (#1270) (505a307a)
+*  Add option to output to syslog from the generator (#1240) (14057e9f)
+* **vault:**  Use vault, remove old gha (#1272) (b4b9a896)
+* **plugin-ci-workflows:**
+  *  Publish skip playwright (#1263) (5becc84a)
+  *  Playwright skip dev image (#1262) (99ef2c9b)
+
+##### Documentation Changes
+
+*  Add favorites docs to readme (#1277) (cd64dbfc)
+*  Dashboards > Visualizations (#1261) (216b9256)
+
 #### 1.0.15
 
 ##### Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-lokiexplore-app",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Query less exploration of log data stored in Loki",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
#### 1.0.16

##### Chores

*  Call interpolateExpression (#1276) (796cacee)
*  Run lint (#1274) (fa1d3b7d)
*  Update Grafana assets to 11.6.1 (#1270) (505a307a)
*  Add option to output to syslog from the generator (#1240) (14057e9f)
* **vault:**  Use vault, remove old gha (#1272) (b4b9a896)
* **plugin-ci-workflows:**
  *  Publish skip playwright (#1263) (5becc84a)
  *  Playwright skip dev image (#1262) (99ef2c9b)

##### Documentation Changes

*  Add favorites docs to readme (#1277) (cd64dbfc)
*  Dashboards > Visualizations (#1261) (216b9256)
