### PR TITLE
feat: enable Logs Drilldown link in Metrics Drilldown

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -284,6 +284,7 @@ maxbrunsfeld
 mdns
 memberlist
 mergo
+metricsdrilldown
 miekg
 MINALERTLEVEL
 mistifyio

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -66,7 +66,11 @@
   "extensions": {
     "addedLinks": [
       {
-        "targets": ["grafana/dashboard/panel/menu", "grafana/explore/toolbar/action"],
+        "targets": [
+          "grafana/dashboard/panel/menu",
+          "grafana/explore/toolbar/action",
+          "grafana-metricsdrilldown-app/open-in-logs-drilldown/v1"
+        ],
         "title": "Open in Grafana Logs Drilldown",
         "description": "Open current query in the Grafana Logs Drilldown view"
       }

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -211,15 +211,15 @@ export function createAppUrl(path = '/explore', urlParams?: URLSearchParams): st
 
 export const UrlParameters = {
   DatasourceId: `var-${VAR_DATASOURCE}`,
-  Fields: `var-${VAR_FIELDS}`,
-  Labels: `var-${VAR_LABELS}`,
-  Levels: `var-${VAR_LEVELS}`,
-  LineFilters: `var-${VAR_LINE_FILTERS}`,
-  Metadata: `var-${VAR_METADATA}`,
-  Patterns: VAR_PATTERNS,
-  PatternsVariable: `var-${VAR_PATTERNS}`,
   TimeRangeFrom: 'from',
   TimeRangeTo: 'to',
+  Labels: `var-${VAR_LABELS}`,
+  Fields: `var-${VAR_FIELDS}`,
+  Metadata: `var-${VAR_METADATA}`,
+  Levels: `var-${VAR_LEVELS}`,
+  LineFilters: `var-${VAR_LINE_FILTERS}`,
+  Patterns: VAR_PATTERNS,
+  PatternsVariable: `var-${VAR_PATTERNS}`,
 } as const;
 export type UrlParameterType = (typeof UrlParameters)[keyof typeof UrlParameters];
 

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -37,19 +37,13 @@ export const ExtensionPoints = {
 
 export type LinkConfigs = Array<PluginExtensionAddedLinkConfig<PluginExtensionPanelContext>>;
 
-// `plugin.addLink` requires these types; unfortunately, the correct `PluginExtensionAddedLinkConfig` type is not exported with 11.2.x
-// TODO: fix this type when we move to `@grafana/data` 11.3.x
 export const linkConfigs: LinkConfigs = [
   {
-    targets: PluginExtensionPoints.DashboardPanelMenu,
-    title,
-    description,
-    icon,
-    path: createAppUrl(),
-    configure: contextToLink,
-  },
-  {
-    targets: PluginExtensionPoints.ExploreToolbarAction,
+    targets: [
+      PluginExtensionPoints.DashboardPanelMenu,
+      PluginExtensionPoints.ExploreToolbarAction,
+      'grafana-metricsdrilldown-app/open-in-logs-drilldown/v1',
+    ],
     title,
     description,
     icon,
@@ -217,15 +211,15 @@ export function createAppUrl(path = '/explore', urlParams?: URLSearchParams): st
 
 export const UrlParameters = {
   DatasourceId: `var-${VAR_DATASOURCE}`,
-  TimeRangeFrom: 'from',
-  TimeRangeTo: 'to',
-  Labels: `var-${VAR_LABELS}`,
   Fields: `var-${VAR_FIELDS}`,
-  Metadata: `var-${VAR_METADATA}`,
+  Labels: `var-${VAR_LABELS}`,
   Levels: `var-${VAR_LEVELS}`,
   LineFilters: `var-${VAR_LINE_FILTERS}`,
+  Metadata: `var-${VAR_METADATA}`,
   Patterns: VAR_PATTERNS,
   PatternsVariable: `var-${VAR_PATTERNS}`,
+  TimeRangeFrom: 'from',
+  TimeRangeTo: 'to',
 } as const;
 export type UrlParameterType = (typeof UrlParameters)[keyof typeof UrlParameters];
 


### PR DESCRIPTION
## Context

This PR supports https://github.com/grafana/metrics-drilldown/issues/524

## What does this do?

Adds `'grafana-metricsdrilldown-app/open-in-logs-drilldown/v1'` as another extension point that can leverage the "Open in Grafana Logs Drilldown" link

## Demo

On a feature branch in Metrics Drilldown, the extension point is working as expected in the Related Logs tab:

https://github.com/user-attachments/assets/2b98dab1-b7a2-496e-9317-9853659c0e9a

## Testing the full experience

It's tedious to do all of the setup involved in testing that this extension point not only exists, but also achieves the goals described in https://github.com/grafana/metrics-drilldown/issues/524. But if you're feeling brave, the full testing instructions are provided in the **How to test** section of https://github.com/grafana/metrics-drilldown/pull/535.