### PR TITLE
JSON - Add reroot component to logs panel title items

### DIFF
--- a/src/Components/ServiceScene/JSONPanel/JsonRootNodeNavigation.tsx
+++ b/src/Components/ServiceScene/JSONPanel/JsonRootNodeNavigation.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+
+import { AdHocFilterWithLabels, SceneObject } from '@grafana/scenes';
+import { Button, Icon } from '@grafana/ui';
+
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
+import { clearJsonParserFields, isLogLineField } from '../../../services/fields';
+import { addJsonParserFieldValue, EMPTY_AD_HOC_FILTER_VALUE, removeLineFormatFilters } from '../../../services/filters';
+import { LineFormatFilterOp } from '../../../services/filterTypes';
+import { breadCrumbDelimiter, drillUpWrapperStyle, itemStringDelimiter } from '../../../services/JSONViz';
+import { LABEL_NAME_INVALID_CHARS } from '../../../services/labels';
+import { addCurrentUrlToHistory } from '../../../services/navigate';
+import { getFieldsVariable, getJsonFieldsVariable, getLineFormatVariable } from '../../../services/variableGetters';
+import { JsonDataFrameLineName, JsonVizRootName } from '../LogsJsonScene';
+import { KeyPath } from '@gtk-grafana/react-json-tree';
+
+interface Props {
+  sceneRef: SceneObject;
+}
+
+export default function JsonRootNodeNavigation({ sceneRef }: Props) {
+  const lineFormatVar = getLineFormatVariable(sceneRef);
+  const filters = lineFormatVar.state.filters;
+  const rootKeyPath = [JsonDataFrameLineName, 0, JsonVizRootName];
+
+  return (
+    <>
+      <span className={drillUpWrapperStyle} key={JsonVizRootName}>
+        <Button
+          size={'sm'}
+          onClick={() => setNewRootNode(rootKeyPath, sceneRef)}
+          variant={'secondary'}
+          fill={'outline'}
+          disabled={!filters.length}
+          name={JsonVizRootName}
+        >
+          {JsonVizRootName}
+        </Button>
+        {filters.length > 0 && <Icon className={breadCrumbDelimiter} name={'angle-right'} />}
+      </span>
+
+      {filters.map((filter, i) => {
+        const selected = filter.key === filters[filters.length - 1].key;
+        return (
+          <span className={drillUpWrapperStyle} key={filter.key}>
+            {
+              <Button
+                size={'sm'}
+                disabled={selected}
+                onClick={() => addDrillUp(filter.key, sceneRef)}
+                variant={'secondary'}
+                fill={'outline'}
+              >
+                {filter.key}
+              </Button>
+            }
+            {i < filters.length - 1 && <Icon className={breadCrumbDelimiter} name={'angle-right'} />}
+            {i === filters.length - 1 && <Icon className={itemStringDelimiter} name={'angle-right'} />}
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
+export function getFullKeyPath(keyPath: ReadonlyArray<string | number>, sceneObject: SceneObject) {
+  const lineFormatVar = getLineFormatVariable(sceneObject);
+
+  const fullPathFilters: AdHocFilterWithLabels[] = [
+    ...lineFormatVar.state.filters,
+    ...keyPath
+      // line format filters only store the parent node field names
+      .filter((key) => typeof key === 'string' && !isLogLineField(key) && key !== JsonVizRootName)
+      // keyPath order is from child to root, we want to order from root to child
+      .reverse()
+      // convert to ad-hoc filter
+      .map((nodeKey) => ({
+        key: nodeKey.toString(),
+        // The operator and value are not used when interpolating the variable, but empty values will cause the ad-hoc filter to get removed from the URL state, we work around this by adding an empty space for the value and operator
+        // we could store the depth of the node as a value, right now we assume that these filters always include every parent node of the current node, ordered by node depth ASC (root node first)
+        operator: LineFormatFilterOp.Empty,
+        value: EMPTY_AD_HOC_FILTER_VALUE,
+      })),
+  ];
+  // the last 3 in the key path are always array
+  const fullKeyPath = [...fullPathFilters.map((filter) => filter.key).reverse(), ...keyPath.slice(-3)];
+  return { fullKeyPath, fullPathFilters };
+}
+
+export const setNewRootNode = (keyPath: KeyPath, sceneRef: SceneObject) => {
+  addCurrentUrlToHistory();
+  const { fullKeyPath, fullPathFilters } = getFullKeyPath(keyPath, sceneRef);
+  // If keyPath length is greater than 3 we're drilling down (root, line index, line)
+  if (keyPath.length > 3) {
+    addJsonParserFieldValue(sceneRef, fullKeyPath);
+
+    const lineFormatVar = getLineFormatVariable(sceneRef);
+
+    lineFormatVar.setState({
+      // Need to strip out any unsupported chars to match the field name we're creating in the json parser args
+      filters: fullPathFilters.map((filter) => ({
+        ...filter,
+        key: filter.key.replace(LABEL_NAME_INVALID_CHARS, '_'),
+      })),
+    });
+    lineFormatEvent('add', keyPath[0].toString());
+  } else {
+    // Otherwise we're drilling back up to the root
+    removeLineFormatFilters(sceneRef);
+    clearJsonParserFields(sceneRef);
+    lineFormatEvent('remove', JsonVizRootName);
+  }
+};
+
+/**
+ * Fires rudderstack event when the viz adds/removes a new root (line format)
+ */
+export const lineFormatEvent = (type: 'add' | 'remove', key: string) => {
+  reportAppInteraction(
+    USER_EVENTS_PAGES.service_details,
+    USER_EVENTS_ACTIONS.service_details.change_line_format_in_json_panel,
+    {
+      key,
+      type: type,
+    }
+  );
+};
+
+/**
+ * Drill back up to a parent node via the sticky "breadcrumbs"
+ * @param key
+ * @param sceneRef
+ */
+export const addDrillUp = (key: string, sceneRef: SceneObject) => {
+  addCurrentUrlToHistory();
+
+  const lineFormatVariable = getLineFormatVariable(sceneRef);
+  const jsonVar = getJsonFieldsVariable(sceneRef);
+  const fieldsVar = getFieldsVariable(sceneRef);
+
+  const lineFormatFilters = lineFormatVariable.state.filters;
+  const keyIndex = lineFormatFilters.findIndex((filter) => filter.key === key);
+  const lineFormatFiltersToKeep = lineFormatFilters.filter((_, index) => index <= keyIndex);
+  const jsonParserKeys: string[] = [];
+
+  for (let i = 0; i < lineFormatFilters.length; i++) {
+    jsonParserKeys.push(
+      `${
+        jsonParserKeys.length
+          ? `${lineFormatFilters
+              .map((filter) => filter.key)
+              .slice(0, i)
+              .join('_')}_`
+          : ''
+      }${lineFormatFilters[i].key}`
+    );
+  }
+
+  const jsonParserKeysToRemove = jsonParserKeys.slice(keyIndex + 1);
+  const fieldsFilterSet = new Set();
+  fieldsVar.state.filters.forEach((fieldFilter) => fieldsFilterSet.add(fieldFilter.key));
+
+  const jsonParserFilters = jsonVar.state.filters.filter(
+    (filter) => !jsonParserKeysToRemove.includes(filter.key) || fieldsFilterSet.has(filter.key)
+  );
+
+  jsonVar.setState({
+    filters: jsonParserFilters,
+  });
+  lineFormatVariable.setState({
+    filters: lineFormatFiltersToKeep,
+  });
+
+  lineFormatEvent('remove', key);
+};

--- a/src/Components/ServiceScene/JSONPanel/LabelRenderer.tsx
+++ b/src/Components/ServiceScene/JSONPanel/LabelRenderer.tsx
@@ -18,6 +18,7 @@ import {
   NodeTypeLoc,
   StructuredMetadataDisplayName,
 } from '../LogsJsonScene';
+import JsonRootNodeNavigation from './JsonRootNodeNavigation';
 import { KeyPath } from '@gtk-grafana/react-json-tree/dist/types';
 
 interface LabelRendererProps {
@@ -50,7 +51,7 @@ export default function LabelRenderer({
   }
 
   if (keyPath[0] === JsonVizRootName) {
-    return model.renderNestedNodeButtons(keyPath, jsonFiltersSupported);
+    return <JsonRootNodeNavigation sceneRef={model} />;
   }
 
   // Value nodes

--- a/src/Components/ServiceScene/JSONPanel/ReRootJSONButton.tsx
+++ b/src/Components/ServiceScene/JSONPanel/ReRootJSONButton.tsx
@@ -1,26 +1,26 @@
 import React, { memo } from 'react';
 
+import { SceneObject } from '@grafana/scenes';
 import { IconButton } from '@grafana/ui';
 
 import { labelButtonStyles } from '../../../services/JSONViz';
+import { setNewRootNode } from './JsonRootNodeNavigation';
 import { KeyPath } from '@gtk-grafana/react-json-tree';
 
-const ReRootJSONButton = memo(
-  ({ keyPath, setNewRootNode }: { keyPath: KeyPath; setNewRootNode: (keyPath: KeyPath) => void }) => {
-    return (
-      <IconButton
-        className={labelButtonStyles}
-        tooltip={`Set ${keyPath[0]} as root node`}
-        onClick={(e) => {
-          e.stopPropagation();
-          setNewRootNode(keyPath);
-        }}
-        size={'md'}
-        name={'eye'}
-        aria-label={`drilldown into ${keyPath[0]}`}
-      />
-    );
-  }
-);
+const ReRootJSONButton = memo(({ keyPath, sceneRef }: { keyPath: KeyPath; sceneRef: SceneObject }) => {
+  return (
+    <IconButton
+      className={labelButtonStyles}
+      tooltip={`Set ${keyPath[0]} as root node`}
+      onClick={(e) => {
+        e.stopPropagation();
+        setNewRootNode(keyPath, sceneRef);
+      }}
+      size={'md'}
+      name={'eye'}
+      aria-label={`drilldown into ${keyPath[0]}`}
+    />
+  );
+});
 ReRootJSONButton.displayName = 'DrilldownButton';
 export default ReRootJSONButton;

--- a/src/Components/ServiceScene/LogsJsonScene.tsx
+++ b/src/Components/ServiceScene/LogsJsonScene.tsx
@@ -37,14 +37,8 @@ import {
   isLogLineField,
 } from '../../services/fields';
 import { LabelType } from '../../services/fieldsTypes';
-import {
-  addJsonParserFieldValue,
-  EMPTY_AD_HOC_FILTER_VALUE,
-  getJsonKey,
-  LABELS_TO_REMOVE,
-  removeLineFormatFilters,
-} from '../../services/filters';
-import { FilterOp, LineFormatFilterOp } from '../../services/filterTypes';
+import { addJsonParserFieldValue, getJsonKey, LABELS_TO_REMOVE } from '../../services/filters';
+import { FilterOp } from '../../services/filterTypes';
 import {
   breadCrumbDelimiter,
   drillUpWrapperStyle,
@@ -62,8 +56,6 @@ import { getPrettyQueryExpr } from '../../services/scenes';
 import { copyText } from '../../services/text';
 import {
   getAdHocFiltersVariable,
-  getFieldsVariable,
-  getJsonFieldsVariable,
   getLineFormatVariable,
   getValueFromFieldsFilter,
 } from '../../services/variableGetters';
@@ -83,6 +75,7 @@ import { NoMatchingLabelsScene } from './Breakdowns/NoMatchingLabelsScene';
 import { highlightLineFilterMatches } from './JSONPanel/highlightLineFilterMatches';
 import JSONFilterNestedNodeButton from './JSONPanel/JSONFilterNestedNodeButton';
 import { FilterValueButton, JSONFilterValueButton } from './JSONPanel/JSONFilterValueButton';
+import { addDrillUp, getFullKeyPath, setNewRootNode } from './JSONPanel/JsonRootNodeNavigation';
 import LogsJsonComponent from './JSONPanel/LogsJsonComponent';
 import ReRootJSONButton from './JSONPanel/ReRootJSONButton';
 import { LogsListScene } from './LogsListScene';
@@ -309,124 +302,6 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
     return getJSONVizNestedProperty(lineField, accessors);
   }
 
-  /**
-   * Drill back up to a parent node via the sticky "breadcrumbs"
-   */
-  private addDrillUp = (key: string) => {
-    addCurrentUrlToHistory();
-
-    const lineFormatVariable = getLineFormatVariable(this);
-    const jsonVar = getJsonFieldsVariable(this);
-    const fieldsVar = getFieldsVariable(this);
-
-    const lineFormatFilters = lineFormatVariable.state.filters;
-    const keyIndex = lineFormatFilters.findIndex((filter) => filter.key === key);
-    const lineFormatFiltersToKeep = lineFormatFilters.filter((_, index) => index <= keyIndex);
-    const jsonParserKeys: string[] = [];
-
-    for (let i = 0; i < lineFormatFilters.length; i++) {
-      jsonParserKeys.push(
-        `${
-          jsonParserKeys.length
-            ? `${lineFormatFilters
-                .map((filter) => filter.key)
-                .slice(0, i)
-                .join('_')}_`
-            : ''
-        }${lineFormatFilters[i].key}`
-      );
-    }
-
-    const jsonParserKeysToRemove = jsonParserKeys.slice(keyIndex + 1);
-    const fieldsFilterSet = new Set();
-    fieldsVar.state.filters.forEach((fieldFilter) => fieldsFilterSet.add(fieldFilter.key));
-
-    const jsonParserFilters = jsonVar.state.filters.filter(
-      (filter) => !jsonParserKeysToRemove.includes(filter.key) || fieldsFilterSet.has(filter.key)
-    );
-
-    jsonVar.setState({
-      filters: jsonParserFilters,
-    });
-    lineFormatVariable.setState({
-      filters: lineFormatFiltersToKeep,
-    });
-
-    this.lineFormatEvent('remove', key);
-  };
-
-  /**
-   * Drills down into node specified by keyPath
-   * Note, if we've already drilled down into a node, the keyPath (from the viz) will not have the parent nodes we need to build the json parser fields.
-   * We re-create the full key path using the values currently stored in the lineFormat variable
-   */
-  private setNewRootNode = (keyPath: KeyPath) => {
-    addCurrentUrlToHistory();
-    const { fullKeyPath, fullPathFilters } = this.getFullKeyPath(keyPath);
-    // If keyPath length is greater than 3 we're drilling down (root, line index, line)
-    if (keyPath.length > 3) {
-      addJsonParserFieldValue(this, fullKeyPath);
-
-      const lineFormatVar = getLineFormatVariable(this);
-
-      lineFormatVar.setState({
-        // Need to strip out any unsupported chars to match the field name we're creating in the json parser args
-        filters: fullPathFilters.map((filter) => ({
-          ...filter,
-          key: filter.key.replace(LABEL_NAME_INVALID_CHARS, '_'),
-        })),
-      });
-      this.lineFormatEvent('add', keyPath[0].toString());
-    } else {
-      // Otherwise we're drilling back up to the root
-      removeLineFormatFilters(this);
-      clearJsonParserFields(this);
-      this.lineFormatEvent('remove', JsonVizRootName);
-    }
-  };
-
-  /**
-   * Fires rudderstack event when the viz adds/removes a new root (line format)
-   */
-  private lineFormatEvent = (type: 'add' | 'remove', key: string) => {
-    reportAppInteraction(
-      USER_EVENTS_PAGES.service_details,
-      USER_EVENTS_ACTIONS.service_details.change_line_format_in_json_panel,
-      {
-        key,
-        type: type,
-      }
-    );
-  };
-
-  /**
-   * Reconstructs the full keyPath even if a line filter is set and the user is currently drilled down into a nested node
-   */
-  private getFullKeyPath(keyPath: ReadonlyArray<string | number>) {
-    const lineFormatVar = getLineFormatVariable(this);
-
-    const fullPathFilters: AdHocFilterWithLabels[] = [
-      ...lineFormatVar.state.filters,
-      ...keyPath
-        // line format filters only store the parent node field names
-        .filter((key) => typeof key === 'string' && !isLogLineField(key) && key !== JsonVizRootName)
-        // keyPath order is from child to root, we want to order from root to child
-        .reverse()
-        // convert to ad-hoc filter
-        .map((nodeKey) => ({
-          key: nodeKey.toString(),
-          // The operator and value are not used when interpolating the variable, but empty values will cause the ad-hoc filter to get removed from the URL state, we work around this by adding an empty space for the value and operator
-          // we could store the depth of the node as a value, right now we assume that these filters always include every parent node of the current node, ordered by node depth ASC (root node first)
-          operator: LineFormatFilterOp.Empty,
-          value: EMPTY_AD_HOC_FILTER_VALUE,
-        })),
-    ];
-
-    // the last 3 in the key path are always array
-    const fullKeyPath = [...fullPathFilters.map((filter) => filter.key).reverse(), ...keyPath.slice(-3)];
-    return { fullKeyPath, fullPathFilters };
-  }
-
   private addFilter = (key: string, value: string, filterType: FilterType, variableType: InterpolatedFilterType) => {
     addCurrentUrlToHistory();
     const logsListScene = sceneGraph.getAncestor(this, LogsListScene);
@@ -443,6 +318,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
   };
 
   /**
+   * @todo externalize
    * Adds a fields filter and JSON parser props on viz interaction
    */
   private addJsonFilter: AddJSONFilter = (keyPath: KeyPath, key: string, value: string, filterType: FilterType) => {
@@ -477,7 +353,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
    * Gets re-root button and key label for root node when line format filter is active.
    * aka breadcrumbs
    */
-  public renderNestedNodeButtons = (keyPath: KeyPath, jsonFiltersSupported?: boolean) => {
+  public renderNestedNodeButtons = () => {
     const lineFormatVar = getLineFormatVariable(this);
     const filters = lineFormatVar.state.filters;
     const rootKeyPath = [JsonDataFrameLineName, 0, JsonVizRootName];
@@ -487,13 +363,13 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
         <span className={drillUpWrapperStyle} key={JsonVizRootName}>
           <Button
             size={'sm'}
-            onClick={() => jsonFiltersSupported && this.setNewRootNode(rootKeyPath)}
+            onClick={() => setNewRootNode(rootKeyPath, this)}
             variant={'secondary'}
             fill={'outline'}
             disabled={!filters.length}
-            name={keyPath[0].toString()}
+            name={JsonVizRootName}
           >
-            {this.getKeyPathString(keyPath, filters.length ? '' : ':')}
+            {JsonVizRootName}
           </Button>
           {filters.length > 0 && <Icon className={breadCrumbDelimiter} name={'angle-right'} />}
         </span>
@@ -506,7 +382,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
                 <Button
                   size={'sm'}
                   disabled={selected}
-                  onClick={() => jsonFiltersSupported && this.addDrillUp(filter.key)}
+                  onClick={() => addDrillUp(filter.key, this)}
                   variant={'secondary'}
                   fill={'outline'}
                 >
@@ -536,7 +412,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
     lineFilters: AdHocFilterWithLabels[],
     jsonFiltersSupported?: boolean
   ) => {
-    const { fullKeyPath } = this.getFullKeyPath(keyPath);
+    const { fullKeyPath } = getFullKeyPath(keyPath, this);
     const fullKey = getJsonKey(fullKeyPath);
     const jsonParserProp = jsonParserPropsMap.get(fullKey);
     const existingFilter =
@@ -552,7 +428,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
       <span className={jsonLabelWrapStyles}>
         {jsonFiltersSupported && (
           <>
-            <ReRootJSONButton keyPath={keyPath} setNewRootNode={this.setNewRootNode} />
+            <ReRootJSONButton keyPath={keyPath} sceneRef={this} />
             <JSONFilterNestedNodeButton
               type={'include'}
               jsonKey={fullKey}
@@ -598,7 +474,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
     }
 
     if (existingVariableType === VAR_FIELDS) {
-      const { fullKeyPath } = this.getFullKeyPath(keyPath);
+      const { fullKeyPath } = getFullKeyPath(keyPath, this);
       const fullKey = getJsonKey(fullKeyPath);
       const jsonParserProp = jsonParserPropsMap.get(fullKey);
       const existingJsonFilter =

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -42,6 +42,7 @@ import { IndexScene } from '../IndexScene/IndexScene';
 import { getPanelWrapperStyles, PanelMenu } from '../Panels/PanelMenu';
 import { addToFilters, FilterType } from './Breakdowns/AddToFiltersButton';
 import { CopyLinkButton } from './CopyLinkButton';
+import JsonRootNodeNavigation from './JSONPanel/JsonRootNodeNavigation';
 import { LogOptionsScene } from './LogOptionsScene';
 import { LogsListScene } from './LogsListScene';
 import { LogsPanelError } from './LogsPanelError';
@@ -360,7 +361,20 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         .setOption('detailsMode', 'sidebar');
     }
 
-    return panel.build();
+    const vizPanel = panel.build();
+    vizPanel.setState({
+      titleItems: (
+        <JsonRootNodeNavigation
+          sceneRef={this}
+          showEndingSeparator={false}
+          hideIfEmpty={true}
+          forceRender={true}
+          maxWidth={`calc(100vw - 320px);`}
+        />
+      ),
+    });
+
+    return vizPanel;
   };
 
   private handleLogOptionsChange = (option: keyof Options, value: string | string[] | boolean) => {

--- a/src/services/JSONViz.ts
+++ b/src/services/JSONViz.ts
@@ -38,7 +38,10 @@ export const jsonLabelWrapStylesPrimary = css({
 export const drillUpWrapperStyle = css({
   alignItems: 'center',
   display: 'flex',
-  overflowX: 'auto',
+});
+export const drillUpContainerStyle = css({
+  display: 'flex',
+  alignItems: 'center',
 });
 export const breadCrumbDelimiter = css({
   marginLeft: '0.5em',


### PR DESCRIPTION
This is a few hacks inside of a trench coat, but every other solution I could come up with required moving the json breadcrumbs outside of the panels, which I liked even less.

JSON root navigation component inside the JSON viz:
<img width="861" height="564" alt="image" src="https://github.com/user-attachments/assets/32866fe8-ac24-4bb3-acbe-00e8fb325356" />

JSON root navigation component inside the logs panel:
<img width="855" height="555" alt="image" src="https://github.com/user-attachments/assets/ce43d07b-ac5e-4d03-9634-4bb65d6c625c" />

We should probably add it within the table as well, although setting a different root only impacts the logs table if the log text toggle is active and the line field is visible, otherwise the normal column/fields display is not impacted when a different root is selected.