### PR TITLE
fix(embedded): force metadata reset on init

### DIFF
--- a/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
+++ b/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
@@ -53,7 +53,7 @@ export default function EmbeddedLogsExploration(props: EmbeddedLogsExplorationPr
 
   useEffect(() => {
     if (!exploration) {
-      initializeMetadataService();
+      initializeMetadataService(true);
       setExploration(buildLogsExplorationFromState(props));
     }
   }, [exploration, props]);

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -2,8 +2,8 @@ import { ServiceSceneCustomState } from '../Components/ServiceScene/ServiceScene
 
 let metadataService: MetadataService;
 
-export function initializeMetadataService(): void {
-  if (!metadataService) {
+export function initializeMetadataService(force = false): void {
+  if (!metadataService || force) {
     metadataService = new MetadataService();
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1324

This might be our first known bug that exists in an embedded context but is only reproducible in an embedded app that conditionally renders the app with different props. TL;DR this is not currently testable in our embedded e2e route. Although it sounds like there is some upcoming work on better testing Grafana with bundled plugins, so that might change in the future.

Note: We could put in some effort to build a meta-UI within the embedded route that allows users to customize the input props, if this were a more significant change I would suggest it, but I think we're fine to let it slide for now.