### PR TITLE
chore(LoadSearchScene): pass drilldown as context

### DIFF
--- a/src/Components/SavedSearches/LoadSearchScene.tsx
+++ b/src/Components/SavedSearches/LoadSearchScene.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/css';
 
-import { AppEvents, CoreApp, GrafanaTheme2 } from '@grafana/data';
+import { AppEvents, GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getAppEvents, locationService, reportInteraction, usePluginComponent } from '@grafana/runtime';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
@@ -145,7 +145,7 @@ export class LoadSearchScene extends SceneObjectBase<LoadSearchSceneState> {
     return (
       <OpenQueryLibraryComponent
         className={styles.button}
-        context={CoreApp.Explore}
+        context="drilldown"
         datasourceFilters={[dsName]}
         icon="folder-open"
         onSelectQuery={onSelectQuery}


### PR DESCRIPTION
Passing a custom context allows us be better identified and, for example, customize the experience for Drilldown users and don't show the "Open in Drilldown" button when you're already there.

Requires github.com/grafana/grafana-enterprise/pull/10877