### PR TITLE
fix(serviceSelection): despect displayed fields if previously set

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -76,7 +76,12 @@ import {
   unwrapWildcardSearch,
   wrapWildcardSearch,
 } from 'services/query';
-import { addTabToLocalStorage, getFavoriteLabelValuesFromStorage, getServiceSelectionPageCount } from 'services/store';
+import {
+  addTabToLocalStorage,
+  getDisplayedFieldsForLabelValue,
+  getFavoriteLabelValuesFromStorage,
+  getServiceSelectionPageCount,
+} from 'services/store';
 import {
   EXPLORATION_DS,
   LEVEL_VARIABLE_VALUE,
@@ -562,6 +567,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setOption('showTime', true)
         .setOption('enableLogDetails', false)
         .setOption('fontSize', 'small')
+        .setOption('displayedFields', getDisplayedFieldsForLabelValue(this, labelName, labelValue))
         // @ts-expect-error Requires Grafana 12.2
         .setOption('noInteractions', true)
         .build(),

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -6,11 +6,13 @@ import { Options } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x
 import { AvgFieldPanelType, CollapsablePanelText } from '../Components/Panels/PanelMenu';
 import { SortBy, SortDirection } from '../Components/ServiceScene/Breakdowns/SortByScene';
 import pluginJson from '../plugin.json';
+import { replaceSlash } from './extensions/links';
 import { isDedupStrategy } from './guards';
 import { logger } from './logger';
 import { unknownToStrings } from './narrowing';
-import { getDataSourceName, getServiceName } from './variableGetters';
-import { SERVICE_NAME } from './variables';
+import { getRouteParams } from './routing';
+import { getDataSourceName } from './variableGetters';
+import { SERVICE_NAME, SERVICE_UI_LABEL } from './variables';
 
 const FAVORITE_PRIMARY_LABEL_VALUES_LOCALSTORAGE_KEY = `${pluginJson.id}.services.favorite`;
 const FAVORITE_PRIMARY_LABEL_NAME_LOCALSTORAGE_KEY = `${pluginJson.id}.primarylabels.tabs.favorite`;
@@ -196,9 +198,25 @@ export function setSortByPreference(target: string, sortBy: string, direction: s
 }
 
 function getExplorationPrefix(sceneRef: SceneObject) {
+  const { labelName, labelValue } = getRouteParams(sceneRef);
+  return getExplorationPrefixForlabelValue(sceneRef, labelName, labelValue);
+}
+
+function getExplorationPrefixForlabelValue(sceneRef: SceneObject, label: string, value: string) {
   const ds = getDataSourceName(sceneRef);
-  const serviceName = getServiceName(sceneRef);
-  return `${ds}.${serviceName}`;
+  if (label === SERVICE_NAME || label === SERVICE_UI_LABEL) {
+    return `${ds}.${replaceSlash(value)}`;
+  }
+  return `${ds}.${label}.${replaceSlash(value)}`;
+}
+
+export function getDisplayedFieldsForLabelValue(sceneRef: SceneObject, label: string, value: string): string[] {
+  const PREFIX = getExplorationPrefixForlabelValue(sceneRef, label, value);
+  const storedFields = localStorage.getItem(`${pluginJson.id}.${PREFIX}.logs.fields`);
+  if (storedFields) {
+    return unknownToStrings(JSON.parse(storedFields)) ?? [];
+  }
+  return [];
 }
 
 export function getDisplayedFields(sceneRef: SceneObject): string[] {

--- a/src/services/variableGetters.ts
+++ b/src/services/variableGetters.ts
@@ -271,11 +271,6 @@ export function getValueFromAdHocVariableFilter(
   };
 }
 
-export function getServiceName(scene: SceneObject) {
-  const labelsVariable = getLabelsVariable(scene);
-  return getServiceNameFromVariableState(labelsVariable.state);
-}
-
 export function getServiceNameFromVariableState(
   adHocFiltersVariableState: SceneVariableState & { filters: AdHocVariableFilter[] }
 ) {


### PR DESCRIPTION
This PR updates the service selection panel to use the displayed fields settings if they were previously set in the service details page.

How to test:
- Browse a service
- Set displayed fields
- Return to the service selection
- Displayed fields for the label/value pair should be respected*

Additionally, fixed the storage key when using a label other than service.

* It currently seems to require a refresh in the service selection page due to scene caching.