### PR TITLE
feat(levels): allow custom options in level variable

### DIFF
--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -15,7 +15,7 @@ weight: 800
 You can easily view and interact with your JSON formatted logs using the Logs Drilldown JSON viewer. This view will help you read your JSON style logs, and filter through them to make your related visualizations more relevant and focused.
 
 {{< admonition type="note" >}}
-Logs Drilldown JSON Viewer is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To use this feature, you must be running Loki 3.5.0 or later.
+To use this feature, you must be running Loki 3.5.0 or later.
 {{< /admonition >}}
 
 ## Viewing JSON logs

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -146,6 +146,8 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
           onOpenMenu={model.getTagValues}
           onFocus={() => model.openSelect(true)}
           menuShouldPortal={true}
+          allowCustomValue={true}
+          onCreateOption={model.onCreateCustomOption(model, options)}
           isOpen={isOpen}
           isLoading={isLoading}
           isClearable={true}
@@ -162,6 +164,14 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
         />
       </div>
     );
+  };
+  private onCreateCustomOption = (model: LevelsVariableScene, options: ChipOption[] | undefined) => {
+    return (value: string) => {
+      const newOption = { selected: true, text: value, value };
+      model.setState({
+        options: options ? [...options, newOption] : [newOption],
+      });
+    };
   };
 }
 export function syncLevelsVariable(sceneRef: SceneObject) {

--- a/src/Components/ServiceScene/JSONPanel/LogsJSONComponent.tsx
+++ b/src/Components/ServiceScene/JSONPanel/LogsJSONComponent.tsx
@@ -138,11 +138,7 @@ export default function LogsJSONComponent({ model }: SceneComponentProps<JSONLog
         showMenuAlways={true}
         statusMessage={$data.state.data?.errors?.[0].message}
         loadingState={$data.state.data?.state}
-        title={
-          <>
-            JSON <Badge color={'blue'} text={'Experimental'} />
-          </>
-        }
+        title={'JSON'}
         menu={menu ? <menu.Component model={menu} /> : undefined}
         actions={<LogsPanelHeaderActions vizType={visualizationType} onChange={logsListScene.setVisualizationType} />}
       >

--- a/src/Components/ServiceScene/JSONPanel/LogsJSONComponent.tsx
+++ b/src/Components/ServiceScene/JSONPanel/LogsJSONComponent.tsx
@@ -4,10 +4,10 @@ import { css } from '@emotion/css';
 
 import { colorManipulator, FieldType, GrafanaTheme2 } from '@grafana/data';
 import { AdHocFilterWithLabels, SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { Alert, Badge, PanelChrome, useStyles2 } from '@grafana/ui';
+import { Alert, PanelChrome, useStyles2 } from '@grafana/ui';
 
 import { NoMatchingLabelsScene } from '../Breakdowns/NoMatchingLabelsScene';
-import { JSONVizRootName, JSONLogsScene } from '../JSONLogsScene';
+import { JSONLogsScene, JSONVizRootName } from '../JSONLogsScene';
 import LabelRenderer from '../JSONPanel/LabelRenderer';
 import ValueRenderer from '../JSONPanel/ValueRenderer';
 import { LogListControls } from '../LogListControls';


### PR DESCRIPTION
Allows users to add a custom level value.
Since the detected_fields endpoint that returns level values is sampled, some valid values might not be presented to the user in the variable dropdown. Lets let users add a custom value since the list of options in the dropdown is not exhaustive. 

Fixes: https://github.com/grafana/logs-drilldown/issues/1503

