### PR TITLE
docs: Add links to videos on Logs Drilldown

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -49,3 +49,8 @@ To take a tour of Grafana Logs Drilldown, follow these steps:
 1. Select the **Fields** tab to see visualizations of the log volume for each field. To drill down into the details in the same way as labels, click the **Select** button for one of the fields.
 1. Click the **Patterns** tab to see the log volume for each automatically detected pattern.
    Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful. Learn more about [Log Patterns](../patterns/).
+
+## Further resources
+
+- Watch: [How to Use the Logs Drilldown App for Grafana](https://www.youtube.com/watch?v=eXwE2vqLcyY)
+- Watch: [All About Logs Drilldown for Grafana Loki](https://www.youtube.com/live/XJMQbEuBeMc) (Loki Community Call October 2024)


### PR DESCRIPTION
I added links to the docs for recent videos I've created on the Grafana YouTube channel about Logs Drilldown in a "Further resources" section.