### PR TITLE
fix(ServiceSelectionScene): roll back showing stored displayed fields

### DIFF
--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -567,7 +567,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setOption('showTime', true)
         .setOption('enableLogDetails', false)
         .setOption('fontSize', 'small')
-        .setOption('displayedFields', getDisplayedFieldsForLabelValue(this, labelName, labelValue))
         // @ts-expect-error Requires Grafana 12.2
         .setOption('noInteractions', true)
         .build(),

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -76,12 +76,7 @@ import {
   unwrapWildcardSearch,
   wrapWildcardSearch,
 } from 'services/query';
-import {
-  addTabToLocalStorage,
-  getDisplayedFieldsForLabelValue,
-  getFavoriteLabelValuesFromStorage,
-  getServiceSelectionPageCount,
-} from 'services/store';
+import { addTabToLocalStorage, getFavoriteLabelValuesFromStorage, getServiceSelectionPageCount } from 'services/store';
 import {
   EXPLORATION_DS,
   LEVEL_VARIABLE_VALUE,

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -211,15 +211,6 @@ function getExplorationPrefixForLabelValue(sceneRef: SceneObject, label: string,
   return `${ds}.${label}.${replaceSlash(value)}`;
 }
 
-export function getDisplayedFieldsForLabelValue(sceneRef: SceneObject, label: string, value: string): string[] {
-  const PREFIX = getExplorationPrefixForLabelValue(sceneRef, label, value);
-  const storedFields = localStorage.getItem(`${pluginJson.id}.${PREFIX}.logs.fields`);
-  if (storedFields) {
-    return unknownToStrings(JSON.parse(storedFields)) ?? [];
-  }
-  return [];
-}
-
 export function getDisplayedFields(sceneRef: SceneObject): string[] {
   const PREFIX = getExplorationPrefix(sceneRef);
   const storedFields = localStorage.getItem(`${pluginJson.id}.${PREFIX}.logs.fields`);


### PR DESCRIPTION
This PR reverts the integration of displayed fields in the Service Selection page from https://github.com/grafana/logs-drilldown/pull/1456 . 

There are many situations where the field can be missing during service selection, such as the case for parsed fields, resulting in empty panels or missing values.

If we're required to support this in the future, we can come back to this and introduce parsers to the landing page, which is not expected for now.