### PR TITLE
docs: remove version

### DIFF
--- a/docs/sources/troubleshooting/_index.md
+++ b/docs/sources/troubleshooting/_index.md
@@ -18,4 +18,4 @@ weight: 900
 [//]: # 'Shared content for error messages and troubleshooting'
 [//]: # 'This content is located in /logs-drilldown/docs/sources/shared/troubleshoot-logs-drilldown.md'
 
-{{< docs/shared lookup="troubleshoot-logs-drilldown.md" source="logs-drilldown" version="<LOGS-DRILLDOWN_VERSION>" >}}
+{{< docs/shared lookup="troubleshoot-logs-drilldown.md" source="logs-drilldown" >}}


### PR DESCRIPTION
Fix the troubleshooting page, which is currently not pulling in the shared file due to the version in the shortcode.

I keep forgetting that logs drilldown doesn't have a docs version.  D'oh!