### PR TITLE
chore(LineFilter): increase default width to accommodate for placeholder

### DIFF
--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -18,6 +18,7 @@ export interface LineFilterEditorProps extends LineFilterProps {
 }
 
 const INITIAL_INPUT_WIDTH = 30;
+const DEFAULT_WIDTH = 29;
 
 export function LineFilterEditor({
   caseSensitive,
@@ -73,7 +74,7 @@ export function LineFilterEditor({
         <LineFilterInput
           regex={regex}
           // Only set width if focused
-          width={focus ? width : undefined}
+          width={focus ? width : DEFAULT_WIDTH}
           onFocus={() => setFocus(true)}
           data-testid={testIds.exploreServiceDetails.searchLogs}
           value={lineFilter ?? ''}


### PR DESCRIPTION
Tiny follow up to https://github.com/grafana/logs-drilldown/pull/1538 , where I noticed the following:

<img width="406" height="46" alt="boo" src="https://github.com/user-attachments/assets/778096e7-bd02-4861-a072-d47275aa59da" />
