### PR TITLE
fix: prevent runtime error in Grafana 11.6 from crashing in Drilldown 1.0.24

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { isAssistantAvailable, providePageContext } from '@grafana/assistant';
 import { AdHocVariableFilter, AppEvents, AppPluginMeta, rangeUtil, urlUtil } from '@grafana/data';
-import { config, getAppEvents, locationService } from '@grafana/runtime';
+import { config, getAppEvents, locationService, getObservablePluginLinks } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   AdHocFilterWithLabels,
@@ -286,8 +286,8 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     ) {
       getMetadataService().setEmbedded(this.state.embedded);
     }
-
-    try {
+    // `getObservablePluginLinks` is introduced in Grafana v12 which is called by isAssistantAvailable
+    if (getObservablePluginLinks !== undefined) {
       this._subs.add(
         isAssistantAvailable().subscribe((isAvailable) => {
           if (isAvailable && !this.assistantInitialized) {
@@ -295,8 +295,6 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
           }
         })
       );
-    } catch (error) {
-      logger.error(error, { msg: `Grafana assistant requires Grafana >= 12.0.0` });
     }
 
     return () => {

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -287,13 +287,17 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       getMetadataService().setEmbedded(this.state.embedded);
     }
 
-    this._subs.add(
-      isAssistantAvailable().subscribe((isAvailable) => {
-        if (isAvailable && !this.assistantInitialized) {
-          this.provideAssistantContext();
-        }
-      })
-    );
+    try {
+      this._subs.add(
+        isAssistantAvailable().subscribe((isAvailable) => {
+          if (isAvailable && !this.assistantInitialized) {
+            this.provideAssistantContext();
+          }
+        })
+      );
+    } catch (error) {
+      logger.error(error, { msg: `Grafana assistant requires Grafana >= 12.0.0` });
+    }
 
     return () => {
       clearKeyBindings();

--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -140,7 +140,8 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
         }),
       });
 
-      try {
+      // `getObservablePluginLinks` is introduced in Grafana v12 which is called by isAssistantAvailable
+      if (getObservablePluginLinks !== undefined) {
         this._subs.add(
           isAssistantAvailable().subscribe(async (isAvailable) => {
             if (isAvailable) {
@@ -179,8 +180,6 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
             }
           })
         );
-      } catch (error) {
-        logger.error(error, { msg: `Grafana assistant requires Grafana >= 12.0.0` });
       }
 
       this._subs.add(
@@ -351,19 +350,15 @@ const getInvestigationLink = async (addToInvestigation: AddToInvestigationButton
   }
 
   // `getObservablePluginLinks` is introduced in Grafana v12
-  try {
-    if (getObservablePluginLinks !== undefined) {
-      const links: PluginExtensionLink[] = await firstValueFrom(
-        getObservablePluginLinks({
-          context,
-          extensionPointId,
-        })
-      );
+  if (getObservablePluginLinks !== undefined) {
+    const links: PluginExtensionLink[] = await firstValueFrom(
+      getObservablePluginLinks({
+        context,
+        extensionPointId,
+      })
+    );
 
-      return links[0];
-    }
-  } catch (e) {
-    logger.error(e, { msg: `Grafana assistant requires Grafana >= 12.0.0` });
+    return links[0];
   }
 
   return undefined;


### PR DESCRIPTION
Looks like https://github.com/grafana/logs-drilldown/pull/1426 introduced a regression for users running Grafana 11.6.
The `isAssistantAvailable` method calls `getObservablePluginLinks` which does not exist in grafana <12.

@svennergr when you get back in the office I would appreciate it if y'all could clean up the `isAssistantAvailable` method to support being called in plugins that support older versions of Grafana then the assistant app does.