### PR TITLE
feat(Patterns): filter by level

### DIFF
--- a/docker-compose-syslog.dev.yaml
+++ b/docker-compose-syslog.dev.yaml
@@ -20,7 +20,7 @@ services:
       - 'host.docker.internal:host-gateway'
 
   loki:
-    image: grafana/loki:main-c40053a
+    image: grafana/loki:k263-d446d47
     environment:
       LOG_CLUSTER_DEPTH: '8'
       LOG_SIM_TH: '0.3'

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -19,7 +19,7 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
   loki:
-    image: grafana/loki:3.5.0
+    image: grafana/loki:k263-d446d47
     environment:
       LOG_CLUSTER_DEPTH: '8'
       LOG_SIM_TH: '0.3'

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -26,7 +26,7 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
   loki:
-    image: grafana/loki:3.5.0
+    image: grafana/loki:k263-d446d47
     environment:
       LOG_CLUSTER_DEPTH: '8'
       LOG_SIM_TH: '0.3'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
   loki:
-    image: grafana/loki:3.5.0
+    image: grafana/loki:k263-d446d47
     environment:
       LOG_CLUSTER_DEPTH: '8'
       LOG_SIM_TH: '0.3'

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -90,7 +90,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
           )}
 
           {!error && !loading && patternFrames?.length === 0 && timeRangeTooOld && <PatternsTooOld />}
