### PR TITLE
chore: promote aggregated metrics to GA

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -214,7 +214,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
       );
     }
 
-    if (getDrilldownSlug() === 'explore' && config.featureToggles.exploreLogsAggregatedMetrics) {
+    if (getDrilldownSlug() === 'explore') {
       controls.push(
         new ToolbarScene({
           isOpen: false,

--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -22,6 +22,7 @@ import {
   CONTROLS_JSON_FIELDS,
   CONTROLS_VARS_DATASOURCE,
   CONTROLS_VARS_FIELDS_COMBINED,
+  CONTROLS_VARS_TOOLBAR,
   LayoutScene,
 } from './LayoutScene';
 import { PatternControls } from './PatternControls';
@@ -118,6 +119,12 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
                       }
                     />
                   )}
+                  {slug === PageSlugs.explore &&
+                    controls.map((control) => {
+                      return control.state.key === CONTROLS_VARS_TOOLBAR ? (
+                        <control.Component key={control.state.key} model={control} />
+                      ) : null;
+                    })}
 
                   {model.state.embeddedLink && <model.state.embeddedLink.Component model={model.state.embeddedLink} />}
 
@@ -130,7 +137,8 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
                   <div className={styles.timeRange}>
                     {controls.map((control) => {
                       return !(control instanceof CustomVariableValueSelectors) &&
-                        !(control instanceof SceneFlexLayout) ? (
+                        !(control instanceof SceneFlexLayout) &&
+                        !(control.state.key === CONTROLS_VARS_TOOLBAR) ? (
                         <control.Component key={control.state.key} model={control} />
                       ) : null;
                     })}

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -92,7 +92,7 @@ import {
   VAR_PRIMARY_LABEL_SEARCH,
 } from 'services/variables';
 
-const aggregatedMetricsEnabled: boolean | undefined = config.featureToggles.exploreLogsAggregatedMetrics;
+const aggregatedMetricsEnabled: boolean | undefined = false;
 // Don't export AGGREGATED_SERVICE_NAME, we want to rename things so the rest of the application is agnostic to how we got the services
 const AGGREGATED_SERVICE_NAME = '__aggregated_metric__';
 


### PR DESCRIPTION
Core PR: https://github.com/grafana/grafana/pull/116174

For the record I do not think this is a good idea, aggregated metrics requiring the query to be rewritten breaks how scenes expects queries to behave.

Also queries less then 1 minute on the service selection will always be empty despite having results:

<img width="4102" height="2210" alt="image" src="https://github.com/user-attachments/assets/f38251fb-5f85-4696-ae81-1ce76ddd6a47" />