### PR TITLE
chore: add tenant id to generator, and enable auth in loki

### DIFF
--- a/config/loki-config.yaml
+++ b/config/loki-config.yaml
@@ -1,4 +1,4 @@
-auth_enabled: false
+auth_enabled: true
 
 server:
   http_listen_port: 3100

--- a/docker-compose-syslog.dev.yaml
+++ b/docker-compose-syslog.dev.yaml
@@ -49,6 +49,6 @@ services:
     build:
       context: ./generator
       dockerfile: Dockerfile.syslog
-    command: -otel=false -syslog=true -syslog-network=udp -syslog-addr=alloy:1514
+    command: -otel=false -syslog=true -syslog-network=udp -syslog-addr=alloy:1514 -tenant-id=1
     depends_on:
       - alloy

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -35,6 +35,6 @@ services:
   generator:
     build:
       context: ./generator
-    command: -url http://loki:3100/loki/api/v1/push
+    command: -url http://loki:3100/loki/api/v1/push -tenant-id=1
     environment:
       - OTLP_ENDPOINT=http://loki:3100/otlp

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -41,7 +41,7 @@ services:
   generator:
     build:
       context: ./generator
-    command: -url http://loki:3100/loki/api/v1/push
+    command: -url http://loki:3100/loki/api/v1/push -tenant-id=1
     environment:
       - OTLP_ENDPOINT=http://loki:3100/otlp
   alloy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,6 @@ services:
     restart: on-failure
   generator:
     image: us-docker.pkg.dev/grafanalabs-global/docker-explore-logs-prod/fake-log-generator:latest
-    command: -url http://loki:3100/loki/api/v1/push
+    command: -url http://loki:3100/loki/api/v1/push -tenant-id=1
     environment:
       - OTLP_ENDPOINT=http://loki:3100/otlp

--- a/provisioning/datasources/default.yaml
+++ b/provisioning/datasources/default.yaml
@@ -10,6 +10,7 @@ datasources:
     access: proxy
     url: http://host.docker.internal:3100
     jsonData:
+      httpHeaderName1: 'X-Scope-OrgID'
       derivedFields:
         - datasourceUid: gdev-jaeger
           matcherRegex: traceID
@@ -28,6 +29,8 @@ datasources:
           name: traceID-tempo
           url: '$${__value.raw}'
           urlDisplayLabel: tempo
+    secureJsonData:
+      httpHeaderValue1: '1'
   - name: gdev-tempo
     type: tempo
     uid: gdev-tempo


### PR DESCRIPTION
This PR changes how logs are generated and queried in the local dev stacks to use a tenant id of `1`.