### PR TITLE
fix(datasources):

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -91,7 +91,11 @@ import {
   renderLogQLLineFilter,
   renderLogQLMetadataFilters,
 } from 'services/query';
-import { addLastUsedDataSourceToStorage, getLastUsedDataSourceFromStorage } from 'services/store';
+import {
+  addLastUsedDataSourceToStorage,
+  getDefaultDatasourceFromDatasourceSrv,
+  getLastUsedDataSourceFromStorage,
+} from 'services/store';
 import {
   AdHocFiltersWithLabelsAndMeta,
   AppliedPattern,
@@ -135,10 +139,10 @@ interface EmbeddedIndexSceneConstructor {
 export class IndexScene extends SceneObjectBase<IndexSceneState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['patterns'] });
 
-  public constructor({
-    datasourceUid = getLastUsedDataSourceFromStorage() ?? 'grafanacloud-logs',
-    ...state
-  }: Partial<IndexSceneState & EmbeddedIndexSceneConstructor>) {
+  public constructor(state: Partial<IndexSceneState & EmbeddedIndexSceneConstructor>) {
+    const datasourceUid =
+      getLastUsedDataSourceFromStorage() ?? getDefaultDatasourceFromDatasourceSrv() ?? 'grafanacloud-logs';
+
     const { unsub, variablesScene } = getVariableSet(
       datasourceUid,
       state?.readOnlyLabelFilters,

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -140,8 +140,12 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['patterns'] });
 
   public constructor(state: Partial<IndexSceneState & EmbeddedIndexSceneConstructor>) {
+    const { jsonData } = plugin.meta as AppPluginMeta<JsonData>;
     const datasourceUid =
-      getLastUsedDataSourceFromStorage() ?? getDefaultDatasourceFromDatasourceSrv() ?? 'grafanacloud-logs';
+      jsonData?.dataSource ??
+      getLastUsedDataSourceFromStorage() ??
+      getDefaultDatasourceFromDatasourceSrv() ??
+      'grafanacloud-logs';
 
     const { unsub, variablesScene } = getVariableSet(
       datasourceUid,

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,4 +1,5 @@
 import { LogsDedupStrategy } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { SceneObject, VariableValue } from '@grafana/scenes';
 import { Options } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen';
 
@@ -157,6 +158,14 @@ function createTabsLocalStorageKey(ds: string) {
 
 export function getLastUsedDataSourceFromStorage(): string | undefined {
   return localStorage.getItem(DS_LOCALSTORAGE_KEY) ?? undefined;
+}
+export function getDefaultDatasourceFromDatasourceSrv(): string | undefined {
+  const ds = getDataSourceSrv()
+    .getList({
+      type: 'loki',
+    })
+    .find((ds) => ds.isDefault);
+  return ds?.uid;
 }
 
 export function addLastUsedDataSourceToStorage(dsKey: string) {


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1308

Pulls in Grafana default datasource, if it happens to be a Loki datasource, otherwise users can configure (`/plugins/grafana-lokiexplore-app`) a default loki datasource for Logs Drilldown.