### PR TITLE
chore: downgrade field errors

### DIFF
--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -404,7 +404,6 @@ async function subscribeToAddToInvestigation(exploreLogsVizPanelMenu: PanelMenu)
 
 export const getPanelWrapperStyles = (theme: GrafanaTheme2) => {
   return {
-    errorWrapper: css({}),
     panelWrapper: css({
       display: 'flex',
       flexDirection: 'column',
@@ -412,6 +411,11 @@ export const getPanelWrapperStyles = (theme: GrafanaTheme2) => {
       label: 'panel-wrapper',
       position: 'absolute',
       width: '100%',
+      // Downgrade severity of panel error
+      'button[aria-label="Panel status"]': {
+        background: 'transparent',
+        color: theme.colors.error.text,
+      },
     }),
   };
 };

--- a/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldValuesBreakdownScene.tsx
@@ -86,7 +86,7 @@ export class FieldValuesBreakdownScene extends SceneObjectBase<FieldValuesBreakd
         <span className={styles.panelWrapper}>
           <FieldsBreakdownScene.LabelsMenu model={fieldsBreakdownScene} />
           {hasError && errorBody && (
-            <div className={styles.errorWrapper}>
+            <div>
               <errorBody.Component model={errorBody} />
             </div>
           )}


### PR DESCRIPTION
Problem:
The base panels don't have any concept of notices, there are panel errors or there aren't.
With recent Loki changes we've added "expected" notices for high cardinality fields so users are able to see panels for all of the fields, but when max series limits are exceeded we return partial data. 

But for users with many high cardinality fields, they are greeted with an onslaught of red errors in every panel, which implies the user did something wrong or has an action to take to correct the problem, but fields with unique IDs will always return these errors if there are more logs then the max series limit set in Loki.

<img width="1727" height="516" alt="image" src="https://github.com/user-attachments/assets/3c935e35-1ece-43d7-ae13-4d85ffc2a756" />

<hr />


This PR simply hacks the CSS of the panel to "tone it down" a bit.

<img width="1727" height="511" alt="image" src="https://github.com/user-attachments/assets/3648df44-ed35-4838-bbf8-e540fabbe6e6" />

<img width="3426" height="850" alt="image" src="https://github.com/user-attachments/assets/921b372a-80b1-423c-96b2-2481a2d3784a" />
<img width="868" height="404" alt="image" src="https://github.com/user-attachments/assets/e5205cb1-454d-4cb7-adec-99207663df27" />
<img width="870" height="432" alt="image" src="https://github.com/user-attachments/assets/57115296-f47a-4d26-ac22-e2cc08d2c095" />


