### PR TITLE
feat(VariableLayoutScene): add control to expand and collapse header filters

### DIFF
--- a/src/Components/Table/ColumnSelection/LogsColumnSearch.tsx
+++ b/src/Components/Table/ColumnSelection/LogsColumnSearch.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Field, IconButton, Input, useTheme2 } from '@grafana/ui';
+import { Field, IconButton, Input, useStyles2 } from '@grafana/ui';
 
 import { debouncedFuzzySearch } from '../../../services/search';
 import { useTableColumnContext } from 'Components/Table/Context/TableColumnsContext';
@@ -17,11 +17,15 @@ function getStyles(theme: GrafanaTheme2) {
       right: theme.spacing(0.2),
       top: theme.spacing(1),
     }),
+    iconExpanded: css({
+      svg: {
+        transform: 'rotate(-180deg)',
+      },
+    }),
   };
 }
 
 interface LogsColumnSearchProps {
-  collapseButtonClassName?: string;
   isTableSidebarCollapsed?: boolean;
   onToggleTableSidebarCollapse?: () => void;
   searchValue: string;
@@ -29,7 +33,6 @@ interface LogsColumnSearchProps {
 }
 
 export function LogsColumnSearch({
-  collapseButtonClassName,
   isTableSidebarCollapsed,
   onToggleTableSidebarCollapse,
   searchValue,
@@ -69,14 +72,13 @@ export function LogsColumnSearch({
     }
   };
 
-  const theme = useTheme2();
-  const styles = getStyles(theme);
+  const styles = useStyles2(getStyles);
   return (
     <>
       <IconButton
-        className={collapseButtonClassName || styles.collapseTableSidebarButton}
+        className={`${styles.collapseTableSidebarButton} ${isTableSidebarCollapsed ? '' : styles.iconExpanded}`}
         onClick={onToggleTableSidebarCollapse}
-        name={isTableSidebarCollapsed ? 'angle-right' : 'angle-left'}
+        name="arrow-from-right"
         tooltip={isTableSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
         size="sm"
       />

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -463,3 +463,13 @@ export function getFieldsPanelTypes(): FieldsPanelsType | null {
 export function setFieldsPanelTypes(panelTypes: FieldsPanelsType) {
   localStorage.setItem(FIELDS_PANEL_TYPES, panelTypes);
 }
+
+// Collapsible filters
+const COLLAPSIBLE_FILTERS_KEY = `${pluginJson.id}.filters.collapsed`;
+export function getCollapsibleFiltersState(): boolean {
+  return !!localStorage.getItem(COLLAPSIBLE_FILTERS_KEY);
+}
+
+export function setCollapsibleFiltersState(state: boolean) {
+  localStorage.setItem(COLLAPSIBLE_FILTERS_KEY, state ? 'true' : '');
+}


### PR DESCRIPTION
Frequent feedback.

Closes [#1495](https://github.com/grafana/logs-drilldown/issues/1495)

https://github.com/user-attachments/assets/51a4807b-4dcc-4b17-a652-c5039f285051


