### PR TITLE
fix(JSON): detected fields not always getting called on activation

### DIFF
--- a/src/Components/ServiceScene/LogsJsonScene.tsx
+++ b/src/Components/ServiceScene/LogsJsonScene.tsx
@@ -181,7 +181,16 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
       } else {
         this.setVizFlags(detectedFieldFrame);
       }
+    } else if (serviceScene.state?.$detectedFieldsData?.state.data?.state === undefined) {
+      serviceScene.state?.$detectedFieldsData?.runQueries();
     }
+
+    // Subscribe to detected fields
+    serviceScene.state?.$detectedFieldsData?.subscribeToState((newState) => {
+      if (newState.data?.state === LoadingState.Done && newState.data?.series.length) {
+        this.setVizFlags(newState.data.series[0]);
+      }
+    });
   }
 
   /**

--- a/src/Components/ServiceScene/LogsJsonScene.tsx
+++ b/src/Components/ServiceScene/LogsJsonScene.tsx
@@ -186,11 +186,13 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
     }
 
     // Subscribe to detected fields
-    serviceScene.state?.$detectedFieldsData?.subscribeToState((newState) => {
-      if (newState.data?.state === LoadingState.Done && newState.data?.series.length) {
-        this.setVizFlags(newState.data.series[0]);
-      }
-    });
+    this._subs.add(
+      serviceScene.state?.$detectedFieldsData?.subscribeToState((newState) => {
+        if (newState.data?.state === LoadingState.Done && newState.data?.series.length) {
+          this.setVizFlags(newState.data.series[0]);
+        }
+      })
+    );
   }
 
   /**

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -234,6 +234,34 @@ test.describe('explore nginx-json breakdown pages ', () => {
       // Assert we still have results
       await expect(page.getByText('▶Line:{}')).toHaveCount(EXPANDED_NODE_COUNT);
     });
+    test('detected fields is called on init when loading json panel', async ({ page }) => {
+      // Load logs tab
+      await explorePage.goToLogsTab();
+      // Switch to json viz
+      await explorePage.getJsonToggleLocator().click();
+      // Reload the page
+      await page.reload();
+      // Verify filter buttons are visible
+      const userIdentifierInclude = page.getByLabel(/Include log lines containing user-identifier=".+"/);
+      await expect(userIdentifierInclude).toHaveCount(EXPANDED_NODE_COUNT); // 50 nodes are expanded by default
+    });
+
+    test('detected fields is called after nav from fields page', async ({ page }) => {
+      // Set JSON as default viz
+      await explorePage.goToLogsTab();
+      await explorePage.getJsonToggleLocator().click();
+
+      await explorePage.goToFieldsTab();
+      // Clear caches
+      await page.reload();
+
+      // Go to fields tab after detected_fields was called on fields
+      await explorePage.goToLogsTab();
+
+      // Verify filter buttons are visible
+      const userIdentifierInclude = page.getByLabel(/Include log lines containing user-identifier=".+"/);
+      await expect(userIdentifierInclude).toHaveCount(EXPANDED_NODE_COUNT); // 50 nodes are expanded by default
+    });
 
     // @todo
     // test('can add filter in logs panel without breaking existing json', async ({ page }) => {});


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1303

Prevents:
* Race condition when loading json viz and detected_fields call is in flight
* Detected_fields not getting called when cached while navigating from the fields tab to the json viz.

Adding e2e coverage for both of these cases as well.