### PR TITLE
chore: whitelist grafana-plugins-platform-bot[bot]

### DIFF
--- a/.cla-assistant.yml
+++ b/.cla-assistant.yml
@@ -1,0 +1,2 @@
+whitelisted:
+  - 'grafana-plugins-platform-bot[bot]'


### PR DESCRIPTION
Trying to whitelist the grafana-plugins-platform-bot[bot] for the CLA signing. Supposedly it needs to be in main to work.