### PR TITLE
feat(EmbeddedLogs): fix missing keyLabel in parsed line filters

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -711,7 +711,11 @@ function getVariableSet(
 
   const lineFiltersVariable = new AdHocFiltersVariable({
     expressionBuilder: renderLogQLLineFilter,
-    filters: defaultLineFilters ?? [],
+    filters:
+      defaultLineFilters?.map((lineFilter, index) => ({
+        ...lineFilter,
+        keyLabel: index.toString(),
+      })) ?? [],
     getTagKeysProvider: () => Promise.resolve({ replace: true, values: [] }),
     getTagValuesProvider: () => Promise.resolve({ replace: true, values: [] }),
     hide: VariableHide.hideVariable,

--- a/src/services/logqlMatchers.test.ts
+++ b/src/services/logqlMatchers.test.ts
@@ -69,4 +69,45 @@ describe('getMatcherFromQuery', () => {
       ]);
     });
   });
+
+  describe('Label filters', () => {
+    test('Parses fields filters in queries', () => {
+      const result = getMatcherFromQuery('{label="value", other_label=~"other value", another_label!="another value"}');
+
+      expect(result.labelFilters).toEqual([
+        {
+          key: 'label',
+          operator: '=',
+          type: 'I',
+          value: 'value',
+        },
+        {
+          key: 'other_label',
+          operator: '=~',
+          type: 'I',
+          value: 'other value',
+        },
+        {
+          key: 'another_label',
+          operator: '!=',
+          type: 'I',
+          value: 'another value',
+        },
+      ]);
+    });
+  });
+
+  describe('Line filters', () => {
+    test('Line filters', () => {
+      const result = getMatcherFromQuery('{service_name="tempo-distributor"} |~ "(?i)Error"');
+
+      expect(result.lineFilters).toEqual([
+        {
+          key: 'caseInsensitive',
+          operator: '|~',
+          value: 'Error',
+        },
+      ]);
+    });
+  });
 });

--- a/src/services/logqlMatchers.test.ts
+++ b/src/services/logqlMatchers.test.ts
@@ -1,0 +1,72 @@
+import {
+  createDataFrame,
+  FieldType,
+  getDefaultTimeRange,
+  LoadingState,
+  PluginExtensionPanelContext,
+} from '@grafana/data';
+
+import { getMatcherFromQuery } from './logqlMatchers';
+
+describe('getMatcherFromQuery', () => {
+  describe('Fields', () => {
+    const context: PluginExtensionPanelContext = {
+      data: {
+        state: LoadingState.Done,
+        series: [
+          createDataFrame({
+            refId: 'test',
+            fields: [
+              { name: 'Time', values: [111111], type: FieldType.time },
+              { name: 'Value', values: ['A'], type: FieldType.string },
+              { name: 'labelTypes', values: [{ label: 'P' }], type: FieldType.other },
+            ],
+          }),
+        ],
+        timeRange: getDefaultTimeRange(),
+      },
+      pluginId: '',
+      id: 0,
+      title: '',
+      timeRange: getDefaultTimeRange(),
+      timeZone: '',
+      dashboard: {
+        uid: '',
+        title: '',
+        tags: [],
+      },
+      targets: [],
+    };
+
+    test('Parses fields filters in queries', () => {
+      const result = getMatcherFromQuery('{service_name="tempo-distributor"} | label="value"');
+
+      expect(result.fields).toEqual([
+        {
+          key: 'label',
+          operator: '=',
+          parser: undefined,
+          type: 'S',
+          value: 'value',
+        },
+      ]);
+    });
+
+    test('Parses fields filters in queries with a given context', () => {
+      const result = getMatcherFromQuery('{service_name="tempo-distributor"} | logfmt | label="value"', context, {
+        refId: 'test',
+        expr: '',
+      });
+
+      expect(result.fields).toEqual([
+        {
+          key: 'label',
+          operator: '=',
+          parser: 'logfmt',
+          type: 'P',
+          value: 'value',
+        },
+      ]);
+    });
+  });
+});

--- a/src/services/logqlMatchers.ts
+++ b/src/services/logqlMatchers.ts
@@ -265,12 +265,8 @@ function getStringFieldOperator(matcher: SyntaxNode) {
   return undefined;
 }
 
