### PR TITLE
feat(assistant-context): provide datasource and labels as context to Assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@bsull/augurs": "^0.6.0",
     "@emotion/css": "11.10.6",
-    "@grafana/assistant": "^0.0.7",
+    "@grafana/assistant": "^0.0.11",
     "@grafana/data": "^12.1.0",
     "@grafana/i18n": "^12.1.0",
     "@grafana/lezer-logql": "^0.2.7",

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -322,16 +322,10 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
   private provideAssistantContext() {
     const setAssistantContext = providePageContext(`${PLUGIN_BASE_URL}/**`, []);
-    const updateAssistantContext = () => {
+    const updateAssistantContext = async () => {
       const contexts = [];
 
-      const dsVar = getDataSourceVariable(this);
-      const ds = getDataSourceSrv()
-        .getList({
-          type: 'loki',
-        })
-        .find((ds) => ds.uid === dsVar.state.value.toString());
-
+      const ds = await getLokiDatasource(this);
       if (!ds) {
         return;
       }
@@ -362,13 +356,13 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     };
 
     this._subs.add(
-      getDataSourceVariable(this).subscribeToState(() => {
-        updateAssistantContext();
+      getDataSourceVariable(this).subscribeToState(async () => {
+        await updateAssistantContext();
       })
     );
     this._subs.add(
-      getLabelsVariable(this).subscribeToState(() => {
-        updateAssistantContext();
+      getLabelsVariable(this).subscribeToState(async () => {
+        await updateAssistantContext();
       })
     );
     this.assistantInitialized = true;

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -7,7 +7,7 @@ import {
   isAssistantAvailable,
 } from '@grafana/assistant';
 import { AdHocVariableFilter, AppEvents, AppPluginMeta, rangeUtil, urlUtil } from '@grafana/data';
-import { config, getAppEvents, getDataSourceSrv, locationService } from '@grafana/runtime';
+import { config, getAppEvents, locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   AdHocFilterWithLabels,

--- a/src/services/assistant.test.ts
+++ b/src/services/assistant.test.ts
@@ -1,0 +1,175 @@
+import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
+
+import { updateAssistantContext } from './assistant';
+import { FilterOp } from './filterTypes';
+import { getLokiDatasource } from './scenes';
+import { getLabelsVariable } from './variableGetters';
+import { VAR_LABELS } from './variables';
+
+jest.mock('./scenes');
+jest.mock('./variableGetters');
+
+const mockGetLokiDatasource = getLokiDatasource as jest.MockedFunction<typeof getLokiDatasource>;
+const mockGetLabelsVariable = getLabelsVariable as jest.MockedFunction<typeof getLabelsVariable>;
+
+describe('assistant', () => {
+  let mockModel: SceneObject;
+  let mockSetAssistantContext: jest.MockedFunction<any>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockModel = {} as SceneObject;
+    mockSetAssistantContext = jest.fn();
+  });
+
+  describe('updateAssistantContext', () => {
+    it('should return early when datasource is not available', async () => {
+      mockGetLokiDatasource.mockResolvedValue(undefined);
+
+      await updateAssistantContext(mockModel, mockSetAssistantContext);
+
+      expect(mockGetLokiDatasource).toHaveBeenCalledWith(mockModel);
+      expect(mockSetAssistantContext).not.toHaveBeenCalled();
+      expect(mockGetLabelsVariable).not.toHaveBeenCalled();
+    });
+
+    it('should create datasource context when datasource is available but no label filters', async () => {
+      const mockDatasource = {
+        name: 'test-loki',
+        uid: 'loki-uid-123',
+        type: 'loki',
+      };
+
+      const mockLabelsVariable = new AdHocFiltersVariable({
+        name: VAR_LABELS,
+        filters: [],
+      });
+
+      mockGetLokiDatasource.mockResolvedValue(mockDatasource as any);
+      mockGetLabelsVariable.mockReturnValue(mockLabelsVariable);
+
+      await updateAssistantContext(mockModel, mockSetAssistantContext);
+
+      expect(mockGetLokiDatasource).toHaveBeenCalledWith(mockModel);
+      expect(mockGetLabelsVariable).toHaveBeenCalledWith(mockModel);
+      expect(mockSetAssistantContext).toHaveBeenCalledWith([
+        expect.objectContaining({
+          node: expect.objectContaining({
+            data: expect.objectContaining({
+              datasourceName: 'test-loki',
+              datasourceUid: 'loki-uid-123',
+              datasourceType: 'loki',
+            }),
+          }),
+        }),
+      ]);
+    });
+
+    it('should create datasource context and label value contexts when filters are present', async () => {
+      const mockDatasource = {
+        name: 'test-loki',
+        uid: 'loki-uid-123',
+        type: 'loki',
+      };
+
+      const mockLabelsVariable = new AdHocFiltersVariable({
+        name: VAR_LABELS,
+        filters: [
+          { key: 'service', value: 'frontend', operator: FilterOp.Equal },
+          { key: 'environment', value: 'production', operator: FilterOp.Equal },
+        ],
+      });
+
+      mockGetLokiDatasource.mockResolvedValue(mockDatasource as any);
+      mockGetLabelsVariable.mockReturnValue(mockLabelsVariable);
+
+      await updateAssistantContext(mockModel, mockSetAssistantContext);
+
+      expect(mockGetLokiDatasource).toHaveBeenCalledWith(mockModel);
+      expect(mockGetLabelsVariable).toHaveBeenCalledWith(mockModel);
+
+      expect(mockSetAssistantContext).toHaveBeenCalledWith([
+        expect.objectContaining({
+          node: expect.objectContaining({
+            data: expect.objectContaining({
+              datasourceName: 'test-loki',
+              datasourceUid: 'loki-uid-123',
+              datasourceType: 'loki',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          node: expect.objectContaining({
+            data: expect.objectContaining({
+              datasourceUid: 'loki-uid-123',
+              datasourceType: 'loki',
+              labelName: 'service',
+              labelValue: 'frontend',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          node: expect.objectContaining({
+            data: expect.objectContaining({
+              datasourceUid: 'loki-uid-123',
+              datasourceType: 'loki',
+              labelName: 'environment',
+              labelValue: 'production',
+            }),
+          }),
+        }),
+      ]);
+    });
+
+    it('should handle single label filter correctly', async () => {
+      const mockDatasource = {
+        name: 'single-loki',
+        uid: 'single-uid',
+        type: 'loki',
+      };
+
+      const mockLabelsVariable = {
+        state: {
+          filters: [{ key: 'app', value: 'api-server' }],
+        },
+      } as AdHocFiltersVariable;
+
+      mockGetLokiDatasource.mockResolvedValue(mockDatasource as any);
+      mockGetLabelsVariable.mockReturnValue(mockLabelsVariable);
+
+      await updateAssistantContext(mockModel, mockSetAssistantContext);
+
+      expect(mockSetAssistantContext).toHaveBeenCalledWith([
+        expect.objectContaining({
+          node: expect.objectContaining({
+            data: expect.objectContaining({
+              datasourceName: 'single-loki',
+              datasourceUid: 'single-uid',
+              datasourceType: 'loki',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          node: expect.objectContaining({
+            data: expect.objectContaining({
+              datasourceUid: 'single-uid',
+              datasourceType: 'loki',
+              labelName: 'app',
+              labelValue: 'api-server',
+            }),
+          }),
+        }),
+      ]);
+    });
+
+    it('should handle null datasource gracefully', async () => {
+      mockGetLokiDatasource.mockResolvedValue(null as any);
+
+      await updateAssistantContext(mockModel, mockSetAssistantContext);
+
+      expect(mockGetLokiDatasource).toHaveBeenCalledWith(mockModel);
+      expect(mockSetAssistantContext).not.toHaveBeenCalled();
+      expect(mockGetLabelsVariable).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/assistant.ts
+++ b/src/services/assistant.ts
@@ -1,0 +1,41 @@
+import { createContext as createAssistantContext, ItemDataType, providePageContext } from '@grafana/assistant';
+import { SceneObject } from '@grafana/scenes';
+
+import { getLokiDatasource } from './scenes';
+import { getLabelsVariable } from './variableGetters';
+
+export const updateAssistantContext = async (
+  model: SceneObject,
+  setAssistantContext: ReturnType<typeof providePageContext>
+) => {
+  const contexts = [];
+
+  const ds = await getLokiDatasource(model);
+  if (!ds) {
+    return;
+  }
+
+  contexts.push(
+    createAssistantContext(ItemDataType.Datasource, {
+      datasourceName: ds.name,
+      datasourceUid: ds.uid,
+      datasourceType: ds.type,
+    })
+  );
+
+  const labelsVar = getLabelsVariable(model);
+  if (labelsVar.state.filters.length > 0) {
+    contexts.push(
+      ...labelsVar.state.filters.map((filter) =>
+        createAssistantContext(ItemDataType.LabelValue, {
+          datasourceUid: ds.uid,
+          datasourceType: ds.type,
+          labelName: filter.key,
+          labelValue: filter.value,
+        })
+      )
+    );
+  }
+
+  setAssistantContext(contexts);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,10 +1126,10 @@
   dependencies:
     tslib "^2.8.0"
 
-"@grafana/assistant@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@grafana/assistant/-/assistant-0.0.7.tgz#3dcdcf414ab1828573f6d0e665bc2f8b884f1a28"
-  integrity sha512-rU339vKDVzqwrYRZE0OX1H5OJvw/nA+fLYB5BK0E5vkxu8PEX9G1SYvVLeGyPmtnoAJAWLNnzKtJXih5bgyQBw==
+"@grafana/assistant@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@grafana/assistant/-/assistant-0.0.11.tgz#5166f633b35107fd605c81c3e37a5491e77b9b71"
+  integrity sha512-3Ejdscc2Y+jdAWTNH9SOmcZtd5RzirNZE149xTVCxeLkIUU6802xLn21qpJsrWe1rdgMRGFUCewYnt0imymtnQ==
 
 "@grafana/data@12.1.0", "@grafana/data@^12.1.0":
   version "12.1.0"
@@ -9988,16 +9988,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10111,14 +10102,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11137,7 +11121,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11150,15 +11134,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This pull request introduces updates to integrate into the Grafana Assistant plugin. It uses `@grafana/assistant`'s `providePageContext` method to automatically provide the selected data source and selected label selectors in the Assistant's context:


https://github.com/user-attachments/assets/543ff874-2e41-4cdb-9ab6-e6ebbe3b8a67


