### PR TITLE
chore: update line filters placeholder

### DIFF
--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -89,7 +89,7 @@ export function LineFilterEditor({
             </span>
           }
           prefix={null}
-          placeholder="Search in log lines"
+          placeholder="Filter logs by string"
           onClear={onClearLineFilter}
           onKeyUp={(e) => {
             handleEnter(e, lineFilter);


### PR DESCRIPTION
Small PR to address a UX papercut, which was mentioned in recent feedback.

For things that update the underlying query, we use "Filter by". Not only that, but the logs panel also has a client-side search that shows a similar placeholder, so confusion is expected.

<img width="862" height="371" alt="imagen" src="https://github.com/user-attachments/assets/c6f21d00-7a3c-414a-876a-708996f11ba4" />

Related with https://github.com/grafana/logs-drilldown/issues/1196