-function parseFields(
-  query: string,
-  fields: FieldFilter[],
-  context?: PluginExtensionPanelContext,
-  lokiQuery?: LokiQuery
-) {
+function parseFields(query: string, context?: PluginExtensionPanelContext, lokiQuery?: LokiQuery) {
+  const fields: FieldFilter[] = [];
   const dataFrame = context?.data?.series.find((frame) => frame.refId === lokiQuery?.refId);
   // We do not currently support "or" in Grafana Logs Drilldown, so grab the left hand side LabelFilter leaf nodes as this will be the first filter expression in a given pipeline stage
   const allFields = getNodesFromQuery(query, [LabelFilter]);
@@ -352,6 +348,7 @@ function parseFields(
       });
     }
   }
+  return fields;
 }
 
 export function getMatcherFromQuery(
@@ -367,7 +364,6 @@ export function getMatcherFromQuery(
   const filter: IndexedLabelFilter[] = [];
   const lineFilters: LineFilterType[] = [];
   const patternFilters: PatternFilterType[] = [];
-  const fields: FieldFilter[] = [];
   const selector = getNodesFromQuery(query, [Selector]);
 
   if (selector.length === 0) {
@@ -379,7 +375,7 @@ export function getMatcherFromQuery(
 
   parseLabelFilters(selectorQuery, filter);
   parseLineFilters(query, lineFilters, patternFilters);
-  parseFields(query, fields, context, lokiQuery);
+  const fields = parseFields(query, context, lokiQuery);
 
   return { fields, labelFilters: filter, lineFilters, patternFilters };
 }

--- a/src/services/logqlMatchers.ts
+++ b/src/services/logqlMatchers.ts
@@ -102,7 +102,8 @@ function getAllPositionsInNodeByType(node: SyntaxNode, type: number): NodePositi
   return positions;
 }
 
-function parseLabelFilters(query: string, filter: IndexedLabelFilter[]) {
+function parseLabelFilters(query: string) {
+  const filters: IndexedLabelFilter[] = [];
   // `Matcher` will select field filters as well as indexed label filters
   const allMatcher = getNodesFromQuery(query, [Matcher]);
   for (const matcher of allMatcher) {
@@ -127,13 +128,14 @@ function parseLabelFilters(query: string, filter: IndexedLabelFilter[]) {
       continue;
     }
 
-    filter.push({
+    filters.push({
       key,
       operator,
       type: LabelType.Indexed,
       value,
     });
   }
+  return filters;
 }
 
 function parseNonPatternFilters(
@@ -185,7 +187,9 @@ function parsePatternFilters(lineFilterValue: string, patternFilters: PatternFil
   });
 }
 
-function parseLineFilters(query: string, lineFilters: LineFilterType[], patternFilters: PatternFilterType[]) {
+function parseLineFilters(query: string) {
+  const lineFilters: LineFilterType[] = [];
+  const patternFilters: PatternFilterType[] = [];
   const allLineFilters = getNodesFromQuery(query, [LineFilter]);
   for (const [index, matcher] of allLineFilters.entries()) {
     const equal = getAllPositionsInNodeByType(matcher, PipeExact);
@@ -233,6 +237,7 @@ function parseLineFilters(query: string, lineFilters: LineFilterType[], patternF
       }
     }
   }
+  return { lineFilters, patternFilters };
 }
 
 function getNumericFieldOperator(matcher: SyntaxNode) {
@@ -362,8 +367,6 @@ export function getMatcherFromQuery(
   patternFilters?: PatternFilterType[];
 } {
   const filter: IndexedLabelFilter[] = [];
-  const lineFilters: LineFilterType[] = [];
-  const patternFilters: PatternFilterType[] = [];
   const selector = getNodesFromQuery(query, [Selector]);
 
   if (selector.length === 0) {
@@ -372,12 +375,11 @@ export function getMatcherFromQuery(
 
   // Get the stream selector portion of the query
   const selectorQuery = getAllPositionsInNodeByType(selector[0], Selector)[0].getExpression(query);
-
-  parseLabelFilters(selectorQuery, filter);
-  parseLineFilters(query, lineFilters, patternFilters);
+  const labelFilters = parseLabelFilters(selectorQuery);
   const fields = parseFields(query, context, lokiQuery);
+  const { lineFilters, patternFilters } = parseLineFilters(query);
 
-  return { fields, labelFilters: filter, lineFilters, patternFilters };
+  return { fields, labelFilters, lineFilters, patternFilters };
 }
 
 export function isQueryWithNode(query: string, nodeType: number): boolean {


### PR DESCRIPTION
Parsed line filters were being passed as "defaultLineFilters", but because they came from the parser, they were lacking a generated attribute called `keyLabel`.

Additionally, switched from using mutation to pure functions and added a few unit tests.

<img width="993" height="596" alt="Error" src="https://github.com/user-attachments/assets/1ea09506-ad5d-496c-916f-8a7709b6fb32" />
