### PR TITLE
fix(LogsPanel): visible range and panel improvements

### DIFF
--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -61,6 +61,7 @@ interface LogsPanelSceneState extends SceneObjectState {
   error?: string;
   logsVolumeCollapsedByError?: boolean;
   prettifyLogMessage: boolean;
+  series: DataFrame[];
   sortOrder: LogsSortOrder;
   wrapLogMessage: boolean;
 }
@@ -77,6 +78,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
       prettifyLogMessage: getBooleanLogOption('prettifyLogMessage', false),
       sortOrder: getLogOption<LogsSortOrder>('sortOrder', LogsSortOrder.Descending),
       wrapLogMessage: getBooleanLogOption('wrapLogMessage', false),
+      series: [],
       ...state,
     });
 
@@ -385,16 +387,9 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
       logsCount: newLogs[0].length,
     });
 
-    if (serviceScene.state.$data?.state.data?.series) {
-      // We need to update the state with the new data without triggering state-dependent changes.
-      serviceScene.state.$data.setState({
-        ...serviceScene.state.$data.state,
-        data: {
-          ...serviceScene.state.$data.state.data,
-          series: newLogs,
-        },
-      });
-    }
+    this.setState({
+      series: newLogs,
+    });
 
     const logsVolumeScene = sceneGraph.findByKeyAndType(this, logsVolumePanelKey, LogsVolumePanel);
     logsVolumeScene.updateVisibleRange(newLogs);

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -355,9 +355,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
             label: 'Copy link to log line',
             onClick: this.handleShareLogLine,
           },
-        ])
-        // @ts-expect-error Requires Grafana 12.2
-        .setOption('detailsMode', 'sidebar');
+        ]);
     }
 
     return panel.build();

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -123,6 +123,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
           }),
         ]),
       });
+      this.subscribeToVisibleRange(panel);
     }
     this.updateContainerHeight(panel);
     setLogsVolumeOption('collapsed', collapsed ? 'true' : undefined);
@@ -165,19 +166,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       })
     );
 
-    this._subs.add(
-      panel.state.$data?.subscribeToState((newState) => {
-        if (newState.data?.state !== LoadingState.Done) {
-          return;
-        }
-        if (serviceScene.state.$data?.state.data?.state === LoadingState.Done && !newState.data.annotations?.length) {
-          this.updateVisibleRange(serviceScene.state.$data?.state.data?.series);
-        } else {
-          this.displayVisibleRange();
-        }
-        syncLevelsVisibleSeries(panel, newState.data.series, this);
-      })
-    );
+    this.subscribeToVisibleRange(panel);
 
     this._subs.add(
       serviceScene.state.$data?.subscribeToState((newState) => {
@@ -204,6 +193,23 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     );
 
     return panel;
+  }
+
+  private subscribeToVisibleRange(panel: VizPanel) {
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    this._subs.add(
+      panel.state.$data?.subscribeToState((newState) => {
+        if (newState.data?.state !== LoadingState.Done) {
+          return;
+        }
+        if (serviceScene.state.$data?.state.data?.state === LoadingState.Done && !newState.data.annotations?.length) {
+          this.updateVisibleRange(serviceScene.state.$data?.state.data?.series);
+        } else {
+          this.displayVisibleRange();
+        }
+        syncLevelsVisibleSeries(panel, newState.data.series, this);
+      })
+    );
   }
 
   public updateContainerHeight(panel: VizPanel) {


### PR DESCRIPTION
- No longer passing `displayMode` so it uses the default value or the stored preference (requires https://github.com/grafana/grafana/pull/108065)
- Fixed visible range when Logs Volume was collapsed
- Removed internal data override when new logs are received from infinite scrolling, which was causing a scroll jump in the new panel

Besides these changes, the current behavior should match the behavior in main minus the bugs.

Part of https://github.com/grafana/grafana/issues/99075

### Before

https://github.com/user-attachments/assets/a7eb9501-8f47-4f96-90f0-f0bc70d3df1d

### After

https://github.com/user-attachments/assets/cd1a0273-f50d-4a81-8f4e-c2dc3c914bfb