-          {!error && !loading && patternFrames?.length === 0 && !timeRangeTooOld && <PatternsNotDetected />}
+          {!error && !loading && !patternFrames && !timeRangeTooOld && <PatternsNotDetected />}
           {!error && !loading && patternFrames && patternFrames.length > 0 && (
             <div className={styles.content}>{body && <body.Component model={body} />}</div>
           )}

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -41,6 +41,7 @@ export interface PatternsBreakdownSceneState extends SceneObjectState {
 
 export type PatternFrame = {
   dataFrame: DataFrame;
+  level?: string;
   pattern: string;
   status?: 'exclude' | 'include';
   sum: number;
@@ -174,11 +175,13 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       const existingPattern = appliedPatterns?.find((appliedPattern) => appliedPattern.pattern === dataFrame.name);
 
       const sum: number = dataFrame.meta?.custom?.sum;
+      const level: string | undefined = dataFrame.meta?.custom?.level;
       const patternFrame: PatternFrame = {
         dataFrame,
         pattern: dataFrame.name ?? '',
         status: existingPattern?.type,
         sum,
+        level,
       };
 
       return patternFrame;

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -41,7 +41,7 @@ export interface PatternsBreakdownSceneState extends SceneObjectState {
 
 export type PatternFrame = {
   dataFrame: DataFrame;
-  level?: string;
+  level: string[];
   pattern: string;
   status?: 'exclude' | 'include';
   sum: number;
@@ -175,7 +175,7 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       const existingPattern = appliedPatterns?.find((appliedPattern) => appliedPattern.pattern === dataFrame.name);
 
       const sum: number = dataFrame.meta?.custom?.sum;
-      const level: string | undefined = dataFrame.meta?.custom?.level;
+      const level: string[] = dataFrame.meta?.custom?.level;
       const patternFrame: PatternFrame = {
         dataFrame,
         pattern: dataFrame.name ?? '',

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsBreakdownScene.tsx
@@ -41,7 +41,7 @@ export interface PatternsBreakdownSceneState extends SceneObjectState {
 
 export type PatternFrame = {
   dataFrame: DataFrame;
-  level: string[];
+  levels: string[];
   pattern: string;
   status?: 'exclude' | 'include';
   sum: number;
@@ -175,13 +175,13 @@ export class PatternsBreakdownScene extends SceneObjectBase<PatternsBreakdownSce
       const existingPattern = appliedPatterns?.find((appliedPattern) => appliedPattern.pattern === dataFrame.name);
 
       const sum: number = dataFrame.meta?.custom?.sum;
-      const level: string[] = dataFrame.meta?.custom?.level;
+      const levels: string[] = dataFrame.meta?.custom?.level;
       const patternFrame: PatternFrame = {
         dataFrame,
         pattern: dataFrame.name ?? '',
         status: existingPattern?.type,
         sum,
-        level,
+        levels,
       };
 
       return patternFrame;

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsFrameScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsFrameScene.tsx
@@ -266,19 +266,6 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
 
   private getTimeseriesDataNode(patternFrames: PatternFrame[]) {
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-
-    console.log('tsnode', {
-      series: patternFrames.map((patternFrame, seriesIndex) => {
-        // Mutating the dataframe config here means that we don't need to update the colors in the table view
-        const dataFrame = patternFrame.dataFrame;
-        dataFrame.fields[1].config.color = overrideToFixedColor(seriesIndex);
-        dataFrame.fields[1].name = '';
-        return dataFrame;
-      }),
-      state: LoadingState.Done,
-      timeRange: timeRange,
-    });
-
     return new SceneDataNode({
       data: {
         series: patternFrames.map((patternFrame, seriesIndex) => {

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsFrameScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsFrameScene.tsx
@@ -18,6 +18,8 @@ import { LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode } from '@gr
 
 import { areArraysEqual } from '../../../../services/comparison';
 import { logger } from '../../../../services/logger';
+import { isOperatorInclusive } from '../../../../services/operatorHelpers';
+import { getLevelsVariable } from '../../../../services/variableGetters';
 import { IndexScene } from '../../../IndexScene/IndexScene';
 import { ServiceScene } from '../../ServiceScene';
 import { onPatternClick } from './FilterByPatternsButton';
@@ -59,6 +61,8 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
 
   private onActivate() {
     this.updateBody();
+    const patternsBreakdownScene = sceneGraph.getAncestor(this, PatternsBreakdownScene);
+    this.updatePatterns(patternsBreakdownScene.state.patternFrames);
 
     // If the patterns have changed, recalculate the dataframes
     this._subs.add(
@@ -92,10 +96,22 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
         }
       })
     );
+
+    this._subs.add(
+      getLevelsVariable(this).subscribeToState((newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          const patternsBreakdownScene = sceneGraph.getAncestor(this, PatternsBreakdownScene);
+          this.updatePatterns(patternsBreakdownScene.state.patternFrames);
+        }
+      })
+    );
   }
 
   private async updatePatterns(patternFrames: PatternFrame[] = []) {
+    patternFrames = this.filterPatternFramesByLevel(patternFrames);
+
     // CSS Grid doesn't need rebuilding, just the children need the updated dataframe
+    // @todo we should probably be setting the state on this scene and subscribing to it from the children
     this.state.body?.forEachChild((child) => {
       if (child instanceof VizPanel) {
         child.setState({
@@ -109,6 +125,31 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
       }
     });
   }
+
+  private filterPatternFramesByLevel = (patternFrames: PatternFrame[]) => {
+    const levelsVar = getLevelsVariable(this);
+    const filters = levelsVar.state.filters;
+
+    if (
+      filters.length &&
+      patternFrames.some((patternFrame) => {
+        return patternFrame.levels.length > 0;
+      })
+    ) {
+      const levelsSet = new Set();
+      filters.forEach((filter) => {
+        if (isOperatorInclusive(filter.operator)) {
+          levelsSet.add(filter.value);
+        }
+      });
+
+      patternFrames = patternFrames.filter((patternFrame) => {
+        return patternFrame.levels.some((level) => levelsSet.has(level));
+      });
+    }
+
+    return patternFrames;
+  };
 
   private async updateBody() {
     const patternsBreakdownScene = sceneGraph.getAncestor(this, PatternsBreakdownScene);
@@ -225,6 +266,18 @@ export class PatternsFrameScene extends SceneObjectBase<PatternsFrameSceneState>
 
   private getTimeseriesDataNode(patternFrames: PatternFrame[]) {
     const timeRange = sceneGraph.getTimeRange(this).state.value;
+
+    console.log('tsnode', {
+      series: patternFrames.map((patternFrame, seriesIndex) => {
+        // Mutating the dataframe config here means that we don't need to update the colors in the table view
+        const dataFrame = patternFrame.dataFrame;
+        dataFrame.fields[1].config.color = overrideToFixedColor(seriesIndex);
+        dataFrame.fields[1].name = '';
+        return dataFrame;
+      }),
+      state: LoadingState.Done,
+      timeRange: timeRange,
+    });
 
     return new SceneDataNode({
       data: {

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -197,6 +197,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
         id: 'levels',
         // @todo custom sort method?
         cell: (props: CellProps<PatternsTableCellData>) => {
+          props.cell.row.original.levels.sort();
           return props.cell.row.original.levels.map((level) => (
             <Button
               key={level}
@@ -206,7 +207,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
                   ? 'primary'
                   : 'secondary'
               }
-              fill={'text'}
+              fill={'outline'}
               className={styles.levelWrap}
               onClick={() => {
                 props.cell.row.original.togglePatternLevel(level);
@@ -304,6 +305,9 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
     levelWrap: css({
       fontSize: theme.typography.bodySmall.fontSize,
       fontFamily: theme.typography.fontFamilyMonospace,
+      '&:not(:last-child)': {
+        marginRight: theme.spacing(0.5),
+      },
     }),
     countTextWrap: css({
       fontSize: theme.typography.bodySmall.fontSize,

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -6,6 +6,7 @@ import { CellProps } from 'react-table';
 import { DataFrame, GrafanaTheme2, LoadingState, PanelData, scaledUnits } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
+  AdHocFilterWithLabels,
   PanelBuilders,
   SceneComponentProps,
   SceneDataNode,
@@ -83,7 +84,8 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
     theme: GrafanaTheme2,
     maxLines: number,
     patternFrames: PatternFrame[],
-    patternsNotMatchingFilters?: string[]
+    patternsNotMatchingFilters?: string[],
+    filters: AdHocFilterWithLabels[]
   ) {
     const styles = getColumnStyles(theme);
     const timeRange = sceneGraph.getTimeRange(this).state.value;
@@ -198,12 +200,17 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
       columns.splice(1, 0, {
         header: 'Levels',
         id: 'levels',
+        // @todo custom sort method?
         cell: (props: CellProps<PatternsTableCellData>) => {
           return props.cell.row.original.levels.map((level) => (
             <Button
               key={level}
               size={'sm'}
-              variant={'secondary'}
+              variant={
+                filters.some((filter) => isOperatorInclusive(filter.operator) && filter.value === level)
+                  ? 'primary'
+                  : 'secondary'
+              }
               fill={'text'}
               className={styles.levelWrap}
               onClick={() => {
@@ -375,7 +382,8 @@ export function PatternTableViewSceneComponent({ model }: SceneComponentProps<Pa
     theme,
     model.state.maxLines ?? LINE_LIMIT,
     patternFrames,
-    patternsNotMatchingFilters
+    patternsNotMatchingFilters,
+    filters
   );
 
   return (

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -198,7 +198,6 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
       columns.splice(1, 0, {
         header: 'Levels',
         id: 'levels',
-        sortType: 'string',
         cell: (props: CellProps<PatternsTableCellData>) => {
           return props.cell.row.original.levels.map((level) => (
             <Button

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -194,7 +194,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
       },
     ];
 
-    if (patternFrames.some((pattern) => pattern.level !== undefined)) {
+    if (patternFrames.some((pattern) => pattern.level.length > 0)) {
       columns.splice(1, 0, {
         header: 'Level',
         id: 'level',

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -72,11 +72,6 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
 
   /**
    * Build columns for interactive table (wrapper for react-table v7)
-   * @param total
-   * @param appliedPatterns
-   * @param theme
-   * @param patternsNotMatchingFilters
-   * @protected
    */
   public buildColumns(
     total: number,
@@ -84,7 +79,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
     theme: GrafanaTheme2,
     maxLines: number,
     patternFrames: PatternFrame[],
-    patternsNotMatchingFilters?: string[],
+    patternsNotMatchingFilters: string[] | undefined,
     filters: AdHocFilterWithLabels[]
   ) {
     const styles = getColumnStyles(theme);
@@ -348,23 +343,6 @@ export function PatternTableViewSceneComponent({ model }: SceneComponentProps<Pa
   let patternFrames = patternFramesRaw ?? [];
   const levelsVar = getLevelsVariable(model);
   const { filters } = levelsVar.useState();
-
-  if (
-    filters.length &&
-    patternFrames.some((patternFrame) => {
-      return patternFrame.levels.length > 0;
-    })
-  ) {
-    const levelsSet = new Set();
-    filters.forEach((filter) => {
-      if (isOperatorInclusive(filter.operator)) {
-        levelsSet.add(filter.value);
-      }
-    });
-    patternFrames = patternFrames.filter((patternFrame) => {
-      return patternFrame.levels.some((level) => levelsSet.has(level));
-    });
-  }
 
   // Get unfiltered patterns for percentage calculation
   const patternsBreakdownScene = sceneGraph.getAncestor(model, PatternsBreakdownScene);

--- a/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Patterns/PatternsViewTableScene.tsx
@@ -48,7 +48,7 @@ export interface PatternsTableCellData {
   dataFrame: DataFrame;
   excludeLink: () => void;
   includeLink: () => void;
-  level: string[];
+  levels: string[];
   pattern: string;
   sum: number;
   togglePatternLevel: (level: string) => void;
@@ -194,13 +194,13 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
       },
     ];
 
-    if (patternFrames.some((pattern) => pattern.level.length > 0)) {
+    if (patternFrames.some((pattern) => pattern.levels.length > 0)) {
       columns.splice(1, 0, {
-        header: 'Level',
-        id: 'level',
+        header: 'Levels',
+        id: 'levels',
         sortType: 'string',
         cell: (props: CellProps<PatternsTableCellData>) => {
-          return props.cell.row.original.level.map((level) => (
+          return props.cell.row.original.levels.map((level) => (
             <Button
               key={level}
               size={'sm'}
@@ -253,7 +253,7 @@ export class PatternsViewTableScene extends SceneObjectBase<SingleViewTableScene
           },
           pattern: pattern.pattern,
           sum: pattern.sum,
-          level: pattern.level,
+          levels: pattern.levels,
           undoLink: () =>
             onPatternClick({
               indexScene: logExploration,
@@ -346,7 +346,7 @@ export function PatternTableViewSceneComponent({ model }: SceneComponentProps<Pa
   if (
     filters.length &&
     patternFrames.some((patternFrame) => {
-      return patternFrame.level.length > 0;
+      return patternFrame.levels.length > 0;
     })
   ) {
     const levelsSet = new Set();
@@ -356,7 +356,7 @@ export function PatternTableViewSceneComponent({ model }: SceneComponentProps<Pa
       }
     });
     patternFrames = patternFrames.filter((patternFrame) => {
-      return patternFrame.level.some((level) => levelsSet.has(level));
+      return patternFrame.levels.some((level) => levelsSet.has(level));
     });
   }
 

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -779,21 +779,24 @@ function getPatternsQueryRunner() {
     return undefined;
   }
 
-  return getResourceQueryRunner([
-    buildResourceQuery(`{${VAR_LABELS_EXPR}}`, 'patterns', { refId: PATTERNS_QUERY_REFID }),
-  ]);
+  return getResourceQueryRunner(
+    [buildResourceQuery(`{${VAR_LABELS_EXPR}}`, 'patterns', { refId: PATTERNS_QUERY_REFID })],
+    { runQueriesMode: 'manual' }
+  );
 }
 
 function getDetectedLabelsQueryRunner() {
-  return getResourceQueryRunner([
-    buildResourceQuery(`{${VAR_LABELS_EXPR}}`, 'detected_labels', { refId: DETECTED_LABELS_QUERY_REFID }),
-  ]);
+  return getResourceQueryRunner(
+    [buildResourceQuery(`{${VAR_LABELS_EXPR}}`, 'detected_labels', { refId: DETECTED_LABELS_QUERY_REFID })],
+    { runQueriesMode: 'manual' }
+  );
 }
 
 function getDetectedFieldsQueryRunner() {
-  return getResourceQueryRunner([
-    buildResourceQuery(DETECTED_FIELD_VALUES_EXPR, 'detected_fields', { refId: DETECTED_FIELDS_QUERY_REFID }),
-  ]);
+  return getResourceQueryRunner(
+    [buildResourceQuery(DETECTED_FIELD_VALUES_EXPR, 'detected_fields', { refId: DETECTED_FIELDS_QUERY_REFID })],
+    { runQueriesMode: 'manual' }
+  );
 }
 
 function getServiceSceneQueryRunner() {

--- a/src/services/datasource.test.ts
+++ b/src/services/datasource.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 
-import { WrappedLokiDatasource } from './datasource';
+import { mergeLokiSamples, WrappedLokiDatasource } from './datasource';
 import { SceneDataQueryResourceRequest } from './datasourceTypes';
 import { DetectedFieldsResponse } from './fields';
 import { LokiDatasource, LokiQuery } from './lokiQuery';
@@ -172,6 +172,29 @@ describe('datasource', () => {
           done();
         }
       });
+    });
+  });
+  describe('mergeLokiSamples', () => {
+    it('should merge dataframes', () => {
+      expect(
+        mergeLokiSamples(
+          [
+            [100, 10],
+            [110, 20],
+          ],
+          [
+            [90, 3],
+            [100, 7],
+            [110, 11],
+            [120, 13],
+          ]
+        )
+      ).toEqual([
+        [90, 3],
+        [100, 17],
+        [110, 31],
+        [120, 13],
+      ]);
     });
   });
 });

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -61,7 +61,7 @@ export interface LokiPattern {
 }
 
 export interface LokiPatternProcessed {
-  level: string[];
+  levels: string[];
   samples: PatternSample[];
 }
 
@@ -211,7 +211,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
         if (lokiPatternsProcessed[pattern.pattern]) {
           if (pattern.level) {
             // add level
-            lokiPatternsProcessed[pattern.pattern].level.push(pattern.level);
+            lokiPatternsProcessed[pattern.pattern].levels.push(pattern.level);
           }
           // merge samples
           lokiPatternsProcessed[pattern.pattern].samples = mergeLokiSamples(
@@ -221,7 +221,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
         } else {
           lokiPatternsProcessed[pattern.pattern] = {
             samples: pattern.samples,
-            level: pattern.level ? [pattern.level] : [],
+            levels: pattern.level ? [pattern.level] : [],
           };
         }
       });
@@ -267,7 +267,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
           meta: {
             custom: {
               sum,
-              level: pattern.level,
+              level: pattern.levels,
             },
             preferredVisualisationType: 'graph',
           },
@@ -275,7 +275,6 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
           refId: interpolatedTarget.refId,
         });
       });
-      console.log('frames', frames);
       frames.sort((a, b) => (b.meta?.custom?.sum as number) - (a.meta?.custom?.sum as number));
       subscriber.next({ data: frames, state: LoadingState.Done });
     } catch (e) {

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -2,7 +2,6 @@ import { Observable, Subscriber } from 'rxjs';
 
 import {
   createDataFrame,
-  DataFrame,
   DataQueryRequest,
   DataQueryResponse,
   Field,
@@ -58,6 +57,11 @@ type PatternSample = [SampleTimeStamp, SampleCount];
 export interface LokiPattern {
   level?: string;
   pattern: string;
+  samples: PatternSample[];
+}
+
+export interface LokiPatternProcessed {
+  level: string[];
   samples: PatternSample[];
 }
 
@@ -202,55 +206,76 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
       let maxValue = -Infinity;
       let minValue = 0;
 
-      const frames: DataFrame[] =
-        lokiPatterns?.map((pattern: LokiPattern) => {
-          const timeValues: number[] = [];
-          const countValues: number[] = [];
-          let sum = 0;
-          pattern.samples.forEach(([time, count]) => {
-            timeValues.push(time * 1000);
-            countValues.push(count);
-            if (count > maxValue) {
-              maxValue = count;
-            }
-            if (count < minValue) {
-              minValue = count;
-            }
-            if (count > maxValue) {
-              maxValue = count;
-            }
-            if (count < minValue) {
-              minValue = count;
-            }
-            sum += count;
-          });
-          return createDataFrame({
-            fields: [
-              {
-                config: {},
-                name: 'time',
-                type: FieldType.time,
-                values: timeValues,
-              },
-              {
-                config: {},
-                name: pattern.pattern,
-                type: FieldType.number,
-                values: countValues,
-              },
-            ],
-            meta: {
-              custom: {
-                sum,
-                level: pattern.level,
-              },
-              preferredVisualisationType: 'graph',
-            },
-            name: pattern.pattern,
-            refId: interpolatedTarget.refId,
-          });
-        }) ?? [];
+      let lokiPatternsProcessed: Record<string, LokiPatternProcessed> = {};
+      lokiPatterns.forEach((pattern) => {
+        if (lokiPatternsProcessed[pattern.pattern]) {
+          if (pattern.level) {
+            // add level
+            lokiPatternsProcessed[pattern.pattern].level.push(pattern.level);
+          }
+          // merge samples
+          lokiPatternsProcessed[pattern.pattern].samples = mergeLokiSamples(
+            pattern.samples,
+            lokiPatternsProcessed[pattern.pattern].samples
+          );
+        } else {
+          lokiPatternsProcessed[pattern.pattern] = {
+            samples: pattern.samples,
+            level: pattern.level ? [pattern.level] : [],
+          };
+        }
+      });
 
+      const frames = Object.keys(lokiPatternsProcessed).map((key) => {
+        const timeValues: number[] = [];
+        const countValues: number[] = [];
+        let sum = 0;
+        const pattern = lokiPatternsProcessed[key];
+        pattern.samples.forEach(([time, count]) => {
+          timeValues.push(time * 1000);
+          countValues.push(count);
+          if (count > maxValue) {
+            maxValue = count;
+          }
+          if (count < minValue) {
+            minValue = count;
+          }
+          if (count > maxValue) {
+            maxValue = count;
+          }
+          if (count < minValue) {
+            minValue = count;
+          }
+          sum += count;
+        });
+
+        return createDataFrame({
+          fields: [
+            {
+              config: {},
+              name: 'time',
+              type: FieldType.time,
+              values: timeValues,
+            },
+            {
+              config: {},
+              name: key,
+              type: FieldType.number,
+              values: countValues,
+            },
+          ],
+          meta: {
+            custom: {
+              sum,
+              level: pattern.level,
+            },
+            preferredVisualisationType: 'graph',
+          },
+          name: key,
+          refId: interpolatedTarget.refId,
+        });
+      });
+      console.log('frames', frames);
       frames.sort((a, b) => (b.meta?.custom?.sum as number) - (a.meta?.custom?.sum as number));
       subscriber.next({ data: frames, state: LoadingState.Done });
     } catch (e) {
@@ -513,6 +538,24 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
   testDatasource(): Promise<TestDataSourceResponse> {
     return Promise.resolve({ message: 'Data source is working', status: 'success', title: 'Success' });
   }
+}
+
+function mergeLokiSamples(s1: PatternSample[], s2: PatternSample[]) {
+  const lokiSamplesMap = new Map<number, number>();
+  s1.forEach((value) => {
+    lokiSamplesMap.set(value[0], value[1]);
+  });
+  s2.forEach((value) => {
+    if (lokiSamplesMap.has(value[0])) {
+      const existingValue = lokiSamplesMap.get(value[0]);
+      lokiSamplesMap.set(value[0], value[1] + (existingValue ?? 0));
+    } else {
+      lokiSamplesMap.set(value[0], value[1]);
+    }
+  });
+  const samples = Array.from(lokiSamplesMap);
+  samples.sort();
+  return samples;
 }
 
 let initialized = false;

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -539,7 +539,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
   }
 }
 
-function mergeLokiSamples(s1: PatternSample[], s2: PatternSample[]) {
+export function mergeLokiSamples(s1: PatternSample[], s2: PatternSample[]) {
   const lokiSamplesMap = new Map<number, number>();
   s1.forEach((value) => {
     lokiSamplesMap.set(value[0], value[1]);
@@ -553,7 +553,7 @@ function mergeLokiSamples(s1: PatternSample[], s2: PatternSample[]) {
     }
   });
   const samples = Array.from(lokiSamplesMap);
-  samples.sort();
+  samples.sort((a, b) => a[0] - b[0]);
   return samples;
 }
 

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -539,6 +539,10 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
   }
 }
 
+/**
+ * Combine multiple Loki pattern samples into one.
+ * Note: Pattern samples might not be square (i.e. each dataframe might not have the same time values) like we'd expect from a dataframe processed by a datasource backend
+ */
 export function mergeLokiSamples(s1: PatternSample[], s2: PatternSample[]) {
   const lokiSamplesMap = new Map<number, number>();
   s1.forEach((value) => {

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -56,6 +56,7 @@ type SampleCount = number;
 type PatternSample = [SampleTimeStamp, SampleCount];
 
 export interface LokiPattern {
+  level?: string;
   pattern: string;
   samples: PatternSample[];
 }
@@ -241,6 +242,7 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
             meta: {
               custom: {
                 sum,
+                level: pattern.level,
               },
               preferredVisualisationType: 'graph',
             },

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -271,10 +271,11 @@ export function sortLevelTransformation() {
   };
 }
 
-export function getResourceQueryRunner(queries: LokiQuery[]) {
+export function getResourceQueryRunner(queries: LokiQuery[], queryRunnerOptions?: Partial<QueryRunnerState>) {
   return new SceneQueryRunner({
     datasource: { uid: WRAPPED_LOKI_DS_UID },
     queries: queries,
+    ...queryRunnerOptions,
   });
 }
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1337,7 +1337,7 @@ test.describe('explore services breakdown page', () => {
     await expect(explorePage.getAllPanelsLocator().first()).toBeInViewport();
   });
 
-  test('should not see maximum of series limit reached after changing filters', async ({ page }) => {
+  test.only('should not see maximum of series limit reached after changing filters', async ({ page }) => {
     explorePage.blockAllQueriesExcept({
       legendFormats: [`{{${levelName}}}`],
       refIds: ['logsPanelQuery', 'content', 'version'],
@@ -1353,8 +1353,10 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToFieldsTab();
     await expect(panelErrorLocator).toHaveCount(0);
 
-    // Now assert that content is hidden (will hit 1000 series limit and throw error)
-    await expect(contentPanelLocator).toHaveCount(0);
+    // Now assert that content is not hidden (will hit 1000 series limit and throw warning)
+    await page.pause();
+    // @todo update in https://github.com/grafana/logs-drilldown/issues/1465 that we're showing a warning
+    await expect(contentPanelLocator).toHaveCount(1);
     await expect(versionPanelLocator).toHaveCount(1);
 
     // Open the dropdown and change from include to exclude
@@ -1386,10 +1388,13 @@ test.describe('explore services breakdown page', () => {
     // Check the right options are visible
     await expect(versionVariableLocator).toContainText('!=');
 
-    // Assert no errors are visible
+    // Assert errors are visible
+    // @todo update in https://github.com/grafana/logs-drilldown/issues/1465 that we're showing a warning
     await expect(panelErrorLocator).toHaveCount(0);
+
     // Now assert that content is hidden (will hit 1000 series limit and throw error)
-    await expect(contentPanelLocator).toHaveCount(0);
+    // @todo update in https://github.com/grafana/logs-drilldown/issues/1465 that we're showing a warning
+    await expect(contentPanelLocator).toHaveCount(1);
     // But version should exist
     await expect(versionPanelLocator).toHaveCount(1);
   });

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -950,6 +950,58 @@ test.describe('explore services breakdown page', () => {
     await expect(page.getByTestId(testIds.exploreServiceDetails.buttonRemovePattern).nth(1)).toBeVisible();
   });
 
+  test('Should filter patterns by level', async ({ page }) => {
+    await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
+    await explorePage.assertTabsNotLoading();
+    // Get total count of rows
+    const unfilteredRowsCount = await page
+      .getByTestId('data-testid table-wrapper')
+      .locator('[role="rowgroup"] [role="row"]')
+      .count();
+    // Click on level within table
+    await page.getByTestId('data-testid table-wrapper').getByRole('button', { name: 'debug' }).click();
+    const filteredRowsCount = await page
+      .getByTestId('data-testid table-wrapper')
+      .locator('[role="rowgroup"] [role="row"]')
+      .count();
+
+    // Assert only one pattern has debug level
+    expect(filteredRowsCount).toBe(1);
+    // Assert total count of rows is greater than 1
+    expect(unfilteredRowsCount).toBeGreaterThan(filteredRowsCount);
+
+    // remove level filter from variable
+    await page
+      .getByTestId('data-testid detected_level filter variable')
+      .getByRole('button', { name: 'Remove' })
+      .click();
+
+    // assert after removing the level filter we see the full count of rows again
+    expect(
+      await page.getByTestId('data-testid table-wrapper').locator('[role="rowgroup"] [role="row"]').count()
+    ).toEqual(unfilteredRowsCount);
+  });
+  test('Should only call patterns API once on time range change', async ({ page }) => {
+    let patternsCount = 0;
+    await page.pause();
+    await page.route('**/patterns?**', async (route, request) => {
+      patternsCount++;
+      // Let the request go through normally
+      const response = await route.fetch();
+      const json = await response.json();
+      return route.fulfill({ json, response });
+    });
+
+    await explorePage.assertTabsNotLoading();
+    await expect.poll(() => patternsCount).toEqual(1);
+    await page.getByTestId(testIds.exploreServiceDetails.tabPatterns).click();
+    await explorePage.assertTabsNotLoading();
+    await expect.poll(() => patternsCount).toEqual(2);
+    await page.getByTestId('data-testid RefreshPicker run button').click();
+    await explorePage.assertTabsNotLoading();
+    await expect.poll(() => patternsCount).toEqual(3);
+  });
+
   test('should update a filter and run new logs', async ({ page }) => {
     await page.getByLabel('Edit filter with key').click();
     await page.getByText('mimir-distributor').click();
@@ -1354,7 +1406,6 @@ test.describe('explore services breakdown page', () => {
     await expect(panelErrorLocator).toHaveCount(0);
 
     // Now assert that content is not hidden (will hit 1000 series limit and throw warning)
-    await page.pause();
     // @todo update in https://github.com/grafana/logs-drilldown/issues/1465 that we're showing a warning
     await expect(contentPanelLocator).toHaveCount(1);
     await expect(versionPanelLocator).toHaveCount(1);

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1337,7 +1337,7 @@ test.describe('explore services breakdown page', () => {
     await expect(explorePage.getAllPanelsLocator().first()).toBeInViewport();
   });
 
-  test.only('should not see maximum of series limit reached after changing filters', async ({ page }) => {
+  test('should not see maximum of series limit reached after changing filters', async ({ page }) => {
     explorePage.blockAllQueriesExcept({
       legendFormats: [`{{${levelName}}}`],
       refIds: ['logsPanelQuery', 'content', 'version'],


### PR DESCRIPTION
Merges patterns with the same pattern name.
<img width="1728" height="460" alt="image" src="https://github.com/user-attachments/assets/7e59610f-7379-4404-ad4c-e956c5309bcf" />

Fixes: https://github.com/grafana/logs-drilldown/issues/1457
Also fixes a bug where the pattern count can be incorrect if a pattern contains multiple levels.


Notes for reviewers:
You must re-run `yarn server` to see levels on the pattern responses.
