### PR TITLE
fix(assistant): move `getObservablePluginLinks` check to `@grafana/assistant` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@bsull/augurs": "^0.6.0",
     "@emotion/css": "11.10.6",
-    "@grafana/assistant": "^0.0.11",
+    "@grafana/assistant": "^0.0.14",
     "@grafana/data": "^12.1.0",
     "@grafana/i18n": "^12.1.0",
     "@grafana/lezer-logql": "^0.2.7",

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { isAssistantAvailable, providePageContext } from '@grafana/assistant';
 import { AdHocVariableFilter, AppEvents, AppPluginMeta, rangeUtil, urlUtil } from '@grafana/data';
-import { config, getAppEvents, locationService, getObservablePluginLinks } from '@grafana/runtime';
+import { config, getAppEvents, locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   AdHocFilterWithLabels,
@@ -286,16 +286,14 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     ) {
       getMetadataService().setEmbedded(this.state.embedded);
     }
-    // `getObservablePluginLinks` is introduced in Grafana v12 which is called by isAssistantAvailable
-    if (getObservablePluginLinks !== undefined) {
-      this._subs.add(
-        isAssistantAvailable().subscribe((isAvailable) => {
-          if (isAvailable && !this.assistantInitialized) {
-            this.provideAssistantContext();
-          }
-        })
-      );
-    }
+
+    this._subs.add(
+      isAssistantAvailable().subscribe((isAvailable) => {
+        if (isAvailable && !this.assistantInitialized) {
+          this.provideAssistantContext();
+        }
+      })
+    );
 
     return () => {
       clearKeyBindings();

--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -140,47 +140,44 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
         }),
       });
 
-      // `getObservablePluginLinks` is introduced in Grafana v12 which is called by isAssistantAvailable
-      if (getObservablePluginLinks !== undefined) {
-        this._subs.add(
-          isAssistantAvailable().subscribe(async (isAvailable) => {
-            if (isAvailable) {
-              const datasource = await getDataSourceSrv().get(getDataSource(this));
-              this.addItem({
-                text: '',
-                type: 'divider',
-              });
-              this.addItem({
-                text: 'AI',
-                type: 'group',
-              });
-              this.addItem({
-                iconClassName: 'ai-sparkle',
-                text: 'Explain in Assistant',
-                onClick: () => {
-                  openAssistant({
-                    prompt:
-                      'Help me understand this query and provide a summary of the data. Be concise and to the point.',
-                    context: [
-                      createContext(ItemDataType.Datasource, {
-                        datasourceName: datasource.name,
-                        datasourceUid: datasource.uid,
-                        datasourceType: datasource.type,
-                      }),
-                      createContext(ItemDataType.Structured, {
-                        title: 'Logs Drilldown Query',
-                        data: {
-                          query: getQueryExpression(this),
-                        },
-                      }),
-                    ],
-                  });
-                },
-              });
-            }
-          })
-        );
-      }
+      this._subs.add(
+        isAssistantAvailable().subscribe(async (isAvailable) => {
+          if (isAvailable) {
+            const datasource = await getDataSourceSrv().get(getDataSource(this));
+            this.addItem({
+              text: '',
+              type: 'divider',
+            });
+            this.addItem({
+              text: 'AI',
+              type: 'group',
+            });
+            this.addItem({
+              iconClassName: 'ai-sparkle',
+              text: 'Explain in Assistant',
+              onClick: () => {
+                openAssistant({
+                  prompt:
+                    'Help me understand this query and provide a summary of the data. Be concise and to the point.',
+                  context: [
+                    createContext(ItemDataType.Datasource, {
+                      datasourceName: datasource.name,
+                      datasourceUid: datasource.uid,
+                      datasourceType: datasource.type,
+                    }),
+                    createContext(ItemDataType.Structured, {
+                      title: 'Logs Drilldown Query',
+                      data: {
+                        query: getQueryExpression(this),
+                      },
+                    }),
+                  ],
+                });
+              },
+            });
+          }
+        })
+      );
 
       this._subs.add(
         this.state.investigationsButton?.subscribeToState(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,10 +1126,10 @@
   dependencies:
     tslib "^2.8.0"
 
-"@grafana/assistant@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@grafana/assistant/-/assistant-0.0.11.tgz#5166f633b35107fd605c81c3e37a5491e77b9b71"
-  integrity sha512-3Ejdscc2Y+jdAWTNH9SOmcZtd5RzirNZE149xTVCxeLkIUU6802xLn21qpJsrWe1rdgMRGFUCewYnt0imymtnQ==
+"@grafana/assistant@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@grafana/assistant/-/assistant-0.0.14.tgz#29e5fab464c0f392f45b0949ea6a39cf6af765f5"
+  integrity sha512-5Ts3FsucKHNnzn0AaOHBM0ouSc7B+ypTMf61zJFfgtBAopnnR2k/KybSq0zxyznYbvElbJdD1QsaFxJdDzrI5w==
 
 "@grafana/data@12.1.0", "@grafana/data@^12.1.0":
   version "12.1.0"


### PR DESCRIPTION
https://github.com/grafana/grafana-assistant-app/pull/1239 moved the `getObservablePluginLinks` check into the SDK itself, which will make the `getObservablePluginLinks` check in Logs Drilldown unnecessary. 

Thanks for catching that @gtk-grafana! Feel free to keep it here, if you want. Just wanted to offer using the new version of `@grafana/assistant`.

Btw, have you thought about running e2e tests in CI against the earliest supported Grafana version?