### PR TITLE
feat: add "where are my logs function"

### DIFF
--- a/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
+++ b/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { AdHocFilterWithLabels, SceneTimeRange, UrlSyncContextProvider } from '@grafana/scenes';
 
@@ -74,7 +74,7 @@ export default function EmbeddedLogsExploration(props: EmbeddedLogsExplorationPr
       initializeMetadataService(true);
       setExploration(buildLogsExplorationFromState(props));
     }
-  }, [exploration, props.datasourceUid, props.embedderName, props.onTimeRangeChange, props.query, props.referenceQuery, props.timeRangeState.from, props.timeRangeState.to]);
+  }, [exploration, props]);
 
   useEffect(() => {
     if (exploration) {

--- a/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
+++ b/src/Components/EmbeddedLogsExploration/EmbeddedLogs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { AdHocFilterWithLabels, SceneTimeRange, UrlSyncContextProvider } from '@grafana/scenes';
 
@@ -11,6 +11,7 @@ import { getMatcherFromQuery } from 'services/logqlMatchers';
 import { initializeMetadataService } from 'services/metadata';
 
 export function buildLogsExplorationFromState({
+  embedderName,
   onTimeRangeChange,
   query,
   referenceQuery,
@@ -57,6 +58,7 @@ export function buildLogsExplorationFromState({
     $timeRange,
     defaultLineFilters: lineFilters,
     embedded: true,
+    embedderName,
     initialLabels,
     referenceLabels,
   });
@@ -72,7 +74,13 @@ export default function EmbeddedLogsExploration(props: EmbeddedLogsExplorationPr
       initializeMetadataService(true);
       setExploration(buildLogsExplorationFromState(props));
     }
-  }, [exploration, props]);
+  }, [exploration, props.datasourceUid, props.embedderName, props.onTimeRangeChange, props.query, props.referenceQuery, props.timeRangeState.from, props.timeRangeState.to]);
+
+  useEffect(() => {
+    if (exploration) {
+      exploration.setState({ embedderName: props.embedderName });
+    }
+  }, [exploration, props.embedderName]);
 
   if (!exploration) {
     return null;

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -203,6 +203,8 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       $variables: state.$variables ?? variablesScene,
       controls: state.controls ?? controls,
       embedded: state.embedded ?? false,
+      embedderName: state.embedderName,
+      isAssistantAvailable: false,
       // Need to clear patterns state when the class in constructed
       patterns: [],
       ...state,
@@ -294,6 +296,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
     this._subs.add(
       isAssistantAvailable().subscribe((isAvailable) => {
+        this.setState({ isAssistantAvailable: isAvailable });
         if (isAvailable && !this.assistantInitialized) {
           this.provideAssistantContext();
         }

--- a/src/Components/IndexScene/types.ts
+++ b/src/Components/IndexScene/types.ts
@@ -18,6 +18,7 @@ export interface IndexSceneState extends SceneObjectState {
   embedded?: boolean;
   embedderName?: string;
   initialLabels?: AdHocVariableFilter[];
+  isAssistantAvailable?: boolean;
   patterns?: AppliedPattern[];
   referenceLabels?: AdHocVariableFilter[];
   routeMatch?: OptionalRouteMatch;

--- a/src/Components/ServiceScene/JSONPanel/LogsJSONComponent.tsx
+++ b/src/Components/ServiceScene/JSONPanel/LogsJSONComponent.tsx
@@ -57,7 +57,7 @@ export default function LogsJSONComponent({ model }: SceneComponentProps<JSONLog
   $data.useState();
 
   const logsListScene = sceneGraph.getAncestor(model, LogsListScene);
-  const { visualizationType, selectedLine } = logsListScene.useState();
+  const { visualizationType, selectedLine, onWhereAreMyLogs } = logsListScene.useState();
   const styles = useStyles2(getStyles, wrapLogMessage);
 
   const fieldsVar = getFieldsVariable(model);
@@ -235,7 +235,11 @@ export default function LogsJSONComponent({ model }: SceneComponentProps<JSONLog
         </>
       )}
       {error && (
-        <LogsPanelError error={error} clearFilters={canClearFilters ? () => clearVariables(model) : undefined} />
+        <LogsPanelError
+          error={error}
+          clearFilters={canClearFilters ? () => clearVariables(model) : undefined}
+          onWhereAreMyLogs={onWhereAreMyLogs}
+        />
       )}
     </div>
   );

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { LoadingState, PanelData } from '@grafana/data';
 import { openAssistant } from '@grafana/assistant';
+import { LoadingState, PanelData } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   SceneComponentProps,
@@ -33,8 +33,8 @@ import { LogsPanelScene } from './LogsPanelScene';
 import { LogsTableScene } from './LogsTableScene';
 import { LogsVolumePanel, logsVolumePanelKey } from './LogsVolume/LogsVolumePanel';
 import { ServiceScene } from './ServiceScene';
-import { isEmptyLogsResult } from 'services/logsFrame';
 import { buildAssistantContext } from 'services/assistant';
+import { isEmptyLogsResult } from 'services/logsFrame';
 import {
   getBooleanLogOption,
   getDisplayedFields,
@@ -265,7 +265,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     }
   }
 
-  showLogsError({ message, isEmptyResult }: { message: string; isEmptyResult: boolean }) {
+  showLogsError({ message, isEmptyResult }: { isEmptyResult: boolean; message: string }) {
     const logsVolumeCollapsedByError = this.state.logsVolumeCollapsedByError ?? !getLogsVolumeOption('collapsed');
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
     const clearableVariables = getVariablesThatCanBeCleared(indexScene);
@@ -297,7 +297,12 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     }
 
     this.whereAreMyLogsHandler = undefined;
-    this.setState({ error: undefined, isEmptyResult: undefined, logsVolumeCollapsedByError: undefined, onWhereAreMyLogs: null });
+    this.setState({
+      error: undefined,
+      isEmptyResult: undefined,
+      logsVolumeCollapsedByError: undefined,
+      onWhereAreMyLogs: null,
+    });
 
     // Recreate the panel with the cleared error state
     this.updateLogsPanel();

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -438,7 +438,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 
   private getWhereAreMyLogsHandler(indexScene: IndexScene, isEmptyResult: boolean) {
     if (
-      !isEmptyResult ||
+      !this.state.isEmptyResult ||
       !indexScene.state.embedded ||
       indexScene.state.embedderName !== 'Asserts' ||
       !indexScene.state.currentFiltersMatchReference ||

--- a/src/Components/ServiceScene/LogsPanelError.tsx
+++ b/src/Components/ServiceScene/LogsPanelError.tsx
@@ -7,18 +7,26 @@ import { GrotError } from 'Components/GrotError';
 interface Props {
   clearFilters?: () => void;
   error: string;
+  onWhereAreMyLogs?: (() => void) | null;
 }
 
-export const LogsPanelError = ({ clearFilters, error }: Props) => {
+export const LogsPanelError = ({ clearFilters, error, onWhereAreMyLogs }: Props) => {
   return (
     <GrotError>
       <div>
         <p>{error}</p>
-        {clearFilters && (
-          <Button variant="secondary" onClick={clearFilters}>
-            Clear filters
-          </Button>
-        )}
+        <div className="gf-form-button-row">
+          {clearFilters && (
+            <Button variant="secondary" onClick={clearFilters}>
+              Clear filters
+            </Button>
+          )}
+          {onWhereAreMyLogs && (
+            <Button variant="secondary" onClick={onWhereAreMyLogs} icon="ai-sparkle">
+              Where are my logs?
+            </Button>
+          )}
+        </div>
       </div>
     </GrotError>
   );

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -477,7 +477,11 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
         <span className={styles.panelWrapper}>
           {!error && <body.Component model={body} />}
           {error && (
-            <LogsPanelError error={error} clearFilters={canClearFilters ? () => clearVariables(body) : undefined} />
+            <LogsPanelError
+              error={error}
+              clearFilters={canClearFilters ? () => clearVariables(body) : undefined}
+              onWhereAreMyLogs={model.getParentScene().state.onWhereAreMyLogs}
+            />
           )}
         </span>
       );

--- a/src/Components/ServiceScene/LogsTableScene.tsx
+++ b/src/Components/ServiceScene/LogsTableScene.tsx
@@ -323,7 +323,11 @@ export class LogsTableScene extends SceneObjectBase<LogsTableSceneState> {
           </>
         )}
         {error && (
-          <LogsPanelError error={error} clearFilters={canClearFilters ? () => clearVariables(model) : undefined} />
+          <LogsPanelError
+            error={error}
+            clearFilters={canClearFilters ? () => clearVariables(model) : undefined}
+            onWhereAreMyLogs={parentModel.state.onWhereAreMyLogs}
+          />
         )}
       </div>
     );

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -808,43 +808,6 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     }
   }
 
-  public getIndexScene() {
-    try {
-      return sceneGraph.getAncestor(this, IndexScene);
-    } catch (e) {
-      return sceneGraph.findDescendents(this, IndexScene)[0];
-    }
-  }
-
-  private handleServiceSceneUrlSync(values: SceneObjectUrlValues) {
-    const stateUpdate: Partial<ServiceSceneState> = {};
-
-    // pageSlug and drillDownLabel url params are only used when embedded
-    if (!this.state.embedded) {
-      return;
-    }
-
-    if (values && typeof values.pageSlug === 'string' && values.pageSlug !== this.state.pageSlug) {
-      const pageSlug = narrowPageOrValueSlug(values.pageSlug);
-      if (pageSlug) {
-        stateUpdate.pageSlug = pageSlug;
-      }
-    }
-
-    if (
-      (values && typeof values.drillDownLabel === 'string') ||
-      (values.drillDownLabel === null && values.drillDownLabel !== this.state.drillDownLabel)
-    ) {
-      stateUpdate.drillDownLabel = values.drillDownLabel ?? undefined;
-    }
-
-    if (Object.keys(stateUpdate).length) {
-      this.setState(stateUpdate);
-      // Need to manually re-render content scene when updated
-      this.updateContentScene();
-    }
-  }
-
   static Component = ({ model }: SceneComponentProps<ServiceScene>) => {
     const { body } = model.useState();
     const indexScene = sceneGraph.getAncestor(model, IndexScene);

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -808,6 +808,43 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     }
   }
 
+  public getIndexScene() {
+    try {
+      return sceneGraph.getAncestor(this, IndexScene);
+    } catch (e) {
+      return sceneGraph.findDescendents(this, IndexScene)[0];
+    }
+  }
+
+  private handleServiceSceneUrlSync(values: SceneObjectUrlValues) {
+    const stateUpdate: Partial<ServiceSceneState> = {};
+
+    // pageSlug and drillDownLabel url params are only used when embedded
+    if (!this.state.embedded) {
+      return;
+    }
+
+    if (values && typeof values.pageSlug === 'string' && values.pageSlug !== this.state.pageSlug) {
+      const pageSlug = narrowPageOrValueSlug(values.pageSlug);
+      if (pageSlug) {
+        stateUpdate.pageSlug = pageSlug;
+      }
+    }
+
+    if (
+      (values && typeof values.drillDownLabel === 'string') ||
+      (values.drillDownLabel === null && values.drillDownLabel !== this.state.drillDownLabel)
+    ) {
+      stateUpdate.drillDownLabel = values.drillDownLabel ?? undefined;
+    }
+
+    if (Object.keys(stateUpdate).length) {
+      this.setState(stateUpdate);
+      // Need to manually re-render content scene when updated
+      this.updateContentScene();
+    }
+  }
+
   static Component = ({ model }: SceneComponentProps<ServiceScene>) => {
     const { body } = model.useState();
     const indexScene = sceneGraph.getAncestor(model, IndexScene);

--- a/src/services/assistant.ts
+++ b/src/services/assistant.ts
@@ -1,18 +1,15 @@
-import { createAssistantContextItem, providePageContext } from '@grafana/assistant';
+import { ChatContextItem, createAssistantContextItem, providePageContext } from '@grafana/assistant';
 import { SceneObject } from '@grafana/scenes';
 
 import { getLokiDatasource } from './scenes';
 import { getLabelsVariable } from './variableGetters';
 
-export const updateAssistantContext = async (
-  model: SceneObject,
-  setAssistantContext: ReturnType<typeof providePageContext>
-) => {
-  const contexts = [];
+export const buildAssistantContext = async (model: SceneObject): Promise<ChatContextItem[]> => {
+  const contexts: ChatContextItem[] = [];
 
   const ds = await getLokiDatasource(model);
   if (!ds) {
-    return;
+    return contexts;
   }
 
   contexts.push(
@@ -32,6 +29,18 @@ export const updateAssistantContext = async (
         })
       )
     );
+  }
+
+  return contexts;
+};
+
+export const updateAssistantContext = async (
+  model: SceneObject,
+  setAssistantContext: ReturnType<typeof providePageContext>
+) => {
+  const contexts = await buildAssistantContext(model);
+  if (contexts.length === 0) {
+    return;
   }
 
   setAssistantContext(contexts);


### PR DESCRIPTION
## Why

Addresses issue https://github.com/grafana/asserts-app-plugin/issues/2164

It often happens that there are no logs matching the filter for a given logs configuration in Asserts. For this, I would like to introduce a "Where are my logs button?" that appears whenever logs drilldown is embedded into Asserts.

## What

### Disclaimer: code is mostly generated by AI

- Provides context for searching for logs via Grafana Assistant whenever there are no logs matching default search criteria.
- [time context is coming from Asserts app plugin](https://github.com/grafana/asserts-app-plugin/pull/2178)

## Testing notes

Tested locally against assertsdemo environment:

<img width="2460" height="1269" alt="image" src="https://github.com/user-attachments/assets/d36da11d-b2a7-444e-a461-bec10127d149" />