### PR TITLE
fix(table): move sorting and remove initial sorting from table

### DIFF
--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -16,7 +16,6 @@ import {
   FieldWithIndex,
   Labels,
   MappingType,
-  sortDataFrame,
   transformDataFrame,
   ValueMap,
 } from '@grafana/data';
@@ -24,7 +23,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { LogsSortOrder, TableCellHeight, TableColoredBackgroundCellOptions } from '@grafana/schema';
 import { Drawer, Table as GrafanaTable, TableCellDisplayMode, TableCustomCellOptions, useTheme2 } from '@grafana/ui';
 
-import { getBodyName, getIdName, getTimeName, LogsFrame } from '../../services/logsFrame';
+import { getBodyName, getIdName, LogsFrame } from '../../services/logsFrame';
 import { testIds } from '../../services/testIds';
 import { useQueryContext } from './Context/QueryContext';
 import {
@@ -74,9 +73,6 @@ function TableAndContext(props: {
   return (
     <GrafanaTable
       onColumnResize={props.onResize}
-      initialSortBy={[
-        { desc: props.logsSortOrder === LogsSortOrder.Descending, displayName: getTimeName(props.logsFrame) },
-      ]}
       initialRowIndex={props.selectedLine}
       cellHeight={TableCellHeight.Sm}
       data={props.data}
@@ -113,15 +109,12 @@ export const Table = (props: Props) => {
 
   const templateSrv = getTemplateSrv();
   const replace = useMemo(() => templateSrv.replace.bind(templateSrv), [templateSrv]);
-  const timeIndex = logsFrame?.timeField.index;
 
   const prepareTableFrame = useCallback(
-    (rawFrame: DataFrame): DataFrame => {
-      if (!rawFrame.length) {
-        return rawFrame;
+    (frame: DataFrame): DataFrame => {
+      if (!frame.length) {
+        return frame;
       }
-
-      const frame = sortDataFrame(rawFrame, timeIndex, props.logsSortOrder === LogsSortOrder.Descending);
 
       const [frameWithOverrides] = applyFieldOverrides({
         data: [frame],

--- a/src/Components/Table/TableProvider.tsx
+++ b/src/Components/Table/TableProvider.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import { AdHocVariableFilter, DataFrame, LogsSortOrder, TimeRange } from '@grafana/data';
+import { AdHocVariableFilter, DataFrame, FieldType, LogsSortOrder, sortDataFrame, TimeRange } from '@grafana/data';
 
 import { parseLogsFrame } from '../../services/logsFrame';
 import { LogLineState } from './Context/TableColumnsContext';
@@ -39,11 +39,16 @@ export const TableProvider = ({
   urlColumns,
   urlTableBodyState,
 }: TableProviderProps) => {
-  if (!dataFrame) {
-    return null;
-  }
+  const logsFrame = useMemo(() => {
+    if (!dataFrame) {
+      return null;
+    }
+    const timeIndex = dataFrame.fields.findIndex((field) => field.type === FieldType.time);
+    const sortedFrame = sortDataFrame(dataFrame, timeIndex, logsSortOrder === LogsSortOrder.Descending);
+    const logsFrame = parseLogsFrame(sortedFrame);
+    return logsFrame;
+  }, [dataFrame, logsSortOrder]);
 
-  const logsFrame = parseLogsFrame(dataFrame);
   if (!logsFrame) {
     return null;
   }


### PR DESCRIPTION
There was a discrepancy between:
- The parsed logsFrame, which contained the original unsorted dataframe in "raw"
- The sorted dataFrame with the current LogsSortOrder method
- The "initial sort by" pointing to the time field.

This caused an incorrect "rowId" to reach the LineActionIcons component. To fix this:

- Sorting has been moved to TableProvider
- logsFrame is now generated after sorting
- Removed setting an "initialSortBy", as the default order is the one that corresponds to the selected sort order in the controls. Then the user can further sort by any of the columns if they want to.

Fixes #1282