### PR TITLE
chore(gha): deploy each commit to dev + ops, auto-merge dev and ops PRs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -21,10 +21,11 @@ jobs:
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
 
       # When pushing to "main", publish and deploy to "dev" and "ops" (CD). For PRs, skip publishing and deploying (run CI only)
-      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'ops' || 'none' }}
+      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev,ops' || 'none' }}
 
       # Deploy provisioned plugin to Grafana Cloud
       grafana-cloud-deployment-type: provisioned
+      auto-merge-environments: dev,ops
       argo-workflow-slack-channel: '#drilldown-cd-alerts-dev-ops'
 
       # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.


### PR DESCRIPTION
This PR does some changes to the GitHub Actions workflows following some changes in plugin-ci-workflows and Grafana Plugins CD Argo Workflow:

- Updates the push to main workflow to trigger a Grafana Cloud deployment to dev + ops
- Updates the push to main workflow to tell Argo to auto-merge PRs in deployment_tools for dev + ops

**Details:**

After https://github.com/grafana/plugin-ci-workflows/pull/131 and https://github.com/grafana/plugin-ci-workflows/pull/135 and https://github.com/grafana/deployment_tools/pull/287893, the behavior of the `environment` parameter in the cd workflow has changed:

- dev deploys to dev only
- ops deploys to ops only (used to be dev + ops)
- prod deploys to dev + ops + prod

We however introduced support to trigger multiple environments by passing them as a comma-separated string, which can be used to restore the old behavior of deploying to dev + ops for each push to main.

We also have the added the ability to auto-merge deployment_tools PRs for other environments rather than the hardcoded dev only, which can be used to auto-merge PRs coming from each push to main.