### PR TITLE
chore(ci): update deployment tools wf

### DIFF
--- a/.github/workflows/update-deployment-tools.yml
+++ b/.github/workflows/update-deployment-tools.yml
@@ -1,10 +1,8 @@
 name: Update Deployment Tools
 description: |
-  Updates the version of a plugin in deployment_tools libsonnet files.
+  Updates the catalog version of a plugin in deployment_tools libsonnet files.
   This action can update a single environment or all environments at once.
-  If provisioning from the plugins catalog, set catalog to true.
-  Be mindful if there is a mix of catalog and non-catalog plugins in the same environment, all will not work as intended.
-  It will modify the version string in the specified libsonnet files and create a commit with the changes.
+  It will modify the _catalog_version string in the specified libsonnet files and create a commit with the changes.
 
 on:
   workflow_dispatch:
@@ -23,11 +21,6 @@ on:
           - prod-canary
           - prod
           - all
-      catalog:
-        description: 'Provision from the plugins catalog'
-        required: true
-        type: boolean
-        default: false
 
 env:
   PLUGIN_ID: grafana-lokiexplore-app
@@ -35,10 +28,12 @@ env:
 jobs:
   build-latest-version:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication with Vault
+      contents: read # Required to read repository contents
     env:
       ENV_INPUT: ${{ inputs.env }}
       VERSION_INPUT: ${{ inputs.version }}
-      CATALOG_INPUT: ${{ inputs.catalog }}
     steps:
       - name: Compute libsonnet paths
         id: compute-paths
@@ -51,7 +46,7 @@ jobs:
 
       - name: Get secrets from Vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         env:
           VAULT_INSTANCE: ops
         with:
@@ -91,7 +86,7 @@ jobs:
             esac
           fi
 
-      # Update version/catalog in the libsonnet file(s)
+      # Update catalog version in the libsonnet file(s)
       - name: Update libsonnet
         run: |
           set -euo pipefail
@@ -103,22 +98,12 @@ jobs:
 
           for path in "${paths[@]}"; do
             echo "Updating $path"
-            if [ "$CATALOG_INPUT" = "true" ]; then
-              count=$(grep -c "_catalog_version: '.*'," "$path")
-              if [ "$count" -eq 1 ]; then
-                sed -i "s/_catalog_version: '.*',/_catalog_version: '${VERSION_INPUT}',/" "$path"
-              else
-                echo "Unexpected format in $path; skipping"
-                exit 1
-              fi
+            count=$(grep -c "_catalog_version: '.*'," "$path")
+            if [ "$count" -eq 1 ]; then
+              sed -i "s/_catalog_version: '.*',/_catalog_version: '${VERSION_INPUT}',/" "$path"
             else
-              count=$(grep -c "version: '.*'," "$path")
-              if [ "$count" -eq 1 ]; then
-                sed -i "s/version: '.*',/version: '${VERSION_INPUT}',/" "$path"
-              else
-                echo "Unexpected format in $path; skipping"
-                exit 1
-              fi
+              echo "Unexpected format in $path; skipping"
+              exit 1
             fi
             git add "$path"
           done
@@ -127,11 +112,7 @@ jobs:
         id: commit-msg
         run: |
           set -euo pipefail
-          SUFFIX=""
-          if [ "$CATALOG_INPUT" = "true" ]; then
-            SUFFIX=" (catalog)"
-          fi
-          echo "message=chore: update $PLUGIN_ID version in $ENV_INPUT to [$VERSION_INPUT]$SUFFIX DrillDown[BOT]" >> $GITHUB_OUTPUT
+          echo "message=chore: update $PLUGIN_ID version in $ENV_INPUT to [$VERSION_INPUT] (catalog) DrillDown[BOT]" >> $GITHUB_OUTPUT
 
       - name: Commit update
         id: commit-update


### PR DESCRIPTION
In the operational sync other teams expressed interest in trying this workflow in addition to the other rollback options. Fixed the permissions issues and remove the legacy version update since everyone already switched the catalogue.  Once it's merged I'll try updating dev. If people find it useful I'll try to get it into plugin-ci-workflows.