### PR TITLE
feat(embedded): remove read-only label filters

### DIFF
--- a/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
+++ b/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
@@ -49,7 +49,7 @@ export function buildLogsExplorationFromState({
     $timeRange,
     defaultLineFilters: lineFilters,
     embedded: true,
-    readOnlyLabelFilters: initialLabels,
+    labelFilters: initialLabels,
   });
 }
 

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -140,6 +140,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     const { unsub, variablesScene } = getVariableSet(
       datasourceUid,
       state?.readOnlyLabelFilters,
+      state?.labelFilters,
       state.embedded,
       state.embedderName,
       state.defaultLineFilters
@@ -633,6 +634,7 @@ function getContentScene(drillDownLabel?: string) {
 function getVariableSet(
   initialDatasourceUid: string,
   readOnlyLabelFilters?: AdHocVariableFilter[],
+  labelFilters?: AdHocVariableFilter[],
   embedded?: boolean,
   embedderName?: string,
   defaultLineFilters?: LineFilterType[]
@@ -647,6 +649,7 @@ function getVariableSet(
     layout: 'combobox',
     name: VAR_LABELS,
     onAddCustomValue: onAddCustomAdHocValue,
+    filters: labelFilters ?? [],
     readonlyFilters: (readOnlyLabelFilters ?? []).map((f) => ({ ...f, origin: embedderName, readOnly: true })),
   });
 

--- a/src/Components/IndexScene/types.ts
+++ b/src/Components/IndexScene/types.ts
@@ -16,6 +16,7 @@ export interface IndexSceneState extends SceneObjectState {
   ds?: LokiDatasource;
   embedded?: boolean;
   embedderName?: string;
+  labelFilters?: AdHocVariableFilter[];
   patterns?: AppliedPattern[];
   readOnlyLabelFilters?: AdHocVariableFilter[];
   routeMatch?: OptionalRouteMatch;


### PR DESCRIPTION
Embedded label filters in logql expression will no longer be read-only in `EmbeddedLogsExploration` component.