### PR TITLE
Fix(volume): Field config getting overwritten

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/Panels/ValueSummary.tsx
+++ b/src/Components/ServiceScene/Breakdowns/Panels/ValueSummary.tsx
@@ -283,6 +283,8 @@ function buildValueSummaryPanel(title: string, options?: { levelColor?: boolean 
     getPanelOption('collapsed', [CollapsablePanelText.collapsed, CollapsablePanelText.expanded]) ??
     CollapsablePanelText.expanded;
 
+  // Field config is overwritten by `syncLabelsValueSummaryVisibleSeries`
+  // @todo merge existing options or make sure to set any changes in `setValueSummaryFieldConfigs` as well
   const body = PanelBuilders.timeseries()
     .setTitle(title)
     .setMenu(new PanelMenu({}))

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -10,7 +10,14 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { LegendDisplayMode, PanelContext, SeriesVisibilityChangeMode, useStyles2 } from '@grafana/ui';
+import {
+  DrawStyle,
+  LegendDisplayMode,
+  PanelContext,
+  SeriesVisibilityChangeMode,
+  StackingMode,
+  useStyles2,
+} from '@grafana/ui';
 
 import { areArraysEqual } from '../../services/comparison';
 import { getTimeSeriesExpr } from '../../services/expressions';
@@ -132,11 +139,17 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private getVizPanel() {
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     const isCollapsed = getLogsVolumeOption('collapsed');
-    // Overrides are defined by setLogsVolumeFieldConfigOverrides
+    // Overrides are defined by setLogsVolumeFieldConfigOverrides, any overrides added here will be overwritten!
     const viz = PanelBuilders.timeseries()
       .setTitle(this.getTitle(serviceScene.state.totalLogsCount, serviceScene.state.logsCount))
       .setOption('legend', { calcs: ['sum'], displayMode: LegendDisplayMode.List, showLegend: true })
       .setUnit('short')
+      .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
+      .setCustomFieldConfig('fillOpacity', 100)
+      .setCustomFieldConfig('lineWidth', 0)
+      .setCustomFieldConfig('pointSize', 0)
+      .setCustomFieldConfig('axisSoftMin', 0)
+      .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
       .setMenu(new PanelMenu({ investigationOptions: { labelName: 'level' } }))
       .setCollapsible(true)
       .setCollapsed(isCollapsed)

--- a/src/Components/ServiceScene/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolumePanel.tsx
@@ -24,7 +24,7 @@ import { ServiceScene } from './ServiceScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
-import { getQueryRunner, setLogsVolumeFieldConfigs, syncLevelsVisibleSeries } from 'services/panel';
+import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
 import { buildDataQuery, LINE_LIMIT } from 'services/query';
 import { getLogsVolumeOption, setLogsVolumeOption } from 'services/store';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
@@ -132,6 +132,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private getVizPanel() {
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     const isCollapsed = getLogsVolumeOption('collapsed');
+    // Overrides are defined by setLogsVolumeFieldConfigOverrides
     const viz = PanelBuilders.timeseries()
       .setTitle(this.getTitle(serviceScene.state.totalLogsCount, serviceScene.state.logsCount))
       .setOption('legend', { calcs: ['sum'], displayMode: LegendDisplayMode.List, showLegend: true })
@@ -151,7 +152,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
             ])
       );
 
-    setLogsVolumeFieldConfigs(viz);
+    setLogsVolumeFieldConfigOverrides(viz);
 
     const panel = viz.build();
     panel.setState({

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -124,23 +124,25 @@ export function setLabelSeriesOverrides(labels: string[], overrideConfig: FieldC
 
 /**
  * Sets labels series visibility in the panel
+ * WARNING: Overwrites any fieldConfig overrides set in the panel builder!
  */
 export function syncLevelsVisibleSeries(panel: VizPanel, series: DataFrame[], sceneRef: SceneObject) {
   const focusedLevels = getVisibleLevels(getLevelLabelsFromSeries(series), sceneRef);
   const config = setLogsVolumeFieldConfigOverrides(FieldConfigBuilders.timeseries()).setOverrides(
     setLabelSeriesOverrides.bind(null, focusedLevels)
   );
+
   if (config instanceof FieldConfigBuilder && panel.getPlugin()) {
-    console.log('config.build()', config.build());
-    console.log('panel', panel.state.fieldConfig);
     const fieldConfig = config.build();
-    panel.onFieldConfigChange({ ...fieldConfig, defaults: { ...panel.state.fieldConfig.defaults } }, true);
+    const mergedConfig = { overrides: fieldConfig.overrides, defaults: panel.state.fieldConfig.defaults };
+    panel.onFieldConfigChange(mergedConfig, true);
   }
 }
 
 /**
  * @todo unit test
- * Set levels series visibility in the panel
+ * Set field visibility in the panel
+ * WARNING: Overwrites fieldConfig set in the panel builder!
  */
 export function syncLabelsValueSummaryVisibleSeries(
   key: string,

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -78,17 +78,10 @@ export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<Fi
   });
 }
 
-export function setLogsVolumeFieldConfigs(
+export function setLogsVolumeFieldConfigOverrides(
   builder: ReturnType<typeof PanelBuilders.timeseries> | ReturnType<typeof FieldConfigBuilders.timeseries>
 ) {
-  return builder
-    .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
-    .setCustomFieldConfig('fillOpacity', 100)
-    .setCustomFieldConfig('lineWidth', 0)
-    .setCustomFieldConfig('pointSize', 0)
-    .setCustomFieldConfig('axisSoftMin', 0)
-    .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-    .setOverrides(setLevelColorOverrides);
+  return builder.setOverrides(setLevelColorOverrides);
 }
 
 export function setValueSummaryFieldConfigs(
@@ -134,11 +127,14 @@ export function setLabelSeriesOverrides(labels: string[], overrideConfig: FieldC
  */
 export function syncLevelsVisibleSeries(panel: VizPanel, series: DataFrame[], sceneRef: SceneObject) {
   const focusedLevels = getVisibleLevels(getLevelLabelsFromSeries(series), sceneRef);
-  const config = setLogsVolumeFieldConfigs(FieldConfigBuilders.timeseries()).setOverrides(
+  const config = setLogsVolumeFieldConfigOverrides(FieldConfigBuilders.timeseries()).setOverrides(
     setLabelSeriesOverrides.bind(null, focusedLevels)
   );
   if (config instanceof FieldConfigBuilder && panel.getPlugin()) {
-    panel.onFieldConfigChange(config.build(), true);
+    console.log('config.build()', config.build());
+    console.log('panel', panel.state.fieldConfig);
+    const fieldConfig = config.build();
+    panel.onFieldConfigChange({ ...fieldConfig, defaults: { ...panel.state.fieldConfig.defaults } }, true);
   }
 }
 
@@ -298,7 +294,7 @@ export function getQueryRunner(queries: LokiQuery[], queryRunnerOptions?: Partia
         queries: queries,
         ...queryRunnerOptions,
       }),
-      transformations: [sortLevelTransformation],
+      transformations: [],
     });
   }
 


### PR DESCRIPTION
Fixes bug in logs volume panel where changes to the panel builders were getting overwritten by the `setLogsVolumeFieldConfigOverrides`.

This PR: 
Only sets fieldConfig.overrides instead of completely nuking the config

To test:
I think the only fieldConfig we didn't have duplicated was the short unit.

Notes:
Added some comments but there is still some debt here to pay down. Ideally we could deep compare the overrides and add new ones that don't exist while leaving the existing overrides in case someone adds more overrides in the future.