### PR TITLE
docs: add logs drilldown learning journey to the docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -46,6 +46,9 @@ cards:
 # Grafana Logs Drilldown
 
 Welcome to our new experience for Loki. Grafana Logs Drilldown lets you automatically visualize and explore your logs without having to write queries.
+
+{{< docs/learning-journeys title="Explore logs using Logs Drilldown" url="https://grafana.com/docs/learning-journeys/drilldown-logs/" >}}
+
 Using Grafana Logs Drilldown you can:
 
 - Easily find logs and log volumes for all of your services.


### PR DESCRIPTION
This PR adds the logs drilldown learning journey to the docs

<img width="801" alt="Screenshot 2025-05-19 at 22 01 57" src="https://github.com/user-attachments/assets/fecef794-c18c-459e-b9ec-1a81102a6264" />
