### PR TITLE
fix: limit patterns to 500

### DIFF
--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -72,6 +72,7 @@ export const DETECTED_FIELDS_PARSER_NAME = 'parser';
 
 export const DETECTED_FIELDS_TYPE_NAME = 'type';
 export const DETECTED_FIELDS_PATH_NAME = 'jsonPath';
+export const MAX_PATTERNS_LIMIT = 500;
 
 export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
   constructor(pluginId: string, uid: string) {
@@ -195,10 +196,12 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
         }
       );
       const response: PatternsResponse = await dsResponse;
-      const lokiPatterns = response?.data;
+      const lokiPatterns = response?.data.slice(0, MAX_PATTERNS_LIMIT);
 
       let maxValue = -Infinity;
       let minValue = 0;
+
+      console.log('lokiPatterns', lokiPatterns);
 
       const frames: DataFrame[] =
         lokiPatterns?.map((pattern: LokiPattern) => {

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -201,8 +201,6 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
       let maxValue = -Infinity;
       let minValue = 0;
 
-      console.log('lokiPatterns', lokiPatterns);
-
       const frames: DataFrame[] =
         lokiPatterns?.map((pattern: LokiPattern) => {
           const timeValues: number[] = [];


### PR DESCRIPTION
We shouldn't ever get more then 100 patterns per hour in the query interval for worst-case behavior when there are no common patterns between logs ingested every hour. 

We should probably follow up and display an unobtrusive warning when the limit is hit, but this will keep crazy queries from crashing the browser until Loki sets a limit on the backend.

Related: https://github.com/grafana/loki/issues/18374