### PR TITLE
fix(table): fix overflow with docked nav

### DIFF
--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -111,6 +111,7 @@ const getStyles = (theme: GrafanaTheme2, height: number, sideBarWidth: number) =
   wrapper: css({
     display: 'flex',
     position: 'relative',
+    flexWrap: 'wrap',
   }),
 });
 
@@ -138,6 +139,7 @@ function TableAndContext(props: {
 
 export const Table = (props: Props) => {
   const { height, labels, logsFrame, timeZone, width } = props;
+
   const theme = useTheme2();
 
   const [tableFrame, setTableFrame] = useState<DataFrame | undefined>(undefined);


### PR DESCRIPTION
Apparently when the menu is docked resizing would push out the whole page.

https://github.com/user-attachments/assets/3f8acb90-e24b-4ddf-99c2-9105369df897

Fixed

https://github.com/user-attachments/assets/92c8fb6a-2b3a-478f-b0be-80309ebba9f2

