### PR TITLE
fix(LoadSearchScene): pass context to exposed component

### DIFF
--- a/src/Components/SavedSearches/LoadSearchScene.tsx
+++ b/src/Components/SavedSearches/LoadSearchScene.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/css';
 
-import { AppEvents, GrafanaTheme2 } from '@grafana/data';
+import { AppEvents, CoreApp, GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getAppEvents, locationService, reportInteraction, usePluginComponent } from '@grafana/runtime';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
@@ -146,6 +146,7 @@ export class LoadSearchScene extends SceneObjectBase<LoadSearchSceneState> {
     return (
       <OpenQueryLibraryComponent
         className={styles.button}
+        context={CoreApp.Explore}
         datasourceFilters={[dsName]}
         icon="folder-open"
         onSelectQuery={onSelectQuery}

--- a/src/services/saveSearch.ts
+++ b/src/services/saveSearch.ts
@@ -98,6 +98,7 @@ function removeFromLocalStorage(uid: string) {
 
 export interface OpenQueryLibraryComponentProps {
   className?: string;
+  context?: string;
   datasourceFilters?: string[];
   fallbackComponent?: ReactNode;
   icon?: string;


### PR DESCRIPTION
This PR passes context from the Load Search Scene to the exposed component, to change the behavior of Saved Queries in the landing page. Without it, when unlocking a query it was closing the drawer.

Currently, in Saved Queries, context is a string, which is then narrowed down to [4 possible values](https://github.com/grafana/grafana-enterprise/blob/main/src/public/query-library/index.ts#L14): explore, dashboard, panel editor, or unknown. When the context is unknown (by value or lack thereof), when unlocking or locking, [the drawer is closed](https://github.com/grafana/grafana-enterprise/blob/main/src/public/query-library/QueryLibrary/QueryLibraryContent.tsx#L168).

For saving a search we don't pass the context, to keep the current behavior to "save and close" associated with "unknown".

Requires:

- Grafana Enterprise
- https://github.com/grafana/grafana/pull/117175

Before.

https://github.com/user-attachments/assets/ba4dae32-1556-4990-b852-05a332ecfab9

After.

https://github.com/user-attachments/assets/6ba1296a-b8de-48cf-afd3-da8a562fa768