### PR TITLE
fix(ServiceSelection): reset service selection after changing data source

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -15,10 +15,3 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            # Commit types omitted from changelogs
-            omit
-            internal
-            chore
-            skip

--- a/.versionrc.js
+++ b/.versionrc.js
@@ -1,9 +1,0 @@
-// Commit types omitted from changelogs
-module.exports = {
-  types: [
-    { type: 'omit', section: 'Omitted', hidden: true },
-    { type: 'internal', section: 'Internal', hidden: true },
-    { type: 'chore', section: 'Chores', hidden: true },
-    { type: 'skip', section: 'Skipped', hidden: true },
-  ],
-};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,3 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  rules: {
-    // Commit types omitted from changelogs
-    'type-enum': [2, 'always', ['omit', 'internal', 'chore', 'skip']],
-  },
 };

--- a/src/Components/IndexScene/ToolbarScene.tsx
+++ b/src/Components/IndexScene/ToolbarScene.tsx
@@ -34,7 +34,7 @@ export class ToolbarScene extends SceneObjectBase<ToolbarSceneState> {
         aggregatedMetrics: {
           active: active ?? false,
           disabled: false,
-          userOverride: userOverride === 'true' ?? false,
+          userOverride: userOverride === 'true',
         },
       },
       ...state,

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -715,8 +715,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
           this.setState({
             body: new SceneCSSGridLayout({ children: [] }),
           });
-          // And re-init with the new query
-          this.updateBody(true);
         }
       })
     );

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -711,7 +711,12 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     this._subs.add(
       getAggregatedMetricsVariable(this).subscribeToState((newState, prevState) => {
         if (newState.value !== prevState.value) {
-          this.resetBody();
+          // Clear the body panels
+          this.setState({
+            body: new SceneCSSGridLayout({ children: [] }),
+          });
+          // And re-init with the new query
+          this.updateBody(true);
         }
       })
     );
@@ -770,19 +775,12 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const dsVariable = getDataSourceVariable(this);
     this._subs.add(
       dsVariable.subscribeToState(() => {
-        this.resetBody();
+        this.setState({
+          body: new SceneCSSGridLayout({ children: [] }),
+        });
       })
     );
   }
-
-  private resetBody = () => {
-    // Clear the body panels
-    this.setState({
-      body: new SceneCSSGridLayout({ children: [] }),
-    });
-    // And re-init with the new query
-    this.updateBody(true);
-  };
 
   /**
    * If the user copies a partial URL we want to prevent throwing runtime errors or running invalid queries, so we set the default tab which will trigger updates to the primary_label

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -448,10 +448,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     primaryLabelVar: AdHocFiltersVariable,
     datasourceVar: DataSourceVariable
   ) {
-    let splitDuration;
-    if (timeRange.to.diff(timeRange.from, 'hours') >= 4 && timeRange.to.diff(timeRange.from, 'hours') <= 26) {
-      splitDuration = '2h';
-    }
     const headerActions = [];
 
     if (this.isAggregatedMetricsActive()) {
@@ -474,7 +470,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
             buildDataQuery(this.getMetricExpression(primaryLabelValue, serviceLabelVar, primaryLabelVar), {
               legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
               refId: `ts-${primaryLabelValue}`,
-              splitDuration,
               step: serviceLabelVar.state.value === AGGREGATED_SERVICE_NAME ? '10s' : undefined,
             }),
           ],

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -647,8 +647,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     this.subscribeToAggregatedMetricToggle();
 
     this.subscribeToAggregatedMetricVariable();
-
-    this.subscribeToDataSourceChanges();
   }
 
   private runVolumeOnActivate() {
@@ -678,6 +676,9 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
   private subscribeToDatasource() {
     this._subs.add(
       getDataSourceVariable(this).subscribeToState((newState) => {
+        this.setState({
+          body: new SceneCSSGridLayout({ children: [] }),
+        });
         this.addDatasourceChangeToBrowserHistory(newState.value.toString());
         this.runVolumeQuery();
       })
@@ -767,17 +768,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
           this.onSupportedAggregatedMetricTimeRange();
         }
         this.runVolumeQuery();
-      })
-    );
-  }
-
-  private subscribeToDataSourceChanges() {
-    const dsVariable = getDataSourceVariable(this);
-    this._subs.add(
-      dsVariable.subscribeToState(() => {
-        this.setState({
-          body: new SceneCSSGridLayout({ children: [] }),
-        });
       })
     );
   }

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -715,6 +715,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
           this.setState({
             body: new SceneCSSGridLayout({ children: [] }),
           });
+          // And re-init with the new query
+          this.updateBody(true);
         }
       })
     );

--- a/src/services/lokiQuery.ts
+++ b/src/services/lokiQuery.ts
@@ -20,7 +20,6 @@ export type LokiQuery = {
   maxLines?: number;
   queryType?: LokiQueryType;
   refId: string;
-  splitDuration?: string;
   step?: string;
   supportingQueryType?: string;
 };


### PR DESCRIPTION
The Service Selection scene has logic to reuse existing panels, which was causing panels to be reused when switching data sources, which had the unintended consequence of not updating them when the data source changes. https://github.com/grafana/logs-drilldown/blob/main/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx#L948

Example:

https://github.com/user-attachments/assets/743c4d92-d938-4e30-9485-b8b922ba113d

After these changes, we'll reset the layout when the data source is changed.

Additionally:
- The "splitDuration" experimental attribute has been removed.
- Fixed non-nullish conditional.
- Reverted [conventional commits change](https://github.com/grafana/logs-drilldown/pull/1442) preventing commits and failing in CI.