### PR TITLE
feat(LogsPanel): customize interaction reporting and add storage key for patterns

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsLogsSampleScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsLogsSampleScene.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../../services/variables';
 import { emptyStateStyles } from '../FieldsBreakdownScene';
 import { PatternsViewTableScene } from './PatternsViewTableScene';
+import { LOG_OPTIONS_PATTERNS_LOCALSTORAGE_KEY } from 'services/store';
 
 interface PatternsLogsSampleSceneState extends SceneObjectState {
   body?: SceneFlexLayout;
@@ -69,6 +70,10 @@ export class PatternsLogsSampleScene extends SceneObjectBase<PatternsLogsSampleS
               .setHoverHeader(true)
               .setOption('showLogContextToggle', true)
               .setOption('showTime', true)
+              // @ts-expect-error Requires Grafana 12.2
+              .setOption('noInteractions', true)
+              // @ts-expect-error Requires Grafana 12.1
+              .setOption('controlsStorageKey', LOG_OPTIONS_PATTERNS_LOCALSTORAGE_KEY)
               .setData(queryRunnerWithFilters)
               .build(),
             height: 300,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -570,6 +570,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setOption('enableLogDetails', false)
         // @ts-expect-error Requires Grafana 12.2
         .setOption('fontSize', 'small')
+        // @ts-expect-error Requires Grafana 12.2
+        .setOption('noInteractions', true)
         .build(),
     });
 

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -231,6 +231,7 @@ export function setDedupStrategy(sceneRef: SceneObject, strategy: LogsDedupStrat
 
 // Log panel options
 export const LOG_OPTIONS_LOCALSTORAGE_KEY = `grafana.explore.logs`;
+export const LOG_OPTIONS_PATTERNS_LOCALSTORAGE_KEY = `grafana.explore.logs.patterns`;
 export function getLogOption<T>(option: keyof Options, defaultValue: T): T {
   const localStorageResult = localStorage.getItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`);
   // TODO: narrow stored value


### PR DESCRIPTION
Requires https://github.com/grafana/grafana/pull/108272
Part of https://github.com/grafana/grafana/issues/99075

- Excluded landing page and patterns from reporting interactions
- Added a custom key for the pattern logs, so that users can have different settings between these