### PR TITLE
fix: set correct datasource when embedding log drilldown component

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -133,6 +133,8 @@ import {
 } from 'services/variables';
 export const showLogsButtonSceneKey = 'showLogsButtonScene';
 
+const DEFAULT_LOGS_DATASOURCE_UID = 'grafanacloud-logs';
+
 interface EmbeddedIndexSceneConstructor {
   datasourceUid?: string;
   hideTimePicker?: boolean;
@@ -145,11 +147,11 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   public constructor(state: Partial<IndexSceneState & EmbeddedIndexSceneConstructor>) {
     const { jsonData } = plugin.meta as AppPluginMeta<JsonData>;
     const datasourceUid =
-      jsonData?.dataSource ??
       state?.datasourceUid ??
+      jsonData?.dataSource ??
       getLastUsedDataSourceFromStorage() ??
       getDefaultDatasourceFromDatasourceSrv() ??
-      'grafanacloud-logs';
+      DEFAULT_LOGS_DATASOURCE_UID;
 
     const { unsub, variablesScene } = getVariableSet(
       datasourceUid,

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -146,6 +146,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     const { jsonData } = plugin.meta as AppPluginMeta<JsonData>;
     const datasourceUid =
       jsonData?.dataSource ??
+      state?.datasourceUid ??
       getLastUsedDataSourceFromStorage() ??
       getDefaultDatasourceFromDatasourceSrv() ??
       'grafanacloud-logs';


### PR DESCRIPTION
## Why                                                                                                                                                                                                                                                                                                                                                                                                                         
When embedding the Logs Drilldown component, there was no way to explicitly specify which datasource to use. The initialization logic would skip straight to checking localStorage or the default datasource, ignoring any datasourceUid passed in the component's state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             

## What
Added `state?.datasourceUid` to the datasource initialization precedence chain for `IndexScene`. 