### PR TITLE
chore(cd): publish auto update deployment tools prod version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,8 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       attestation: true
       run-playwright: false
+
+      # Auto merge to prod in deployment tools
+      grafana-cloud-deployment-type: provisioned
+      auto-merge-environments: prod
+      argo-workflow-slack-channel: '#drilldown-cd-alerts-dev-ops'


### PR DESCRIPTION
Auto update prod deployment tools version in the publish.yml cd workflow. Basically when we publish a new version to prod, we'd like the deployment tools prs to automatically be created and merged. I'm following the configuration for auto updating deployment tools from our ci job that updates dev an ops https://github.com/grafana/logs-drilldown/blob/main/.github/workflows/pr-ci.yml#L26. Let me know if this is possible for prod, from the code it looked to be supported, thanks!