### PR TITLE
chore(JSON): only calculate line filter matches if highlighting is enabled

### DIFF
--- a/src/Components/ServiceScene/JSONPanel/ValueRenderer.tsx
+++ b/src/Components/ServiceScene/JSONPanel/ValueRenderer.tsx
@@ -25,16 +25,16 @@ export default function ValueRenderer({ keyPath, lineFilters, valueAsString, mod
     return null;
   }
 
-  if (hasValidParentNode(keyPath)) {
-    let valueArray = highlightLineFilterMatches(lineFilters, value);
-
-    // If we have highlight matches we won't show syntax highlighting
-    if (valueArray.length) {
-      return valueArray;
-    }
-  }
-
   if (model.state.showHighlight) {
+    if (hasValidParentNode(keyPath)) {
+      let valueArray = highlightLineFilterMatches(lineFilters, value);
+
+      // If we have highlight matches we won't show syntax highlighting
+      if (valueArray.length) {
+        return valueArray;
+      }
+    }
+
     // Check syntax highlighting results
     let highlightedResults: Array<string | React.JSX.Element> = [];
     Object.keys(logsSyntaxMatches).some((key) => {

--- a/src/Components/ServiceScene/LogsJsonScene.tsx
+++ b/src/Components/ServiceScene/LogsJsonScene.tsx
@@ -444,7 +444,9 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
       );
 
     let highlightedValue: string | Array<string | React.JSX.Element> = [];
-    highlightedValue = highlightLineFilterMatches(lineFilters, keyPath[0].toString());
+    if (this.state.showHighlight) {
+      highlightedValue = highlightLineFilterMatches(lineFilters, keyPath[0].toString());
+    }
 
     return (
       <span className={jsonLabelWrapStyles}>
@@ -491,7 +493,7 @@ export class LogsJsonScene extends SceneObjectBase<LogsJsonSceneState> {
     const existingVariableType = this.getFilterVariableTypeFromPath(keyPath);
 
     let highlightedValue: string | Array<string | React.JSX.Element> = [];
-    if (hasValidParentNode(keyPath)) {
+    if (this.state.showHighlight && hasValidParentNode(keyPath)) {
       highlightedValue = highlightLineFilterMatches(lineFilters, keyPath[0].toString());
     }
 

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -323,11 +323,17 @@ test.describe('explore nginx-json breakdown pages ', () => {
     test('line filters wrap matches in mark tag', async ({ page }) => {
       await explorePage.goToLogsTab();
       await explorePage.getJsonToggleLocator().click();
+
       // Highlight method (json label) and PATCH (json value)
       await page.getByTestId(testIds.exploreServiceDetails.searchLogs).fill('method');
       await page.getByRole('button', { exact: true, name: 'Include' }).click();
       await explorePage.assertTabsNotLoading();
       await explorePage.assertPanelsNotLoading();
+
+      // Should not be visible until highlighting is clicked
+      await expect(page.locator('mark', { hasText: 'method' })).toHaveCount(0);
+      // Enable highlighting
+      await page.getByRole('button', { name: 'Enable highlighting' }).click();
       await expect(page.locator('mark', { hasText: 'method' }).first()).toBeVisible();
     });
 


### PR DESCRIPTION
Only calculates line filter matches when highlighting is toggled.

Fixes: https://github.com/grafana/logs-drilldown/issues/1414

