### PR TITLE
fix: unexpected clear variable behavior

### DIFF
--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -40,7 +40,7 @@ import { StatusWrapper } from './StatusWrapper';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { getFieldOptions } from 'services/filters';
 import { getSortByPreference } from 'services/store';
-import { ALL_VARIABLE_VALUE, VAR_FIELD_GROUP_BY, VAR_LABELS } from 'services/variables';
+import { ALL_VARIABLE_VALUE, VAR_FIELD_GROUP_BY, VAR_FIELDS, VAR_LABELS } from 'services/variables';
 
 export const averageFields = ['duration', 'count', 'total', 'bytes'];
 export const FIELDS_BREAKDOWN_GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
@@ -171,11 +171,11 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
   private updateOptions(dataFrame: DataFrame) {
     if (!dataFrame || !dataFrame.length) {
       const indexScene = sceneGraph.getAncestor(this, IndexScene);
-      const variablesToClear = getVariablesThatCanBeCleared(indexScene);
+      const variablesToClear = getVariablesThatCanBeCleared(indexScene, VAR_FIELDS);
       let body;
       if (variablesToClear.length > 0) {
         this.state.changeFieldCount?.(0);
-        body = new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) });
+        body = new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this), type: 'fields' });
       } else {
         body = new EmptyLayoutScene({ type: 'fields' });
       }
@@ -234,11 +234,11 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     if (fieldsVariable.state.options && fieldsVariable.state.options.length <= 1) {
       // If there's 1 or fewer fields build the empty or clear layout UI
       const indexScene = sceneGraph.getAncestor(this, IndexScene);
-      const variablesToClear = getVariablesThatCanBeCleared(indexScene);
+      const variablesToClear = getVariablesThatCanBeCleared(indexScene, VAR_FIELDS);
 
       if (variablesToClear.length > 0) {
         this.state.changeFieldCount?.(0);
-        stateUpdate.body = new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) });
+        stateUpdate.body = new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this), type: 'fields' });
       } else {
         stateUpdate.body = new EmptyLayoutScene({ type: 'fields' });
       }

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -172,9 +172,8 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     if (!dataFrame || !dataFrame.length) {
       const indexScene = sceneGraph.getAncestor(this, IndexScene);
       const variablesToClear = getVariablesThatCanBeCleared(indexScene);
-
       let body;
-      if (variablesToClear.length > 1) {
+      if (variablesToClear.length > 0) {
         this.state.changeFieldCount?.(0);
         body = new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) });
       } else {
@@ -237,7 +236,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       const indexScene = sceneGraph.getAncestor(this, IndexScene);
       const variablesToClear = getVariablesThatCanBeCleared(indexScene);
 
-      if (variablesToClear.length > 1) {
+      if (variablesToClear.length > 0) {
         this.state.changeFieldCount?.(0);
         stateUpdate.body = new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) });
       } else {

--- a/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelValuesBreakdownScene.tsx
@@ -309,7 +309,7 @@ export class LabelValuesBreakdownScene extends SceneObjectBase<LabelValueBreakdo
         const indexScene = sceneGraph.getAncestor(this, IndexScene);
         const variablesToClear = getVariablesThatCanBeCleared(indexScene);
 
-        if (variablesToClear.length > 1) {
+        if (variablesToClear.length > 0) {
           this.setState({
             body: new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) }),
           });

