### PR TITLE
chore(faro): faro log successful plugin load

### DIFF
--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -1,11 +1,17 @@
 import React, { lazy } from 'react';
 
 import { AppRootProps } from '@grafana/data';
-const LogExplorationView = lazy(() => import('./LogExplorationPage'));
 
+import { logger } from 'services/logger';
+
+const LogExplorationView = lazy(() => import('./LogExplorationPage'));
 const PluginPropsContext = React.createContext<AppRootProps | null>(null);
 
 class App extends React.PureComponent<AppRootProps> {
+  componentDidMount() {
+    // Log plugin loading success for SLO monitoring
+    logger.info('Plugin loaded successfully');
+  }
   render() {
     return (
       <PluginPropsContext.Provider value={this.props}>


### PR DESCRIPTION
Add a Faro log tracking the plugin successfully loading, to be tried out in a plugin SLO. Since the other [FARO PR](https://github.com/grafana/logs-drilldown/pull/1486) is in a holding pattern due to security concerns, I'm just using the current implementation of Faro.