### PR TITLE
feat(table): column width estimator and toggle logsPanelControls

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,4 @@ yarn.lock
 tsconfig-for-bundle-types.json
 playwright-report/
 **/*.md
+*.yaml

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -4,7 +4,7 @@ services:
   grafana:
     container_name: 'grafana-logsapp'
     environment:
-      - GF_FEATURE_TOGGLES_ENABLE=accessControlOnCall lokiLogsDataplane
+      - GF_FEATURE_TOGGLES_ENABLE=accessControlOnCall lokiLogsDataplane exploreLogsAggregatedMetrics exploreLogsShardSplitting newLogsPanel logsPanelControls
       - GF_LOG_FRONTEND_ENABLED=true
       - GF_LOG_FRONTEND_CUSTOM_ENDPOINT=http://localhost:12347/collect
       - GF_TRACING_OPENTELEMETRY_JAEGER_ADDRESS=http://host.docker.internal:14268/api/traces

--- a/src/Components/ServiceScene/LogListControls.tsx
+++ b/src/Components/ServiceScene/LogListControls.tsx
@@ -9,6 +9,7 @@ import { IconButton, useStyles2 } from '@grafana/ui';
 import { LogLineState } from 'Components/Table/Context/TableColumnsContext';
 
 interface Props {
+  disabledLineState?: boolean;
   lineState?: LogLineState;
   onLineStateClick?(): void;
   onScrollToBottomClick?(): void;
@@ -26,6 +27,7 @@ interface Props {
 }
 
 export const LogListControls = ({
+  disabledLineState,
   lineState,
   onLineStateClick,
   onScrollToBottomClick,
@@ -92,7 +94,7 @@ export const LogListControls = ({
       )}
       {showLabels !== undefined && onToggleLabelsClick && (
         <IconButton
-          name="key-skeleton-alt"
+          name="tag-alt"
           aria-pressed={showLabels}
           className={showLabels ? styles.controlButtonActive : styles.controlButton}
           onClick={() => onToggleLabelsClick(!showLabels)}
@@ -112,7 +114,8 @@ export const LogListControls = ({
       )}
       {onLineStateClick && lineState && (
         <IconButton
-          name={lineState === LogLineState.text ? 'brackets-curly' : 'text-fields'}
+          disabled={disabledLineState}
+          name={lineState === LogLineState.text ? 'tag-alt' : 'text-fields'}
           className={styles.controlButton}
           onClick={onLineStateClick}
           tooltip={lineState === LogLineState.text ? 'Show labels' : 'Show log text'}

--- a/src/Components/Table/LogLineCellComponent.tsx
+++ b/src/Components/Table/LogLineCellComponent.tsx
@@ -153,11 +153,9 @@ export const LogLineCellComponent = (props: Props) => {
           {isAuto && hasLabels && <>{labels}</>}
           {bodyState === LogLineState.labels && hasLabels && <>{labels}</>}
           {bodyState === LogLineState.labels && !hasLabels && <RawLogLineText value={value} />}
-
           {/* Raw log line*/}
           {isAuto && !hasLabels && <RawLogLineText value={value} />}
           {bodyState === LogLineState.text && <RawLogLineText value={value} />}
-
           {isHover && <Scroller scrollerRef={ref} />}
         </div>
       </ScrollSyncPane>

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -107,7 +107,7 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
                 aria-label={'Show log labels'}
                 onClick={onLogTextToggle}
                 className={styles.logLineButton}
-                name={'brackets-curly'}
+                name={'tag-alt'}
                 size={'md'}
               />
             ) : (

--- a/src/Components/Table/LogsTableHeaderWrap.tsx
+++ b/src/Components/Table/LogsTableHeaderWrap.tsx
@@ -21,7 +21,7 @@ export function LogsTableHeaderWrap(props: {
 
   slideRight?: (cols: FieldNameMetaStore) => void;
 }) {
-  const { bodyState, columns, setBodyState, setColumns } = useTableColumnContext();
+  const { bodyState, columns, setBodyState, setColumns, columnWidthMap, setColumnWidthMap } = useTableColumnContext();
   const { logsFrame } = useQueryContext();
   const styles = getStyles();
   const { linkButton } = useSharedStyles();
@@ -47,8 +47,14 @@ export function LogsTableHeaderWrap(props: {
       pendingColumnState[field.name].active = false;
       pendingColumnState[field.name].index = undefined;
       setColumns(pendingColumnState);
+
+      // Remove the column width from columnWidthMap when hiding the column
+      if (columnWidthMap[field.name] !== undefined) {
+        const { [field.name]: omit, ...updatedColumnWidthMap } = columnWidthMap;
+        setColumnWidthMap(updatedColumnWidthMap);
+      }
     },
-    [columns, setColumns]
+    [columns, setColumns, columnWidthMap, setColumnWidthMap]
   );
 
   const isBodyField = props.headerProps.field.name === getBodyName(logsFrame);

--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -541,6 +541,9 @@ function getInitialFieldWidth(
   // First field gets icons, and a little extra width
   const extraPadding = fieldIndex === 0 ? 50 : 0;
 
+  // Width of the logs panel controls sidebar
+  const logsPanelControls = 35;
+
   // Time fields have consistent widths
   if (field.type === FieldType.time) {
     return 200 + extraPadding;
@@ -557,7 +560,10 @@ function getInitialFieldWidth(
   if (columnMeta.maxLength) {
     // Super rough estimate, about 6.5px per char, and 95px for some space for the header icons (remember when sorted a new icon is added to the table header).
     // I guess to be a little tighter we could only add the extra padding IF the field name is longer then the longest value
-    return Math.min(Math.max(maxLength * 6.5 + 95 + extraPadding, minWidth + extraPadding), maxWidth);
+    return Math.min(
+      Math.max(maxLength * 6.5 + 95 + logsPanelControls + extraPadding, minWidth + extraPadding),
+      maxWidth
+    );
   }
 
   if (field.name === getBodyName(logsFrame)) {
@@ -566,7 +572,7 @@ function getInitialFieldWidth(
 
   // Just derived fields, which should have uniform length
   return Math.min(
-    Math.max((field.values?.[0]?.length ?? 80) * 6.5 + 95 + extraPadding, minWidth + extraPadding),
+    Math.max((field.values?.[0]?.length ?? 80) * 6.5 + 95 + logsPanelControls + extraPadding, minWidth + extraPadding),
     maxWidth
   );
 }


### PR DESCRIPTION
- #1399  

- Disable the labels/show raw log line button if the Log Line column is not visualized.

https://github.com/user-attachments/assets/208be83d-5849-447e-8728-a1978aca7d7e



- Updated the Column width estimator isn't taking the new icons into effect. Also removed columns from the columnWidthMap on hide. Not sure we want that change, but it took me a while to realize that was skipping the `getInitialFieldWidth` function.
<img width="513" height="236" alt="Screenshot 2025-07-16 at 12 01 35 PM" src="https://github.com/user-attachments/assets/1ff25ef4-fdd5-4f3e-9a0b-5304ac75e58b" />
