### PR TITLE
feat(header): add collapsing header

### DIFF
--- a/src/Components/IndexScene/GiveFeedbackButton.tsx
+++ b/src/Components/IndexScene/GiveFeedbackButton.tsx
@@ -35,9 +35,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css({
       display: 'flex',
       gap: theme.spacing(1),
-      marginLeft: 'auto',
       position: 'relative',
-      top: theme.spacing(-1),
     }),
   };
 };

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -286,6 +286,14 @@ export function setLogsVisualizationType(type: string) {
   localStorage.setItem(VISUALIZATION_TYPE_LOCALSTORAGE_KEY, type);
 }
 
+const TOGGLE_HEADER_COLLAPSE_KEY = `${pluginJson.id}.headerOptions.toggleCollapse`;
+export function getHeaderCollapse(): boolean {
+  return !!localStorage.getItem(TOGGLE_HEADER_COLLAPSE_KEY);
+}
+export function setHeaderCollapse(collapse: boolean) {
+  localStorage.setItem(TOGGLE_HEADER_COLLAPSE_KEY, collapse ? 'true' : '');
+}
+
 const SHOW_ERROR_PANELS_KEY = `${pluginJson.id}.panelOptions.showErrors`;
 export function getShowErrorPanels(): boolean {
   return !!localStorage.getItem(SHOW_ERROR_PANELS_KEY);


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1259

Pros:
* Save vertical space, especially on smaller viewports
* Expand/collapse button is small and will go unnoticed

Cons:
* People are going to forget this is set and have no idea what field/level filters have been set
* Expand/collapse button is small and will go unnoticed
* Removes level filters from view - making it more difficult to quickly change level filters.

I'm not sure the pros outweigh the cons, while there might be some cases when you have many filters that are taking up lots of space, if you are actively refining a search you need to be able to quickly add/remove filters in any context, hiding things will inevitably lead some users to try and click back into fields breakdowns to remove filters instead of using the variables.

Tl;DR - While there might be some use-cases this is helpful, I don't think this is something we'd want to expose by default.

## Tablet widths

<img width="934" alt="image" src="https://github.com/user-attachments/assets/83c392b8-713c-48fb-a5ff-31e84c376613" />

<img width="936" alt="image" src="https://github.com/user-attachments/assets/0c2e7f1e-eb2b-4543-b6ca-130be5019d0b" />

## Desktop widths

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/e80a73cd-5860-47ed-b82f-4936905da644" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b8f75638-2248-4cb4-809b-a6880279bd5b" />

## Desktop widths - many filters

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bcaf6309-5f03-4422-bd91-dd75c4ff7921" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5b976ddc-7acc-4dd9-9dab-c5ca35211312" />