--- a/src/Components/ServiceScene/Breakdowns/NoMatchingLabelsScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NoMatchingLabelsScene.tsx
@@ -8,14 +8,15 @@ import { emptyStateStyles } from './FieldsBreakdownScene';
 
 export interface ClearFiltersLayoutSceneState extends SceneObjectState {
   clearCallback: () => void;
+  type?: 'fields' | 'labels';
 }
 export class NoMatchingLabelsScene extends SceneObjectBase<ClearFiltersLayoutSceneState> {
   public static Component = ({ model }: SceneComponentProps<NoMatchingLabelsScene>) => {
-    const { clearCallback } = model.useState();
+    const { clearCallback, type = 'labels' } = model.useState();
     return (
       <GrotError>
         <Alert title="" severity="info">
-          No labels match these filters.{' '}
+          No {type} match these filters.{' '}
           <Button className={emptyStateStyles.button} onClick={() => clearCallback()}>
             Clear filters
           </Button>{' '}

--- a/src/services/variableHelpers.ts
+++ b/src/services/variableHelpers.ts
@@ -10,14 +10,20 @@ import { isOperatorInclusive } from './operatorHelpers';
 import { includeOperators, numericOperators, operators } from './operators';
 import { getRouteParams } from './routing';
 import { getLabelsVariable } from './variableGetters';
-import { SERVICE_NAME, SERVICE_UI_LABEL, VAR_LABELS } from './variables';
+import { SERVICE_NAME, SERVICE_UI_LABEL, VAR_FIELDS, VAR_LABELS } from './variables';
 
 type ClearableVariable = AdHocFiltersVariable | CustomConstantVariable;
-export function getVariablesThatCanBeCleared(indexScene: IndexScene): ClearableVariable[] {
+export function getVariablesThatCanBeCleared(
+  indexScene: IndexScene,
+  variableName?: typeof VAR_LABELS | typeof VAR_FIELDS
+): ClearableVariable[] {
   const variables = sceneGraph.getVariables(indexScene);
   let variablesToClear: ClearableVariable[] = [];
 
   for (const variable of variables.state.variables) {
+    if (variableName && variable.state.name !== variableName) {
+      continue;
+    }
     if (variable instanceof AdHocFiltersVariable && variable.state.filters.length) {
       variablesToClear.push(variable);
     }

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1414,7 +1414,7 @@ test.describe('explore services breakdown page', () => {
     await page.goto(
       '/a/grafana-lokiexplore-app/explore/service/nginx-json/fields?var-ds=gdev-loki&from=now-5m&to=now&patterns=%5B%5D&var-fields=bytes|=|""&var-levels=&var-patterns=&var-lineFilter=&var-filters=service_name%7C%3D%7Cnginx-json&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&var-fieldBy=$__all'
     );
-    await expect(page.getByText('No labels match these filters.')).toHaveCount(1);
+    await expect(page.getByText('No fields match these filters.')).toHaveCount(1);
     await expect(page.getByLabel(E2EComboboxStrings.editByKey('bytes'))).toHaveCount(1);
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(0);
     await page.getByText('Clear filters').click();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -4,7 +4,7 @@ import { DEFAULT_URL_COLUMNS } from '../src/Components/Table/constants';
 import { FilterOp } from '../src/services/filterTypes';
 import { LokiQuery, LokiQueryDirection } from '../src/services/lokiQuery';
 import { testIds } from '../src/services/testIds';
-import { SERVICE_NAME } from '../src/services/variables';
+import { SERVICE_NAME, VAR_FIELDS } from '../src/services/variables';
 import { ComboBoxIndex, E2EComboboxStrings, ExplorePage, levelTextMatch, PlaywrightRequest } from './fixtures/explore';
 import { mockEmptyQueryApiResponse } from './mocks/mockEmptyQueryApiResponse';
 
@@ -1379,14 +1379,37 @@ test.describe('explore services breakdown page', () => {
     expect(responses[responses.length - 1][key[0]].results[key[0]].status).toBe(200);
   });
 
-  // @todo add labels test
+  test('should see empty labels UI', async ({ page }) => {
+    explorePage.blockAllQueriesExcept({
+      legendFormats: [`{{${labelName}}}`],
+    });
+    await page.goto(
+      '/a/grafana-lokiexplore-app/explore/service/nginx/labels?var-ds=gdev-loki&from=now-5m&to=now&patterns=%5B%5D&var-fields=&var-levels=&var-patterns=&var-lineFilter=&var-filters=service_name%7C%3D%7Cnginx&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&var-fieldBy=$__all'
+    );
+    await page.getByRole('link', { name: 'Select cluster' }).click();
+    await expect.poll(() => page.getByTestId('data-testid button-filter-exclude').count()).toBeGreaterThan(0);
+    const excludeButtons = await page.getByTestId('data-testid button-filter-exclude').all();
+
+    for (const locator of excludeButtons) {
+      await locator.click();
+    }
+    await expect(page.getByText('No labels match these filters.')).toHaveCount(1);
+    await page.getByText('Clear filters').click();
+    await expect.poll(() => explorePage.getAllPanelsLocator().count()).toBeGreaterThan(0);
+  });
+
   test('should see empty fields UI', async ({ page }) => {
     await page.goto(
       '/a/grafana-lokiexplore-app/explore/service/nginx/fields?var-ds=gdev-loki&from=now-5m&to=now&patterns=%5B%5D&var-fields=&var-levels=&var-patterns=&var-lineFilter=&var-filters=service_name%7C%3D%7Cnginx&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&var-fieldBy=$__all'
     );
     await expect(page.getByText('We did not find any fields for the given timerange.')).toHaveCount(1);
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(0);
+    await explorePage.addCustomValueToCombobox('test', FilterOp.Equal, ComboBoxIndex.fields, 'test', 'test');
+    await expect(page.getByText('No fields match these filters.')).toHaveCount(1);
+    await page.getByText('Clear filters').click();
+    await expect(page.getByText('We did not find any fields for the given timerange.')).toHaveCount(1);
   });
+
   test('should see clear fields UI', async ({ page }) => {
     await page.goto(
       '/a/grafana-lokiexplore-app/explore/service/nginx-json/fields?var-ds=gdev-loki&from=now-5m&to=now&patterns=%5B%5D&var-fields=bytes|=|""&var-levels=&var-patterns=&var-lineFilter=&var-filters=service_name%7C%3D%7Cnginx-json&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&var-fieldBy=$__all'

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1379,6 +1379,7 @@ test.describe('explore services breakdown page', () => {
     expect(responses[responses.length - 1][key[0]].results[key[0]].status).toBe(200);
   });
 
+  // @todo add labels test
   test('should see empty fields UI', async ({ page }) => {
     await page.goto(
       '/a/grafana-lokiexplore-app/explore/service/nginx/fields?var-ds=gdev-loki&from=now-5m&to=now&patterns=%5B%5D&var-fields=&var-levels=&var-patterns=&var-lineFilter=&var-filters=service_name%7C%3D%7Cnginx&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&var-fieldBy=$__all'


### PR DESCRIPTION
Fixes: https://github.com/grafana/logs-drilldown/issues/1566

If there are any variables that can be cleared we should be showing the "clear variables" button instead of the empty state UI.