### PR TITLE
chore(eslint): disable sort/object-properties, remove recommendations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": [
     "./.config/.eslintrc",
     "plugin:jsx-a11y/strict",
-    "plugin:sort/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript"
@@ -28,6 +27,7 @@
         "separator": "\n"
       }
     ],
+    "sort/object-properties": "off",
     "sort/type-properties": "error",
     "sort/string-unions": "error",
     "sort/exports": "off"

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -35,7 +35,6 @@ export const ExtensionPoints = {
   MetricInvestigation: 'grafana-lokiexplore-app/investigation/v1',
 } as const;
 
-/* eslint-disable sort/object-properties */
 export type LinkConfigs = Array<PluginExtensionAddedLinkConfig<PluginExtensionPanelContext>>;
 
 // `plugin.addLink` requires these types; unfortunately, the correct `PluginExtensionAddedLinkConfig` type is not exported with 11.2.x


### PR DESCRIPTION
Turn off object key sorting and remove recommendation because we know what we wants 🧠 better.