### PR TITLE
chore(@grafana/assistant): bump grafana/assistant sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@bsull/augurs": "^0.6.0",
     "@emotion/css": "11.10.6",
-    "@grafana/assistant": "^0.0.14",
+    "@grafana/assistant": "0.0.16",
     "@grafana/data": "^12.1.0",
     "@grafana/i18n": "^12.1.0",
     "@grafana/lezer-logql": "^0.2.7",

--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { firstValueFrom } from 'rxjs';
 
-import { createContext, isAssistantAvailable, ItemDataType, openAssistant } from '@grafana/assistant';
+import { createAssistantContextItem, isAssistantAvailable, openAssistant } from '@grafana/assistant';
 import { DataFrame, GrafanaTheme2, PanelMenuItem, PluginExtensionLink } from '@grafana/data';
 // Certain imports are not available in the dependant package, but can be if the plugin is running in a different Grafana version.
 // We need both imports to support Grafana v11 and v12.
@@ -157,16 +157,14 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
               text: 'Explain in Assistant',
               onClick: () => {
                 openAssistant({
+                  origin: 'logs-drilldown-explore',
                   prompt:
                     'Help me understand this query and provide a summary of the data. Be concise and to the point.',
                   context: [
-                    createContext(ItemDataType.Datasource, {
-                      datasourceName: datasource.name,
+                    createAssistantContextItem('datasource', {
                       datasourceUid: datasource.uid,
-                      datasourceType: datasource.type,
-                      img: datasource.meta?.info?.logos?.small,
                     }),
-                    createContext(ItemDataType.Structured, {
+                    createAssistantContextItem('structured', {
                       title: 'Logs Drilldown Query',
                       data: {
                         query: getQueryExpression(this),

--- a/src/services/assistant.ts
+++ b/src/services/assistant.ts
@@ -1,4 +1,4 @@
-import { createContext as createAssistantContext, ItemDataType, providePageContext } from '@grafana/assistant';
+import { createAssistantContextItem as createAssistantContext, providePageContext } from '@grafana/assistant';
 import { SceneObject } from '@grafana/scenes';
 
 import { getLokiDatasource } from './scenes';
@@ -16,10 +16,8 @@ export const updateAssistantContext = async (
   }
 
   contexts.push(
-    createAssistantContext(ItemDataType.Datasource, {
-      datasourceName: ds.name,
+    createAssistantContext('datasource', {
       datasourceUid: ds.uid,
-      datasourceType: ds.type,
     })
   );
 
@@ -27,9 +25,8 @@ export const updateAssistantContext = async (
   if (labelsVar.state.filters.length > 0) {
     contexts.push(
       ...labelsVar.state.filters.map((filter) =>
-        createAssistantContext(ItemDataType.LabelValue, {
+        createAssistantContext('label_value', {
           datasourceUid: ds.uid,
-          datasourceType: ds.type,
           labelName: filter.key,
           labelValue: filter.value,
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,10 +1126,10 @@
   dependencies:
     tslib "^2.8.0"
 
-"@grafana/assistant@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@grafana/assistant/-/assistant-0.0.14.tgz#29e5fab464c0f392f45b0949ea6a39cf6af765f5"
-  integrity sha512-5Ts3FsucKHNnzn0AaOHBM0ouSc7B+ypTMf61zJFfgtBAopnnR2k/KybSq0zxyznYbvElbJdD1QsaFxJdDzrI5w==
+"@grafana/assistant@0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@grafana/assistant/-/assistant-0.0.16.tgz#af013db8ecdd6d4fc0e0dd398605a8760d8badb1"
+  integrity sha512-ViPkwhBdwGjcI7+++WP1SZmgGr/rrHfgWqE0O+UNbyo+6QCXjl05vYSbDnDmK5tE/OOvsn+X7Y60n0ERe2jzVw==
 
 "@grafana/data@12.1.0", "@grafana/data@^12.1.0":
   version "12.1.0"


### PR DESCRIPTION
This PR updates the `@grafana/assistant` package to it's latest version. 

Additionally I'm proposing to pin down the version instead of automatically updating minor & patch versions to prevent potential issues on automatic upgrades in the ealy stages of our sdk.