### PR TITLE
feat(LogsPanel): set details mode

### DIFF
--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -355,7 +355,9 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
             label: 'Copy link to log line',
             onClick: this.handleShareLogLine,
           },
-        ]);
+        ])
+        // @ts-expect-error Requires Grafana 12.2
+        .setOption('detailsMode', 'sidebar');
     }
 
     return panel.build();


### PR DESCRIPTION
Uses details mode for the Logs panel. The other panels default to inline.

Requires https://github.com/grafana/grafana/pull/107902