### PR TITLE
feat(FieldsBreakdown): Show panels with errors

### DIFF
--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -361,8 +361,10 @@ async function subscribeToAddToInvestigation(exploreLogsVizPanelMenu: PanelMenu)
 
 export const getPanelWrapperStyles = (theme: GrafanaTheme2) => {
   return {
+    errorWrapper: css({}),
     panelWrapper: css({
       display: 'flex',
+      flexDirection: 'column',
       height: '100%',
       label: 'panel-wrapper',
       position: 'absolute',

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -241,8 +241,8 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
       this._subs.add(
         panel?.state.$data?.getResultsStream().subscribe((result) => {
           if (result.data.errors && result.data.errors.length > 0) {
-            child.setState({ isHidden: true });
-            this.updateFieldCount();
+            // child.setState({ isHidden: true });
+            // this.updateFieldCount();
           }
         })
       );
@@ -258,7 +258,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
       AvgFieldPanelType.timeseries;
 
     activeLayout?.state.children.forEach((child) => {
-      if (child instanceof SceneCSSGridItem && !child.state.isHidden) {
+      if (child instanceof SceneCSSGridItem) {
         const panels = sceneGraph.findDescendents(child, VizPanel);
         if (panels.length) {
           // Will only be one panel as a child of CSSGridItem
@@ -385,7 +385,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
   private updateFieldCount() {
     const activeLayout = this.getActiveGridLayouts();
     const activeLayoutChildren = activeLayout?.state.children as SceneCSSGridItem[] | undefined;
-    const activePanels = activeLayoutChildren?.filter((child) => !child.state.isHidden);
+    const activePanels = activeLayoutChildren;
 
     const fieldsBreakdownScene = sceneGraph.getAncestor(this, FieldsBreakdownScene);
     fieldsBreakdownScene.state.changeFieldCount?.(activePanels?.length ?? 0);

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -16,6 +16,7 @@ import {
 } from '@grafana/scenes';
 import { DrawStyle, IconButton, InlineSwitch, Label, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafana/ui';
 
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
 import { ValueSlugs } from '../../../services/enums';
 import {
   buildFieldsQueryString,
@@ -411,11 +412,15 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
   }
 
   public toggleErrorPanels(event: React.ChangeEvent<HTMLInputElement>) {
-    this.setState({ showErrorPanels: event.target.checked });
-    setShowErrorPanels(event.target.checked);
+    const showErrorPanels = event.target.checked;
+    this.setState({ showErrorPanels });
+    setShowErrorPanels(showErrorPanels);
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    reportAppInteraction(USER_EVENTS_PAGES.service_details, USER_EVENTS_ACTIONS.service_details.toggle_error_panels, {
+      checked: showErrorPanels,
+    });
     // No need to re-run queries if we have the query runners in the panel with the error state.
-    if (!event.target.checked) {
+    if (!showErrorPanels) {
       if (serviceScene.state.$detectedFieldsData?.state) {
         this.updateChildren(serviceScene.state.$detectedFieldsData?.state);
       } else {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -14,7 +14,7 @@ import {
   VariableDependencyConfig,
   VariableValueOption,
 } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { Label, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { areArraysEqual } from '../../../services/comparison';
 import { CustomConstantVariable, CustomConstantVariableState } from '../../../services/CustomConstantVariable';
@@ -298,7 +298,17 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     const { options, value } = variable.useState();
     return (
       <div className={cx(styles.labelsMenuWrapper, hideSearch ? styles.labelsMenuWrapperNoSearch : undefined)}>
-        {body instanceof FieldsAggregatedBreakdownScene && <FieldsAggregatedBreakdownScene.Selector model={body} />}
+        {body instanceof FieldsAggregatedBreakdownScene && (
+          <span className={styles.toggleWrapper}>
+            <Label className={styles.toggleLabel}>
+              <Tooltip content={'Show panels that return errors'}>
+                <span className={styles.toggleLabelText}>Show errors</span>
+              </Tooltip>
+              <FieldsAggregatedBreakdownScene.ShowErrorPanelToggle model={body} />
+            </Label>
+            <FieldsAggregatedBreakdownScene.Selector model={body} />
+          </span>
+        )}
         {body instanceof FieldValuesBreakdownScene && <FieldValuesBreakdownScene.Selector model={body} />}
         {hideSearch !== true && body instanceof FieldValuesBreakdownScene && <search.Component model={search} />}
         {!loading && options.length > 1 && (
@@ -370,6 +380,16 @@ function getStyles(theme: GrafanaTheme2) {
       justifyContent: 'space-between',
     }),
     labelsMenuWrapperNoSearch: css({
+      flexDirection: 'row',
+    }),
+    toggleLabel: css({
+      marginRight: theme.spacing(2),
+    }),
+    toggleLabelText: css({
+      marginRight: theme.spacing(1),
+    }),
+    toggleWrapper: css({
+      display: 'flex',
       flexDirection: 'row',
     }),
     valuesMenuWrapper: css({

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -95,7 +95,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
 
     this.setState({
-      loading: serviceScene.state.$detectedLabelsData?.state.data?.state !== LoadingState.Done,
+      loading: serviceScene.state.$detectedLabelsData?.state.data?.state === LoadingState.Loading,
     });
 
     // Subscriptions
@@ -128,7 +128,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     this._subs.add(
       serviceScene.state.$detectedFieldsData?.subscribeToState(
         (newState: QueryRunnerState, oldState: QueryRunnerState) => {
-          if (newState.data?.state === LoadingState.Done) {
+          if (newState.data?.state === LoadingState.Done || newState.data?.state === LoadingState.Error) {
             if (newState.data.series?.[0]) {
               this.updateOptions(newState.data.series?.[0]);
             }

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -14,7 +14,7 @@ import {
   VariableDependencyConfig,
   VariableValueOption,
 } from '@grafana/scenes';
-import { Label, Tooltip, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 
 import { areArraysEqual } from '../../../services/comparison';
 import { CustomConstantVariable, CustomConstantVariableState } from '../../../services/CustomConstantVariable';
@@ -300,12 +300,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       <div className={cx(styles.labelsMenuWrapper, hideSearch ? styles.labelsMenuWrapperNoSearch : undefined)}>
         {body instanceof FieldsAggregatedBreakdownScene && (
           <span className={styles.toggleWrapper}>
-            <Label className={styles.toggleLabel}>
-              <Tooltip content={'Show panels that return errors'}>
-                <span className={styles.toggleLabelText}>Show errors</span>
-              </Tooltip>
-              <FieldsAggregatedBreakdownScene.ShowErrorPanelToggle model={body} />
-            </Label>
+            <FieldsAggregatedBreakdownScene.ShowErrorPanelToggle model={body} />
             <FieldsAggregatedBreakdownScene.Selector model={body} />
           </span>
         )}
@@ -381,12 +376,6 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     labelsMenuWrapperNoSearch: css({
       flexDirection: 'row',
-    }),
-    toggleLabel: css({
-      marginRight: theme.spacing(2),
-    }),
-    toggleLabelText: css({
-      marginRight: theme.spacing(1),
     }),
     toggleWrapper: css({
       display: 'flex',

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -373,8 +373,6 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
       .setMenu(new PanelMenu({}))
       .setTitle(tagKey);
 
-    const body = bodyOpts.build();
-
     const { direction, sortBy } = getSortByPreference('labels', DEFAULT_SORT_BY, 'desc');
 
     const getFilter = () => labelBreakdownScene.state.search.state.filter ?? '';
@@ -382,16 +380,6 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
     return new LayoutSwitcher({
       active: 'grid',
       layouts: [
-        new SceneFlexLayout({
-          children: [
-            new SceneReactObject({ reactNode: <LabelBreakdownScene.LabelsMenu model={labelBreakdownScene} /> }),
-            new SceneFlexItem({
-              body,
-              minHeight: 300,
-            }),
-          ],
-          direction: 'column',
-        }),
         new SceneFlexLayout({
           children: [
             new SceneReactObject({ reactNode: <LabelBreakdownScene.LabelsMenu model={labelBreakdownScene} /> }),
@@ -457,7 +445,6 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
         }),
       ],
       options: [
-        { label: 'Single', value: 'single' },
         { label: 'Grid', value: 'grid' },
         { label: 'Rows', value: 'rows' },
       ],

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.test.tsx
@@ -19,7 +19,6 @@ describe('LayoutSwitcher', () => {
   const mockLayouts: SceneObject[] = [new MockSceneObject({}), new MockSceneObject({}), new MockSceneObject({})];
 
   const mockOptions = [
-    { label: 'Single', value: LayoutTypeEnum.single },
     { label: 'Grid', value: LayoutTypeEnum.grid },
     { label: 'Rows', value: LayoutTypeEnum.rows },
   ];
@@ -33,45 +32,13 @@ describe('LayoutSwitcher', () => {
     });
   });
 
-  describe('isTopLevelLayoutType', () => {
-    test('should return true when single layout is not available', () => {
-      const topLevelOptions = [
-        { label: 'Grid', value: LayoutTypeEnum.grid },
-        { label: 'Rows', value: LayoutTypeEnum.rows },
-      ];
-      layoutSwitcher.setState({ options: topLevelOptions });
-      expect(layoutSwitcher.isTopLevelLayoutType()).toBe(true);
-    });
-
-    test('should return false when single layout is available', () => {
-      expect(layoutSwitcher.isTopLevelLayoutType()).toBe(false);
-    });
-  });
-
   describe('updateLayout', () => {
-    test('should set grid layout when stored layout is single and it is top level', () => {
-      (getSceneLayout as jest.Mock).mockReturnValue(LayoutTypeEnum.single);
-      layoutSwitcher.setState({ options: mockOptions.filter((o) => o.value !== LayoutTypeEnum.single) });
-
-      layoutSwitcher.updateLayout();
-
-      expect(layoutSwitcher.state.active).toBe('grid');
-    });
-
     test('should set stored layout when it is not single', () => {
       (getSceneLayout as jest.Mock).mockReturnValue(LayoutTypeEnum.grid);
 
       layoutSwitcher.updateLayout();
 
       expect(layoutSwitcher.state.active).toBe('grid');
-    });
-
-    test('should set stored layout when single is available', () => {
-      (getSceneLayout as jest.Mock).mockReturnValue(LayoutTypeEnum.single);
-
-      layoutSwitcher.updateLayout();
-
-      expect(layoutSwitcher.state.active).toBe('single');
     });
   });
 

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -16,10 +16,9 @@ export interface LayoutSwitcherState extends SceneObjectState {
   options: Array<SelectableValue<LayoutType>>;
 }
 
-export type LayoutType = 'grid' | 'rows' | 'single';
+export type LayoutType = 'grid' | 'rows';
 
 export enum LayoutTypeEnum {
-  single = 'single',
   grid = 'grid',
   rows = 'rows',
 }
@@ -35,26 +34,12 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  public isTopLevelLayoutType = () => {
-    // Top layouts do not have 'single' layout type
-    const isTopLevel = this.state.options.every((o) => o.value !== LayoutTypeEnum.single);
-    return isTopLevel;
-  };
-
   public updateLayout = () => {
     const layout = getSceneLayout();
     if (layout) {
-      if (layout === LayoutTypeEnum.single && this.isTopLevelLayoutType()) {
-        // top level layouts do not have single layout type default to grid
-        this.setState({ active: LayoutTypeEnum.grid });
-      } else {
-        this.setState({
-          active:
-            layout === LayoutTypeEnum.grid || layout === LayoutTypeEnum.rows || layout === LayoutTypeEnum.single
-              ? layout
-              : LayoutTypeEnum.grid,
-        });
-      }
+      this.setState({
+        active: layout === LayoutTypeEnum.grid || layout === LayoutTypeEnum.rows ? layout : LayoutTypeEnum.grid,
+      });
     }
   };
 

--- a/src/Components/ServiceScene/Breakdowns/QueryErrorAlert.tsx
+++ b/src/Components/ServiceScene/Breakdowns/QueryErrorAlert.tsx
@@ -3,13 +3,21 @@ import React from 'react';
 import { css } from '@emotion/css';
 
 import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
-import { Alert, useStyles2 } from '@grafana/ui';
+import { Alert, LinkButton, useStyles2 } from '@grafana/ui';
 
+import { PageSlugs } from '../../../services/enums';
+import { getDrillDownTabLink } from '../../../services/navigate';
 import { GrotError } from '../../GrotError';
+import { ServiceScene } from '../ServiceScene';
 
 export const MaxSeriesRegex = /maximum of series \(\d+\) reached for a single query/;
 
-export function QueryErrorAlert(props: { errors?: DataQueryError[]; isPartial: boolean; tagKey: string }) {
+export function QueryErrorAlert(props: {
+  errors?: DataQueryError[];
+  isPartial: boolean;
+  serviceScene: ServiceScene;
+  tagKey: string;
+}) {
   const styles = useStyles2(getQueryErrorStyles);
   const errorSet = new Set<string>();
   const traceSet = new Set<string>();
@@ -37,6 +45,11 @@ export function QueryErrorAlert(props: { errors?: DataQueryError[]; isPartial: b
           {errors?.map((err, index) => (
             <QueryErrorContent traces={traceSet} key={index} err={err} label={props.tagKey} />
           ))}
+          <div className={styles.buttonWrap}>
+            <LinkButton variant={'secondary'} href={getDrillDownTabLink(PageSlugs.fields, props.serviceScene)}>
+              Return to all fields
+            </LinkButton>
+          </div>
         </Alert>
       </div>
     </GrotError>
@@ -110,6 +123,10 @@ function ErrorMessage(props: { err: DataQueryError; label: string }) {
 
 export const getQueryErrorStyles = (theme: GrafanaTheme2) => {
   return {
+    buttonWrap: css({
+      display: 'flex',
+      justifyContent: 'flex-end',
+    }),
     queryError: css({
       textAlign: 'left',
     }),

--- a/src/Components/ServiceScene/Breakdowns/QueryErrorAlert.tsx
+++ b/src/Components/ServiceScene/Breakdowns/QueryErrorAlert.tsx
@@ -7,7 +7,9 @@ import { Alert, useStyles2 } from '@grafana/ui';
 
 import { GrotError } from '../../GrotError';
 
-export function QueryErrorAlert(props: { errors?: DataQueryError[]; tagKey: string }) {
+export const MaxSeriesRegex = /maximum of series \(\d+\) reached for a single query/;
+
+export function QueryErrorAlert(props: { errors?: DataQueryError[]; isPartial: boolean; tagKey: string }) {
   const styles = useStyles2(getQueryErrorStyles);
   const errorSet = new Set<string>();
   const traceSet = new Set<string>();
@@ -23,10 +25,15 @@ export function QueryErrorAlert(props: { errors?: DataQueryError[]; tagKey: stri
     }
     return true;
   });
+
+  const title = props.isPartial
+    ? `Showing partial results for ${props.tagKey}`
+    : `Error fetching results for ${props.tagKey}`;
+
   return (
     <GrotError>
       <div className={styles.queryError}>
-        <Alert title={`Error fetching results for ${props.tagKey}`} severity={'error'}>
+        <Alert title={title} severity={'error'}>
           {errors?.map((err, index) => (
             <QueryErrorContent traces={traceSet} key={index} err={err} label={props.tagKey} />
           ))}
@@ -60,7 +67,7 @@ export function QueryErrorContent(props: { err: DataQueryError; label: string; t
 }
 
 function ErrorMessage(props: { err: DataQueryError; label: string }) {
-  if (props.err.message?.match(/maximum of series \(\d+\) reached for a single query/)) {
+  if (props.err.message?.match(MaxSeriesRegex)) {
     return (
       <>
         {props.err.message && (
@@ -81,8 +88,8 @@ function ErrorMessage(props: { err: DataQueryError; label: string }) {
               in your Loki configuration.
             </p>
             <p>
-              <strong>Tip:</strong> Reduce the time range, or add additional filters to reduce the number of
-              unique values in the {props.label} field.
+              <strong>Tip:</strong> Reduce the time range, or add additional filters to reduce the number of unique
+              values in the {props.label} field.
             </p>
           </>
         )}

--- a/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SelectLabelActionScene.tsx
@@ -159,6 +159,14 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
       ? numericFilterOption
       : sparseIncludeOption;
 
+    const panel = sceneGraph.getAncestor(model, VizPanel);
+    const $panelData = sceneGraph.getData(panel);
+    // Need to re-render on data changes now, or disabled button state might get stale.
+    const { data } = $panelData.useState();
+    const hasData = (data?.series.length ?? 0) > 0;
+    const isError = (data?.errors?.length ?? 0) > 0;
+    const disabled = !hasData && isError;
+
     return (
       <>
         {hasOtherFilter && (
@@ -196,6 +204,7 @@ export class SelectLabelActionScene extends SceneObjectBase<SelectLabelActionSce
         )}
         {hideValueDrilldown !== true && (
           <LinkButton
+            disabled={disabled}
             title={`View breakdown of values for ${labelName}`}
             variant="primary"
             fill="outline"

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -75,6 +75,7 @@ export const USER_EVENTS_ACTIONS = {
     search_string_in_variables_changed: 'search_string_in_variables_changed',
     // Clicking on "Select" button button in time series panels. Used in multiple views.The view type is passed as a parameter. Props: field, previousField, view
     select_field_in_breakdown_clicked: 'select_field_in_breakdown_clicked',
+    toggle_error_panels: 'toggle_error_panels',
     // Value breakdown sort change
     value_breakdown_sort_change: 'value_breakdown_sort_change',
     // Wasm not supported

--- a/src/services/navigate.ts
+++ b/src/services/navigate.ts
@@ -186,3 +186,7 @@ export function navigateToIndex() {
     pushUrlHandler(serviceUrl);
   }
 }
+
+export function goBack() {
+  locationService.getHistory().goBack();
+}

--- a/src/services/navigate.ts
+++ b/src/services/navigate.ts
@@ -186,7 +186,3 @@ export function navigateToIndex() {
     pushUrlHandler(serviceUrl);
   }
 }
-
-export function goBack() {
-  locationService.getHistory().goBack();
-}

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { DataQueryRequest, DataQueryResponse, LoadingState, QueryResultMetaStat } from '@grafana/data';
 
+import { MaxSeriesRegex } from '../Components/ServiceScene/Breakdowns/QueryErrorAlert';
 import pluginJson from '../plugin.json';
 import { combineResponses } from './combineResponses';
 import { logger } from './logger';
@@ -308,7 +309,7 @@ function isRetriableError(errorResponse: DataQueryResponse) {
     : errorResponse.error?.message ?? '';
   if (message.includes('timeout')) {
     return true;
-  } else if (message.includes('parse error')) {
+  } else if (message.includes('parse error') || message.match(MaxSeriesRegex)) {
     // If the error is a parse error, we want to signal to stop querying.
     throw new Error(message);
   }

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -277,6 +277,15 @@ export function setLogsVisualizationType(type: string) {
   localStorage.setItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY, type);
 }
 
+const SHOW_ERROR_PANELS_KEY = `${pluginJson.id}.panelOptions.showErrors`;
+export function getShowErrorPanels(): boolean {
+  return !!localStorage.getItem(SHOW_ERROR_PANELS_KEY);
+}
+
+export function setShowErrorPanels(showErrorPanels: boolean) {
+  localStorage.setItem(SHOW_ERROR_PANELS_KEY, showErrorPanels ? 'true' : '');
+}
+
 // JSON filter debug mode
 const JSON_PARSER_PROPS_DEBUG_KEY = `${pluginJson.id}.jsonParser.visible`;
 export function getJsonParserVariableVisibility(): boolean {


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1343

https://github.com/user-attachments/assets/06cfe42e-299b-47dc-8996-6791a5e7d0a2

For reviewers:
Sharded results should show partial results in the panel.
When panels with errors are displayed the user can still get to the value breakdown, which will always show an error, however it is still useful for users that have partial sharded results. 