### PR TITLE
fix(table): make column menu keyboard accessible

### DIFF
--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -3,11 +3,12 @@ import React, { PropsWithChildren, useRef } from 'react';
 import { css } from '@emotion/css';
 
 import { Field, GrafanaTheme2 } from '@grafana/data';
-import { ClickOutsideWrapper, IconButton, Popover, useTheme2 } from '@grafana/ui';
+import { IconButton, Popover, useTheme2 } from '@grafana/ui';
 
 import { getBodyName } from '../../services/logsFrame';
 import { useQueryContext } from './Context/QueryContext';
 import { LogLineState, useTableColumnContext } from './Context/TableColumnsContext';
+import { LogsTableHeaderMenu } from './LogsTableHeaderMenu';
 import { useTableHeaderContext } from 'Components/Table/Context/TableHeaderContext';
 
 export interface LogsTableHeaderProps extends PropsWithChildren<CustomHeaderRendererProps> {
@@ -20,6 +21,11 @@ export interface CustomHeaderRendererProps {
 }
 
 const getStyles = (theme: GrafanaTheme2, isFirstColumn: boolean, isLine: boolean) => ({
+  closeButton: css({
+    position: 'absolute',
+    top: '14px',
+    right: '2px',
+  }),
   clearButton: css({
     marginLeft: '5px',
   }),
@@ -43,6 +49,8 @@ const getStyles = (theme: GrafanaTheme2, isFirstColumn: boolean, isLine: boolean
     marginRight: '5px',
   }),
   tableHeaderMenu: css({
+    display: 'block',
+    position: 'static',
     backgroundColor: theme.colors.background.primary,
     border: `1px solid ${theme.colors.border.weak}`,
     borderRadius: theme.shape.radius.default,
@@ -138,13 +146,17 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
       </span>
 
       {referenceElement.current && (
-        //@ts-ignore
         <Popover
           show={isHeaderMenuActive}
           content={
-            <ClickOutsideWrapper onClick={() => setHeaderMenuActive(false)} useCapture={true}>
-              <div className={styles.tableHeaderMenu}>{props.children}</div>
-            </ClickOutsideWrapper>
+            <LogsTableHeaderMenu
+              setHeaderMenuActive={(active) => {
+                setHeaderMenuActive(active);
+                referenceElement.current?.focus();
+              }}
+            >
+              {props.children}
+            </LogsTableHeaderMenu>
           }
           referenceElement={referenceElement.current}
         />

--- a/src/Components/Table/LogsTableHeader.tsx
+++ b/src/Components/Table/LogsTableHeader.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/css';
 import { Field, GrafanaTheme2 } from '@grafana/data';
 import { IconButton, Popover, useTheme2 } from '@grafana/ui';
 
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
 import { getBodyName } from '../../services/logsFrame';
 import { useQueryContext } from './Context/QueryContext';
 import { LogLineState, useTableColumnContext } from './Context/TableColumnsContext';
@@ -103,6 +104,10 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
             onClick={() => {
               const { [props.field.name]: omit, ...map } = { ...columnWidthMap };
               setColumnWidthMap?.(map);
+              reportAppInteraction(
+                USER_EVENTS_PAGES.service_details,
+                USER_EVENTS_ACTIONS.service_details.table_columns_header_button_reset_width
+              );
             }}
           />
         )}
@@ -113,7 +118,13 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
                 tooltipPlacement={'top'}
                 tooltip={'Show log labels'}
                 aria-label={'Show log labels'}
-                onClick={onLogTextToggle}
+                onClick={() => {
+                  onLogTextToggle();
+                  reportAppInteraction(
+                    USER_EVENTS_PAGES.service_details,
+                    USER_EVENTS_ACTIONS.service_details.table_columns_header_button_show_labels
+                  );
+                }}
                 className={styles.logLineButton}
                 name={'tag-alt'}
                 size={'md'}
@@ -123,7 +134,13 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
                 tooltipPlacement={'top'}
                 tooltip={'Show log text'}
                 aria-label={'Show log text'}
-                onClick={onLogTextToggle}
+                onClick={() => {
+                  onLogTextToggle();
+                  reportAppInteraction(
+                    USER_EVENTS_PAGES.service_details,
+                    USER_EVENTS_ACTIONS.service_details.table_columns_header_button_show_text
+                  );
+                }}
                 className={styles.logLineButton}
                 name={'text-fields'}
                 size={'md'}
@@ -140,6 +157,10 @@ export const LogsTableHeader = (props: LogsTableHeaderProps) => {
           aria-label={`Show ${props.field.name} menu`}
           onClick={(e) => {
             setHeaderMenuActive(!isHeaderMenuActive);
+            reportAppInteraction(
+              USER_EVENTS_PAGES.service_details,
+              USER_EVENTS_ACTIONS.service_details.table_columns_header_menu_show
+            );
           }}
           name={'ellipsis-v'}
         />

--- a/src/Components/Table/LogsTableHeaderMenu.tsx
+++ b/src/Components/Table/LogsTableHeaderMenu.tsx
@@ -1,0 +1,56 @@
+import React, { PropsWithChildren, useEffect, useRef } from 'react';
+
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { ClickOutsideWrapper, IconButton, useStyles2 } from '@grafana/ui';
+
+interface LogsTableHeaderProps extends PropsWithChildren {
+  setHeaderMenuActive: (active: boolean) => void;
+}
+
+export function LogsTableHeaderMenu({ setHeaderMenuActive, children }: LogsTableHeaderProps) {
+  const styles = useStyles2(getStyles);
+  const ref = useRef<null | HTMLButtonElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+  return (
+    <ClickOutsideWrapper includeButtonPress={false} onClick={() => setHeaderMenuActive(false)} useCapture={true}>
+      <div className={styles.tableHeaderMenu}>
+        <IconButton
+          ref={ref}
+          className={styles.closeButton}
+          aria-label={t('logs.table.header.close', 'Close')}
+          name={'times'}
+          onClick={() => setHeaderMenuActive(false)}
+        />
+        {children}
+      </div>
+    </ClickOutsideWrapper>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  closeButton: css({
+    position: 'absolute',
+    top: '14px',
+    right: '2px',
+  }),
+  tableHeaderMenu: css({
+    display: 'block',
+    position: 'static',
+    backgroundColor: theme.colors.background.primary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    boxShadow: theme.shadows.z3,
+    height: '100%',
+    label: 'tableHeaderMenu',
+    margin: theme.spacing(1, 0),
+    maxHeight: '400px',
+    minWidth: '250px',
+    padding: theme.spacing(2),
+    width: '100%',
+  }),
+});

--- a/src/Components/Table/LogsTableHeaderWrap.tsx
+++ b/src/Components/Table/LogsTableHeaderWrap.tsx
@@ -5,6 +5,7 @@ import { css, cx } from '@emotion/css';
 import { Field } from '@grafana/data';
 import { Icon } from '@grafana/ui';
 
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
 import { getBodyName } from '../../services/logsFrame';
 import { useQueryContext } from './Context/QueryContext';
 import { LogLineState, useTableColumnContext } from 'Components/Table/Context/TableColumnsContext';
@@ -62,7 +63,16 @@ export function LogsTableHeaderWrap(props: {
   return (
     <LogsTableHeader {...props.headerProps}>
       <div className={styles.linkWrap}>
-        <button className={cx(linkButton, styles.link)} onClick={() => hideColumn(props.headerProps.field)}>
+        <button
+          className={cx(linkButton, styles.link)}
+          onClick={() => {
+            hideColumn(props.headerProps.field);
+            reportAppInteraction(
+              USER_EVENTS_PAGES.service_details,
+              USER_EVENTS_ACTIONS.service_details.table_columns_header_menu_hide_column
+            );
+          }}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 17 16"
@@ -88,7 +98,16 @@ export function LogsTableHeaderWrap(props: {
       </div>
       {props.slideLeft && (
         <div className={styles.linkWrap}>
-          <button className={cx(linkButton, styles.link)} onClick={() => props.slideLeft?.(columns)}>
+          <button
+            className={cx(linkButton, styles.link)}
+            onClick={() => {
+              props.slideLeft?.(columns);
+              reportAppInteraction(
+                USER_EVENTS_PAGES.service_details,
+                USER_EVENTS_ACTIONS.service_details.table_columns_header_menu_slide_left
+              );
+            }}
+          >
             <Icon className={cx(styles.icon, styles.reverse)} name={'arrow-from-right'} size={'md'} />
             Move left
           </button>
@@ -96,7 +115,16 @@ export function LogsTableHeaderWrap(props: {
       )}
       {props.slideRight && (
         <div className={styles.linkWrap}>
-          <button className={cx(linkButton, styles.link)} onClick={() => props.slideRight?.(columns)}>
+          <button
+            className={cx(linkButton, styles.link)}
+            onClick={() => {
+              props.slideRight?.(columns);
+              reportAppInteraction(
+                USER_EVENTS_PAGES.service_details,
+                USER_EVENTS_ACTIONS.service_details.table_columns_header_menu_slide_right
+              );
+            }}
+          >
             <Icon className={styles.icon} name={'arrow-from-right'} size={'md'} />
             Move right
           </button>
@@ -112,6 +140,14 @@ export function LogsTableHeaderWrap(props: {
               } else {
                 setBodyState(LogLineState.text);
               }
+
+              reportAppInteraction(
+                USER_EVENTS_PAGES.service_details,
+                USER_EVENTS_ACTIONS.service_details.table_columns_header_menu_show_labels,
+                {
+                  state: bodyState === LogLineState.text ? LogLineState.labels : LogLineState.text,
+                }
+              );
             }}
           >
             {bodyState === LogLineState.text ? (
@@ -127,7 +163,16 @@ export function LogsTableHeaderWrap(props: {
 
       {props.autoColumnWidths && (
         <div className={styles.linkWrap}>
-          <button className={cx(linkButton, styles.link)} onClick={() => props.autoColumnWidths?.()}>
+          <button
+            className={cx(linkButton, styles.link)}
+            onClick={() => {
+              props.autoColumnWidths?.();
+              reportAppInteraction(
+                USER_EVENTS_PAGES.service_details,
+                USER_EVENTS_ACTIONS.service_details.table_columns_header_menu_reset_width
+              );
+            }}
+          >
             <Icon className={styles.icon} name={'arrows-h'} size={'md'} />
             Reset column widths
           </button>

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -98,6 +98,18 @@ export const USER_EVENTS_ACTIONS = {
     visualization_init: 'visualization_init',
     // fields rollup viz type toggle
     fields_panel_type_toggle: 'fields_panel_type_toggle',
+    // table header buttons
+    table_columns_header_button_reset_width: 'table_columns_header_button_reset_width',
+    table_columns_header_button_show_labels: 'table_columns_header_button_show_labels',
+    table_columns_header_button_show_text: 'table_columns_header_button_show_text',
+    // table column header menu
+    table_columns_header_menu_show: 'table_columns_header_menu_show',
+    table_columns_header_menu_reset_width: 'table_columns_header_menu_reset_width',
+    table_columns_header_menu_show_labels: 'table_columns_header_menu_show_labels',
+    table_columns_header_menu_show_text: 'table_columns_header_menu_show_text',
+    table_columns_header_menu_slide_left: 'table_columns_header_menu_slide_left',
+    table_columns_header_menu_slide_right: 'table_columns_header_menu_slide_right',
+    table_columns_header_menu_hide_column: 'table_columns_header_menu_hide_column',
   },
   [USER_EVENTS_PAGES.all]: {
     interval_too_long: 'interval_too_long',


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1060


<img width="284" height="209" alt="image" src="https://github.com/user-attachments/assets/091d38d2-800c-4d85-9083-42afdea62691" />


There is still quite a bit sub-optimal behavior around focusing elements in the table, primarily any action that moves or removes a column in the dialog will reset the tabindex to the start.

It might even be best to leave the column headers inaccessible to keyboard navigation as there are other UI elements that provide all functionality within the table header component with less unexpected behavior (column management (left) sidebar, or table options (right)).

Argument 1:
If we add more functionality in the column headers that isn't available elsewhere in the UI, then this PR should be merged, but now I'm thinking that we should not merge this PR, and potentially have a discussion about removing the column header component all together.

Argument 2:
Move left/right is nice, we should merge this PR to see if folks are getting use out of this, and then reevaluate argument 1.
