### PR TITLE
Hack day: Pulling logs as exemplars

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.test.ts
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.test.ts
@@ -16,4 +16,12 @@ describe('extractValueFromString', () => {
     expect(extractValueFromString('1e9m', 'duration')).toEqual({ unit: 'm', value: 1000000000 });
     expect(extractValueFromString('99µs', 'duration')).toEqual({ unit: 'µs', value: 99 });
   });
+
+  it('should parse floats', () => {
+    expect(extractValueFromString('10.1', 'float')).toEqual({ unit: null, value: 10.1 });
+  });
+
+  it('should return undefined for complex values', () => {
+    expect(extractValueFromString('30m7.343118469s', 'duration')).toEqual(undefined);
+  });
 });

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -144,7 +144,7 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
       if (gtFilter) {
         const extractedValue = extractValueFromString(getValueFromFieldsFilter(gtFilter).value, this.state.fieldType);
 
-        if (extractedValue) {
+        if (extractedValue && extractedValue.unit) {
           stateUpdate.gt = extractedValue.value;
           stateUpdate.gtu = extractedValue.unit;
           stateUpdate.gte = gtFilter.operator === FilterOp.gte;
@@ -154,7 +154,7 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
       if (ltFilter) {
         const extractedValue = extractValueFromString(getValueFromFieldsFilter(ltFilter).value, this.state.fieldType);
 
-        if (extractedValue) {
+        if (extractedValue && extractedValue.unit) {
           stateUpdate.lt = extractedValue.value;
           stateUpdate.ltu = extractedValue.unit;
           stateUpdate.lte = ltFilter.operator === FilterOp.lte;
@@ -416,10 +416,15 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
   };
 }
 
+/**
+ * This works with bytes and duration values that are generated within the UI, not to be used with arbitrary duration values from Loki!
+ * @param inputString
+ * @param inputType
+ */
 export function extractValueFromString(
   inputString: string,
-  inputType: 'bytes' | 'duration'
-): { unit: DisplayByteUnits | DisplayDurationUnits; value: number } | undefined {
+  inputType: 'bytes' | 'duration' | 'float'
+): { unit: DisplayByteUnits | DisplayDurationUnits | null; value: number } | undefined {
   if (inputType === 'duration') {
     const durationValues = Object.values(DisplayDurationUnits);
 
@@ -460,6 +465,14 @@ export function extractValueFromString(
         };
       }
     }
+  }
+
+  if (inputType === 'float') {
+    const value = Number(inputString);
+    return {
+      unit: null,
+      value,
+    };
   }
 
   return undefined;

--- a/src/services/time.ts
+++ b/src/services/time.ts
@@ -1,0 +1,81 @@
+// Adapted from parsePrometheusDuration from /grafana/grafana/public/app/features/alerting/unified/utils/time.ts
+// @todo push up to core?
+// @todo negative numbers
+// @todo unit tests
+
+export enum TimeOptions {
+  nanoSeconds = 'ns',
+  microSeconds = 'µs',
+  milliseconds = 'ms',
+  seconds = 's',
+  minutes = 'm',
+  hours = 'h',
+  days = 'd',
+  weeks = 'w',
+  years = 'y',
+}
+
+const PROMETHEUS_SUFFIX_MULTIPLIER: Record<string, number> = {
+  ns: 1 / 1000 / 1000,
+  µs: 1 / 1000,
+  ms: 1,
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+  y: 365 * 24 * 60 * 60 * 1000,
+};
+
+const DURATION_REGEXP = new RegExp(/^(?:(?<value>\d+(?:\.\d+)?)(?<type>ns|µs|ms|s|m|h|d|w|y))|0$/);
+const INVALID_FORMAT = new Error(
+  `Must be of format "(number)(unit)", for example "1m", or just "0". Available units: ${Object.values(
+    TimeOptions
+  ).join(', ')}`
+);
+
+/**
+ * Parses interval strings from Loki
+ * e.g. 949.96µs, -38m10.878295379s, 147h11m43.529675258s
+ */
+export function parseLokiDuration(duration: string): number {
+  // Don't know how durations can be negative, but loki sends em' back?
+  const multiplier = duration[0] === '-' ? -1 : 1;
+  if (multiplier === -1) {
+    duration = duration.slice(1);
+  }
+
+  let input = duration;
+  const parts: Array<[number, string]> = [];
+
+  function matchDuration(part: string) {
+    const match = DURATION_REGEXP.exec(part);
+    const hasValueAndType = match?.groups?.value && match?.groups?.type;
+
+    if (!match || !hasValueAndType) {
+      throw INVALID_FORMAT;
+    }
+
+    if (match && match.groups?.value && match.groups?.type) {
+      input = input.replace(match[0], '');
+      parts.push([Number(match.groups.value), match.groups.type]);
+    }
+
+    if (input) {
+      matchDuration(input);
+    }
+  }
+
+  matchDuration(duration);
+
+  if (!parts.length) {
+    throw INVALID_FORMAT;
+  }
+
+  const totalDuration = parts.reduce((acc, [value, type]) => {
+    const duration = value * PROMETHEUS_SUFFIX_MULTIPLIER[type];
+    return acc + duration;
+  }, 0);
+
+  return totalDuration * multiplier;
+}

--- a/src/services/transformations.ts
+++ b/src/services/transformations.ts
@@ -1,0 +1,21 @@
+// copied from grafana/grafana/public/app/features/transformers/extractFields/types.ts
+export interface ExtractFieldsOptions {
+  delimiter?: string;
+  format?: FieldExtractorID;
+  jsonPaths?: JSONPath[];
+  keepTime?: boolean;
+  regExp?: string;
+  replace?: boolean;
+  source?: string;
+}
+export enum FieldExtractorID {
+  JSON = 'json',
+  KeyValues = 'kvp',
+  Auto = 'auto',
+  RegExp = 'regexp',
+  Delimiter = 'delimiter',
+}
+export interface JSONPath {
+  alias?: string;
+  path: string;
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -15,13 +15,13 @@ const config = async (env: any): Promise<Configuration> => {
     },
     plugins: [
       // new BundleAnalyzerPlugin(),
-      new LiveReloadPlugin({
-        appendScriptTag: true,
-        delay: 1000,
-        hostname: 'localhost',
-        port: 35828,
-        protocol: 'http',
-      }),
+      // new LiveReloadPlugin({
+      //   appendScriptTag: true,
+      //   delay: 1000,
+      //   hostname: 'localhost',
+      //   port: 35828,
+      //   protocol: 'http',
+      // }),
     ],
   });
 };


### PR DESCRIPTION
Goal:
Pull in existing logs frame as exemplars to avg_over_time panels (duration, bytes, float fields).

Problems:
* Loki query direction: Converting logs to time series as exemplars has a major flaw, all of the logs are clustered together on one end of the range, we’d want a new loki query direction that would enable us to pull logs evenly distributed over the time range. If we ever get to that we’d also want to query equal numbers of logs across p1/p50/p99 so we have exemplary values and median values to compare against

* Scenes doesn’t let you add annotations via transformations ([YET](https://github.com/grafana/scenes/pull/1207)), the datalayer API provides annotation support, but that requires that you fire a query for each data provider layer (AFAIK, but my understanding of the datalayer stuff is not great), I hacked it together by manually setting the data provider state. If we ever get to this we’d either need to make scenes changes to provide a different transformation layer that allows adding annotation frames, or we’d need to fire an additional logs query for every duration/bytes/float field.

* Duration/bytes: Grafana doesn’t currently support converting loki duration/bytes units to numeric values, I [hacked in duration support](https://github.com/grafana/logs-drilldown/blob/b58ddab16c37778e502770d0b78dfd7fd1baf683/src/services/time.ts) (and found a [potential loki bug](https://github.com/grafana/loki/issues/18977) with negative duration in the process), but bytes would still need some love. Not a lot of work, but took more finagling then I expected.

* Histograms don’t support exemplars. Maybe not a huge deal but leads to a confusing UX if exemplars are only present when duration/bytes/float fields only have exemplars when the time series option is selected.

* Exemplar performance is atrocious, Leon is working on making this better, but another blocker unless we limit each panel to only a few exemplars, which kinda knee-caps any benefit.

The above is mostly assuming a prometheus-like exemplar use-case for debugging exemplary values in an aggregated time series panel, another potential use would be showing an exemplar for each pinned log, but the juice still aint worth the squeeze.

At least not yet, some changes are in flight that address some of these issues:
https://github.com/grafana/grafana/pull/109758
https://github.com/grafana/grafana/pull/109220
https://github.com/grafana/scenes/pull/1207
https://github.com/grafana/grafana/pull/61594
https://github.com/leeoniya/uMarks

<img width="720" height="240" alt="image" src="https://github.com/user-attachments/assets/6dc09f74-7ee5-42de-9683-4827e7c16e76" />
<img width="720" height="161" alt="image" src="https://github.com/user-attachments/assets/37085de1-2d71-443b-b834-a9728656cbbf" />

Tl;DR:
Probably not worth further investigation at this time, but potentially interesting as a hackathon project.