### PR TITLE
docs: Make local build consistent so docs/shared lookups work

### DIFF
--- a/docs/sources/troubleshooting/_index.md
+++ b/docs/sources/troubleshooting/_index.md
@@ -15,8 +15,4 @@ weight: 900
 
 # Troubleshooting
 
-[//]: # 'Shared content for error messages and troubleshooting'
-[//]: # 'This content is located in /logs-drilldown/docs/sources/shared/troubleshoot-logs-drilldown.md'
-
 {{< docs/shared lookup="troubleshoot-logs-drilldown.md" source="explore-logs" version="next" >}}
-

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,7 +1,8 @@
 # List of projects to provide to the make-docs script.
 # Format is PROJECT[:[VERSION][:[REPOSITORY][:[DIRECTORY]]]]
-# The following PROJECTS value mounts content into the explore-logs project, at the "latest" version, which is the default if not explicitly set.
-# This results in the content being served at /docs/explore-logs/latest/.
+# The following PROJECTS value mounts content into the explore-logs project, at the "next" version, which is the default if not explicitly set.
+# This results in the content being served at /docs/explore-logs/next/ and matches the website sync directory.
+# The content is mounted in a number of places in the website repository.
 # The source of the content is the current repository which is determined by the name of the parent directory of the git root.
 # This overrides the default behavior of assuming the repository directory is the same as the project name.
-PROJECTS := explore-logs::$(notdir $(basename $(shell git rev-parse --show-toplevel)))
+PROJECTS := explore-logs:next:$(notdir $(basename $(shell git rev-parse --show-toplevel)))


### PR DESCRIPTION
We sync docs to the legacy explore-logs directory and only to the "next" version so this updates `make docs` to match that.