### PR TITLE
feat(LogsTablePanel): Add support for the Logs Table native visualization

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -551,3 +551,4 @@ mutatable
 DSUID
 newrecords
 logsdrilldowndefaultlabels
+logstable

--- a/src/Components/ServiceScene/LogOptionsScene.tsx
+++ b/src/Components/ServiceScene/LogOptionsScene.tsx
@@ -49,14 +49,14 @@ export class LogOptionsScene extends SceneObjectBase<LogOptionsState> {
   }
 
   handleWrapLinesChange = (type: boolean) => {
-    this.getLogsPanelScene().setState({ prettifyLogMessage: type, wrapLogMessage: type });
+    this.getLogsPanelScene()?.setState({ prettifyLogMessage: type, wrapLogMessage: type });
     setLogOption('wrapLogMessage', type);
     setLogOption('prettifyLogMessage', type);
     this.getLogsListScene().setLogsVizOption({ prettifyLogMessage: type, wrapLogMessage: type });
   };
 
   onChangeLogsSortOrder = (sortOrder: LogsSortOrder) => {
-    this.getLogsPanelScene().setState({ sortOrder: sortOrder });
+    this.getLogsPanelScene()?.setState({ sortOrder: sortOrder });
     setLogOption('sortOrder', sortOrder);
     this.getLogsListScene().setLogsVizOption({ sortOrder: sortOrder });
   };
@@ -66,15 +66,19 @@ export class LogOptionsScene extends SceneObjectBase<LogOptionsState> {
   };
 
   getLogsPanelScene = () => {
-    return sceneGraph.getAncestor(this, LogsPanelScene);
+    try {
+      return sceneGraph.getAncestor(this, LogsPanelScene);
+    } catch (e) {
+      // This will fail on initialization, so no need to pollute output.
+    }
+    return undefined;
   };
 }
 
 function LogOptionsRenderer({ model }: SceneComponentProps<LogOptionsScene>) {
   const { buttonRendererScene, lineLimitScene, onChangeVisualizationType, visualizationType } = model.useState();
-  const { sortOrder, wrapLogMessage } = model.getLogsPanelScene().useState();
+  const state = model.getLogsPanelScene()?.useState();
   const styles = useStyles2(getStyles);
-  const wrapLines = wrapLogMessage ?? false;
 
   return (
     <div className={styles.container}>
@@ -102,14 +106,14 @@ function LogOptionsRenderer({ model }: SceneComponentProps<LogOptionsScene>) {
                   value: LogsSortOrder.Ascending,
                 },
               ]}
-              value={sortOrder}
+              value={state?.sortOrder}
               onChange={model.onChangeLogsSortOrder}
             />
           </InlineField>
           <InlineField className={styles.buttonGroupWrapper} transparent>
             <RadioButtonGroup
               size="sm"
-              value={wrapLines}
+              value={state?.wrapLogMessage ?? false}
               onChange={model.handleWrapLinesChange}
               options={[
                 {

--- a/src/Components/ServiceScene/LogOptionsScene.tsx
+++ b/src/Components/ServiceScene/LogOptionsScene.tsx
@@ -65,7 +65,7 @@ export class LogOptionsScene extends SceneObjectBase<LogOptionsState> {
   };
 
   getLogsPanelScene = () => {
-    //@todo unhack
+    //@todo fix
     return this.parent as any;
     // return sceneGraph.getAncestor(this, LogsPanelScene);
   };

--- a/src/Components/ServiceScene/LogOptionsScene.tsx
+++ b/src/Components/ServiceScene/LogOptionsScene.tsx
@@ -14,6 +14,7 @@ import { LogsPanelHeaderActions } from '../Table/LogsHeaderActions';
 import { LineLimitScene } from './LineLimitScene';
 import { LogOptionsButtonsScene } from './LogOptionsButtonsScene';
 import { LogsListScene } from './LogsListScene';
+import { LogsPanelScene } from './LogsPanelScene';
 import { logsControlsSupported } from 'services/panel';
 import { LogsVisualizationType, setLogOption } from 'services/store';
 
@@ -65,9 +66,7 @@ export class LogOptionsScene extends SceneObjectBase<LogOptionsState> {
   };
 
   getLogsPanelScene = () => {
-    //@todo fix
-    return this.parent as any;
-    // return sceneGraph.getAncestor(this, LogsPanelScene);
+    return sceneGraph.getAncestor(this, LogsPanelScene);
   };
 }
 

--- a/src/Components/ServiceScene/LogOptionsScene.tsx
+++ b/src/Components/ServiceScene/LogOptionsScene.tsx
@@ -14,7 +14,6 @@ import { LogsPanelHeaderActions } from '../Table/LogsHeaderActions';
 import { LineLimitScene } from './LineLimitScene';
 import { LogOptionsButtonsScene } from './LogOptionsButtonsScene';
 import { LogsListScene } from './LogsListScene';
-import { LogsPanelScene } from './LogsPanelScene';
 import { logsControlsSupported } from 'services/panel';
 import { LogsVisualizationType, setLogOption } from 'services/store';
 
@@ -66,7 +65,9 @@ export class LogOptionsScene extends SceneObjectBase<LogOptionsState> {
   };
 
   getLogsPanelScene = () => {
-    return sceneGraph.getAncestor(this, LogsPanelScene);
+    //@todo unhack
+    return this.parent as any;
+    // return sceneGraph.getAncestor(this, LogsPanelScene);
   };
 }
 

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 
 import { LoadingState, PanelData, shallowCompare } from '@grafana/data';
-import { config, locationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   SceneComponentProps,

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -454,6 +454,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     const { error, errorType, canClearFilters } = this.state;
 
     this.logsPanelScene = new LogsPanelScene({ error, errorType, canClearFilters });
+    const logsTablePanelNG = getFeatureFlag('logsTablePanelNG');
 
     const panelHeight = 'calc(100vh - 180px)';
     const children =
@@ -473,7 +474,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
             ]
           : [
               new SceneFlexItem({
-                body: 'logsTablePanel' in config.featureToggles && config.featureToggles.logsTablePanel
+                body: logsTablePanelNG
                   ? new LogsTablePanelScene({ error, canClearFilters })
                   : new LogsTableScene({ error, canClearFilters }),
                 height: 'calc(100vh - 220px)',

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -26,6 +26,7 @@ import { getRouteParams } from '../../services/routing';
 import { getLabelsVariable } from '../../services/variableGetters';
 import { getVariablesThatCanBeCleared } from '../../services/variableHelpers';
 import { IndexScene } from '../IndexScene/IndexScene';
+import { DEFAULT_URL_COLUMNS, DEFAULT_URL_COLUMNS_LEVELS } from '../Table/constants';
 import { LogLineState } from '../Table/Context/TableColumnsContext';
 import { SelectedTableRow } from '../Table/LogLineCellComponent';
 import { ActionBarScene } from './ActionBarScene';
@@ -45,6 +46,7 @@ import {
   getLogsVisualizationType,
   getLogsVolumeOption,
   LogsVisualizationType,
+  setDisplayedFieldsInStorage,
   setLogsVisualizationType,
 } from 'services/store';
 
@@ -198,10 +200,27 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
   };
 
   showBackendFields = () => {
-    // This is technically a user action, but I think it makes sense to continue to get served the backend fields
-    this.setState({ displayedFields: [], userDisplayedFields: false });
-    if (this.logsPanelScene) {
-      this.logsPanelScene.showBackendFields();
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    const backendDisplayedFields = serviceScene.state.backendDisplayedFields ?? [];
+
+    setDisplayedFieldsInStorage(this, backendDisplayedFields);
+    setDisplayedFieldsInStorage(this, null, true);
+
+    const urlColumns =
+      backendDisplayedFields.filter(
+        (column) => DEFAULT_URL_COLUMNS.includes(column) || DEFAULT_URL_COLUMNS_LEVELS.includes(column)
+      ) || [];
+
+    this.setState({
+      displayedFields: backendDisplayedFields,
+      userDisplayedFields: false,
+      urlColumns,
+    });
+
+    if (this.logsPanelScene?.state.body) {
+      this.logsPanelScene.setLogsVizOption({
+        displayedFields: backendDisplayedFields,
+      });
     }
   };
 

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 
 import { LoadingState, PanelData, shallowCompare } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   SceneComponentProps,
@@ -32,6 +32,7 @@ import { ActionBarScene } from './ActionBarScene';
 import { JSONLogsScene } from './JSONLogsScene';
 import { ErrorType } from './LogsPanelError';
 import { LogsPanelScene } from './LogsPanelScene';
+import { LogsTablePanelScene } from './LogsTablePanelScene';
 import { LogsTableScene } from './LogsTableScene';
 import { LogsVolumePanel, logsVolumePanelKey } from './LogsVolume/LogsVolumePanel';
 import { ServiceScene } from './ServiceScene';
@@ -472,8 +473,10 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
             ]
           : [
               new SceneFlexItem({
-                body: new LogsTableScene({ error, canClearFilters }),
-                height: panelHeight,
+                body: 'logsTablePanel' in config.featureToggles && config.featureToggles.logsTablePanel
+                  ? new LogsTablePanelScene({ error, canClearFilters })
+                  : new LogsTableScene({ error, canClearFilters }),
+                height: 'calc(100vh - 220px)',
               }),
             ];
 

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -381,7 +381,6 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
       this.setState({ dedupStrategy: value });
       this.setLogsVizOption({ dedupStrategy: value });
     } else if (option === 'defaultDisplayedFields' && Array.isArray(value)) {
-      // @todo is this a user action?
       const parent = this.getParentScene();
       parent.setState({ otelDisplayedFields: value });
     }

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -1,0 +1,339 @@
+import React from 'react';
+
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2, LogsSortOrder } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import {
+  DeepPartial,
+  SceneComponentProps,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneObjectUrlSyncConfig,
+  SceneObjectUrlValues,
+  VizConfigBuilder,
+  VizPanel,
+} from '@grafana/scenes';
+import {
+  defaultOptions,
+  Options,
+  pluginVersion,
+} from '@grafana/schema/dist/esm/raw/composable/logstable/panelcfg/x/LogsTablePanelCfg_types.gen';
+import { useStyles2 } from '@grafana/ui';
+
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
+import { areArraysEqual } from '../../services/comparison';
+import { getAllLabelsFromDataFrame } from '../../services/labels';
+import { setControlsExpandedStateFromLocalStorage } from '../../services/scenes';
+import { getLogOption, setDisplayedFieldsInStorage } from '../../services/store';
+import { clearVariables } from '../../services/variableHelpers';
+import { PanelMenu } from '../Panels/PanelMenu';
+import { DEFAULT_URL_COLUMNS, DETECTED_LEVEL, LEVEL } from '../Table/constants';
+import { NoMatchingLabelsScene } from './Breakdowns/NoMatchingLabelsScene';
+import { LogOptionsScene, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from './LogOptionsScene';
+import { LogsListScene } from './LogsListScene';
+import { ErrorType, LogsPanelError } from './LogsPanelError';
+import { logger } from 'services/logger';
+import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
+import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
+
+interface LogsTableSceneState extends SceneObjectState {
+  canClearFilters?: boolean;
+  emptyScene?: NoMatchingLabelsScene;
+  error?: string;
+  errorType?: ErrorType;
+  isDisabledLineState: boolean;
+  menu?: PanelMenu;
+  panel?: VizPanel<Options, {}>;
+  sortOrder: LogsSortOrder;
+}
+export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
+  // Reference to the active panel, maybe a bad idea if they get out of sync, but the point here is you should be updating the options not the panel
+  private _viz: VizPanel | null = null;
+
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, {
+    // urlColumns are options.displayedFields
+    keys: ['sortOrder', 'urlColumns'],
+  });
+
+  constructor(state: Partial<LogsTableSceneState>) {
+    super({
+      ...state,
+      sortOrder: getLogOption<LogsSortOrder>('sortOrder', LogsSortOrder.Descending),
+      isDisabledLineState: false,
+      // @todo override from local storage
+    });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  private getPanelOptions() {
+    return this.state.panel?.state.options;
+  }
+
+  private setStateFromUrl() {
+    const searchParams = new URLSearchParams(locationService.getLocation().search);
+
+    this.updateFromUrl({
+      sortOrder: searchParams.get('sortOrder'),
+    });
+  }
+
+  getUrlState() {
+    return {
+      sortOrder: JSON.stringify(this.state.sortOrder),
+    };
+  }
+
+  updateFromUrl(values: SceneObjectUrlValues) {
+    try {
+      if (typeof values.sortOrder === 'string' && values.sortOrder) {
+        const decodedSortOrder = narrowLogsSortOrder(JSON.parse(values.sortOrder));
+        if (decodedSortOrder) {
+          this.setState({ sortOrder: decodedSortOrder });
+        }
+      }
+    } catch (e) {
+      // URL Params can be manually changed and it will make JSON.parse() fail.
+      logger.error(e, { msg: 'LogsTableScene: updateFromUrl unexpected error' });
+    }
+  }
+
+  protected onOptionsChange(options: DeepPartial<Options>, prevOptions: DeepPartial<Options>) {
+    console.log('options change', options);
+  }
+
+  public onActivate() {
+    // @todo add from local storage, url
+    const parentScene = this.getParentScene();
+    const panelBuilder = new VizConfigBuilder<Options, {}>('logstable', pluginVersion, () => ({
+      ...defaultOptions,
+      // Could do url columns
+      displayedFields: parentScene.state.displayedFields,
+    }));
+
+    // @todo set field defaults
+    // panelBuilder.setOverrides();
+
+    const panel = new VizPanel({ ...panelBuilder.build() });
+    this._viz = panel;
+
+    panel.subscribeToState((newState, prevState) => {
+      this.onOptionsChange(newState.options, prevState.options);
+    });
+
+    panel.setState({
+      showMenuAlways: true,
+      menu: new PanelMenu({}),
+      headerActions: new LogOptionsScene({
+        onChangeVisualizationType: parentScene.setVisualizationType,
+        visualizationType: parentScene.state.visualizationType,
+      }),
+    });
+
+    this.setState({
+      emptyScene: new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) }),
+      menu: new PanelMenu({}),
+      panel,
+    });
+    setControlsExpandedStateFromLocalStorage(this.getParentScene());
+    this.setStateFromUrl();
+
+    // Subscribe to location changes to detect URL parameter changes
+    this._subs.add(
+      locationService.getHistory().listen(() => {
+        this.subscribeFromUrl();
+      })
+    );
+
+    this.getParentScene().subscribeToState((newState, prevState) => {
+      const options = this.getPanelOptions();
+      if (!areArraysEqual(newState.displayedFields, prevState.displayedFields)) {
+        this.state.panel?.setState({
+          options: {
+            ...options,
+            displayedFields: newState.displayedFields,
+          },
+        });
+      }
+    });
+
+    this.onLoadSyncDisplayedFieldsWithUrlColumns();
+
+    reportAppInteraction(
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.visualization_init,
+      {
+        viz: 'table',
+      },
+      true
+    );
+  }
+
+  private getParentScene() {
+    console.log('getParentScene', this);
+    return sceneGraph.getAncestor(this, LogsListScene);
+  }
+
+  subscribeFromUrl = () => {
+    const searchParams = new URLSearchParams(locationService.getLocation().search);
+    // Check URL columns for body parameter and update isDisabledLineState accordingly
+    let urlColumns: string[] | null = [];
+    try {
+      urlColumns = unknownToStrings(JSON.parse(decodeURIComponent(searchParams.get('urlColumns') ?? '')));
+
+      // If body or line is in the url columns, show the line state controls
+      if (urlColumns.includes(DATAPLANE_BODY_NAME_LEGACY) || urlColumns.includes(DATAPLANE_LINE_NAME)) {
+        this.setState({ isDisabledLineState: true });
+      } else {
+        this.setState({ isDisabledLineState: false });
+      }
+    } catch (e) {
+      console.error('Error parsing urlColumns:', e);
+    }
+  };
+
+  onLoadSyncDisplayedFieldsWithUrlColumns = () => {
+    const searchParams = new URLSearchParams(locationService.getLocation().search);
+    let urlColumns: string[] | null = [];
+    try {
+      urlColumns = unknownToStrings(JSON.parse(decodeURIComponent(searchParams.get('urlColumns') ?? '')));
+      // If body or line is in the url columns, show the line state controls
+      if (urlColumns.includes(DATAPLANE_BODY_NAME_LEGACY) || urlColumns.includes(DATAPLANE_LINE_NAME)) {
+        this.setState({ isDisabledLineState: true });
+      }
+    } catch (e) {
+      console.error(e);
+    }
+    const parentModel = this.getParentScene();
+
+    const displayedFields = parentModel.state.displayedFields.filter(
+      (field) => field !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME
+    );
+
+    // Add displayed fields to url columns
+    if (urlColumns.length > 0 && parentModel.state.displayedFields.length > 0) {
+      parentModel.setState({
+        urlColumns: Array.from(new Set([...urlColumns, ...displayedFields])),
+      });
+    }
+  };
+
+  // Update displayed fields in the parent scene
+  updateDisplayedFields = (urlColumns: string[]) => {
+    const parentModel = this.getParentScene();
+    // Remove any default columns that are no longer in urlColumns, if the user has un-selected the default columns
+    const defaultUrlColumns = this.findDefaultUrlColumns(urlColumns);
+    // If body or line is in the url columns, show the line state controls
+    if (defaultUrlColumns.includes(DATAPLANE_BODY_NAME_LEGACY) || defaultUrlColumns.includes(DATAPLANE_LINE_NAME)) {
+      this.setState({ isDisabledLineState: true });
+    } else {
+      this.setState({ isDisabledLineState: false });
+    }
+
+    // Remove any default urlColumn for displayedFields
+    const levelFieldName = this.hasDetectedLevel();
+    const allDefaultColumns = [...defaultUrlColumns];
+    if (levelFieldName) {
+      allDefaultColumns.push(levelFieldName);
+    }
+    const newDisplayedFields = Array.from(new Set([...(urlColumns || [])])).filter(
+      (field) => !allDefaultColumns.includes(field)
+    );
+    // sync state displayedFields for LogsPanelScene
+    parentModel.setState({
+      displayedFields: newDisplayedFields,
+    });
+    // sync LocalStorage displayedFields for Go to explore
+    setDisplayedFieldsInStorage(this, parentModel.state.displayedFields);
+  };
+
+  // find defaultUrlColumns and match order
+  findDefaultUrlColumns = (urlColumns: string[]) => {
+    let defaultUrlColumns = DEFAULT_URL_COLUMNS;
+    defaultUrlColumns = defaultUrlColumns.reduce<string[]>((acc, col) => {
+      // return the column in the same index position as urlColumns
+      if (urlColumns.includes(col)) {
+        const urlIndex = urlColumns.indexOf(col);
+        acc[urlIndex] = col;
+      }
+      return acc;
+    }, []);
+
+    return defaultUrlColumns;
+  };
+
+  // check if the data has a detected_level or level field
+  hasDetectedLevel = () => {
+    const dataProvider = sceneGraph.getData(this);
+    const data = dataProvider.state.data;
+    if (!data?.series?.length) {
+      return null;
+    }
+
+    // Get all available labels from the series
+    const allLabels = getAllLabelsFromDataFrame(data.series);
+
+    // Check if detected_level or level exists in the labels
+    if (allLabels.includes(DETECTED_LEVEL)) {
+      return DETECTED_LEVEL;
+    }
+    if (allLabels.includes(LEVEL)) {
+      return LEVEL;
+    }
+
+    return null;
+  };
+
+  public static Component = ({ model }: SceneComponentProps<LogsTablePanelScene>) => {
+    const styles = useStyles2(getStyles);
+    // Get state from parent model
+    // const parentModel = sceneGraph.getAncestor(model, LogsListScene);
+    const { error, errorType, canClearFilters, panel } = model.useState();
+    // const { displayedFields } = parentModel.useState();
+    // const { data } = sceneGraph.getData(model).useState();
+
+    // const dataFrame = getLogsPanelFrame(data);
+
+    // Define callback function to update filters in react
+    // const addFilter = (filter: AdHocVariableFilter) => {
+    //   const variableType = getVariableForLabel(dataFrame, filter.key, model);
+    //   addAdHocFilter(filter, parentModel, variableType);
+    // };
+
+    return (
+      <div className={styles.panelWrapper}>
+        {!error && panel && <panel.Component model={panel} />}
+        {error && (
+          <LogsPanelError
+            error={error}
+            errorType={errorType}
+            clearFilters={canClearFilters ? () => clearVariables(model) : undefined}
+            sceneRef={model}
+          />
+        )}
+      </div>
+    );
+  };
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'row-reverse',
+    justifyContent: 'space-between',
+    height: '100%',
+    flex: 1,
+  }),
+  tableContainer: css({
+    overflow: 'hidden',
+    flex: '1 1 auto',
+    minWidth: 0,
+  }),
+  panelWrapper: css({
+    height: '100%',
+    label: 'panel-wrapper-table',
+    width: '100%',
+  }),
+});

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2, LogsSortOrder } from '@grafana/data';
+import { FieldConfig, FieldConfigSource, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   DeepPartial,
+  FieldConfigOverridesBuilder,
   SceneComponentProps,
   sceneGraph,
   SceneObjectBase,
@@ -40,6 +41,7 @@ import { getVariableForLabel } from 'services/fields';
 import { FilterOp } from 'services/filterTypes';
 import { logger } from 'services/logger';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
+import { setTableFieldOverrides, storeTableFieldConfig } from 'services/logsTable';
 import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
 
 interface LogsTableSceneState extends SceneObjectState {
@@ -118,10 +120,17 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
       wrapText: getBooleanLogOption('wrapText', true),
     }));
 
-    // @todo set field defaults
-    // panelBuilder.setOverrides();
+    panelBuilder.setOverrides((builder: FieldConfigOverridesBuilder<FieldConfig>) => {
+      setTableFieldOverrides(builder, this);
+    });
 
     const panel = new VizPanel({ ...panelBuilder.build() });
+    const defaultOnFieldConfigChange = panel.onFieldConfigChange.bind(panel);
+    panel.onFieldConfigChange = (fieldConfigUpdate: FieldConfigSource, replace?: boolean) => {
+      storeTableFieldConfig(fieldConfigUpdate, this);
+      defaultOnFieldConfigChange(fieldConfigUpdate, replace);
+    };
+
     panel.setState({
       extendPanelContext: (_, context) => this.extendLogsTableContext(context),
     });

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -20,7 +20,7 @@ import {
   Options,
   pluginVersion,
 } from '@grafana/schema/dist/esm/raw/composable/logstable/panelcfg/x/LogsTablePanelCfg_types.gen';
-import { useStyles2 } from '@grafana/ui';
+import { AdHocFilterItem, PanelContext, useStyles2 } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
 import { areArraysEqual } from '../../services/comparison';
@@ -30,10 +30,14 @@ import { getLogOption, setDisplayedFieldsInStorage } from '../../services/store'
 import { clearVariables } from '../../services/variableHelpers';
 import { PanelMenu } from '../Panels/PanelMenu';
 import { DEFAULT_URL_COLUMNS, DETECTED_LEVEL, LEVEL } from '../Table/constants';
+import { addToFilters } from './Breakdowns/AddToFiltersButton';
 import { NoMatchingLabelsScene } from './Breakdowns/NoMatchingLabelsScene';
 import { LogOptionsScene, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from './LogOptionsScene';
 import { LogsListScene } from './LogsListScene';
 import { ErrorType, LogsPanelError } from './LogsPanelError';
+import { ServiceScene } from './ServiceScene';
+import { getVariableForLabel } from 'services/fields';
+import { FilterOp } from 'services/filterTypes';
 import { logger } from 'services/logger';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
 import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
@@ -114,6 +118,9 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
     // panelBuilder.setOverrides();
 
     const panel = new VizPanel({ ...panelBuilder.build() });
+    panel.setState({
+      extendPanelContext: (_, context) => this.extendLogsTableContext(context),
+    });
 
     panel.subscribeToState((newState, prevState) => {
       this.onOptionsChange(newState.options, prevState.options);
@@ -167,8 +174,28 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
     );
   }
 
+  private extendLogsTableContext = (context: PanelContext) => {
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    context.onAddAdHocFilter = ({ value, key, operator }: AdHocFilterItem) => {
+      const frame = serviceScene.state.$data?.state?.data?.series?.[0];
+      const variableType = getVariableForLabel(frame, key, serviceScene);
+
+      const operation = operator === FilterOp.Equal ? 'toggle' : 'exclude';
+
+      addToFilters(key, value, operation, this, variableType);
+
+      reportAppInteraction(
+        USER_EVENTS_PAGES.service_details,
+        USER_EVENTS_ACTIONS.service_details.logs_detail_filter_applied,
+        {
+          action: operation,
+          filterType: variableType,
+          key,
+        }
+      );
+    };
+  };
   private getParentScene() {
-    console.log('getParentScene', this);
     return sceneGraph.getAncestor(this, LogsListScene);
   }
 

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -49,9 +49,6 @@ interface LogsTableSceneState extends SceneObjectState {
   sortOrder: LogsSortOrder;
 }
 export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
-  // Reference to the active panel, maybe a bad idea if they get out of sync, but the point here is you should be updating the options not the panel
-  private _viz: VizPanel | null = null;
-
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
     // urlColumns are options.displayedFields
     keys: ['sortOrder', 'urlColumns'],
@@ -117,7 +114,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
     // panelBuilder.setOverrides();
 
     const panel = new VizPanel({ ...panelBuilder.build() });
-    this._viz = panel;
 
     panel.subscribeToState((newState, prevState) => {
       this.onOptionsChange(newState.options, prevState.options);

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -26,7 +26,7 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '..
 import { areArraysEqual } from '../../services/comparison';
 import { getAllLabelsFromDataFrame } from '../../services/labels';
 import { setControlsExpandedStateFromLocalStorage } from '../../services/scenes';
-import { getLogOption, setDisplayedFieldsInStorage } from '../../services/store';
+import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from '../../services/store';
 import { clearVariables } from '../../services/variableHelpers';
 import { PanelMenu } from '../Panels/PanelMenu';
 import { DEFAULT_URL_COLUMNS, DETECTED_LEVEL, LEVEL } from '../Table/constants';
@@ -102,7 +102,10 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
   }
 
   protected onOptionsChange(options: DeepPartial<Options>, prevOptions: DeepPartial<Options>) {
-    console.log('options change', options);
+    // todo: Update after Grafana >= 13.1
+    if ('wrapText' in options && 'wrapText' in prevOptions && options.wrapText !== prevOptions.wrapText) {
+      setLogOption('wrapText', Boolean(options.wrapText));
+    }
   }
 
   public onActivate() {
@@ -112,6 +115,7 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
       ...defaultOptions,
       // Could do url columns
       displayedFields: parentScene.state.displayedFields,
+      wrapText: getBooleanLogOption('wrapText', true),
     }));
 
     // @todo set field defaults

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -261,7 +261,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
   buildLinkToLogLine = (uid: string) => {
     const parent = this.getParentScene();
     const timeRange = sceneGraph.getTimeRange(parent).state.value;
-    console.log(parent.state.displayedFields);
     const link = generateLogShortlink(
       'panelState',
       {

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -24,16 +24,16 @@ import {
 import { AdHocFilterItem, PanelContext, useStyles2 } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
-import { areArraysEqual, areArraysStrictlyEqual } from '../../services/comparison';
+import { areArraysEqual } from '../../services/comparison';
 import { getAllLabelsFromDataFrame } from '../../services/labels';
 import { setControlsExpandedStateFromLocalStorage } from '../../services/scenes';
 import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from '../../services/store';
 import { clearVariables } from '../../services/variableHelpers';
 import { PanelMenu } from '../Panels/PanelMenu';
-import { DEFAULT_URL_COLUMNS, DETECTED_LEVEL, LEVEL } from '../Table/constants';
+import { DETECTED_LEVEL, LEVEL } from '../Table/constants';
 import { addToFilters } from './Breakdowns/AddToFiltersButton';
 import { NoMatchingLabelsScene } from './Breakdowns/NoMatchingLabelsScene';
-import { LogOptionsScene, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from './LogOptionsScene';
+import { LogOptionsScene } from './LogOptionsScene';
 import { LogsListScene } from './LogsListScene';
 import { ErrorType, LogsPanelError } from './LogsPanelError';
 import { ServiceScene } from './ServiceScene';

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -126,6 +126,7 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
     const parentScene = this.getParentScene();
     const panelBuilder = new VizConfigBuilder<Options, {}>('logstable', pluginVersion, () => ({
       ...defaultOptions,
+      sortOrder: this.state.sortOrder,
       displayedFields: parentScene.state.displayedFields,
       wrapText: getBooleanLogOption('wrapText', true),
     }));

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -45,7 +45,7 @@ import { setTableFieldOverrides, storeTableFieldConfig } from 'services/logsTabl
 import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
 import { runSceneQueries } from 'services/query';
 
-interface LogsTableSceneState extends SceneObjectState {
+interface LogsTablePanelSceneState extends SceneObjectState {
   canClearFilters?: boolean;
   emptyScene?: NoMatchingLabelsScene;
   error?: string;
@@ -55,13 +55,13 @@ interface LogsTableSceneState extends SceneObjectState {
   panel?: VizPanel<Options, {}>;
   sortOrder: LogsSortOrder;
 }
-export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
+export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
     // urlColumns are options.displayedFields
     keys: ['sortOrder', 'urlColumns'],
   });
 
-  constructor(state: Partial<LogsTableSceneState>) {
+  constructor(state: Partial<LogsTablePanelSceneState>) {
     super({
       ...state,
       sortOrder: getLogOption<LogsSortOrder>('sortOrder', LogsSortOrder.Descending),

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { FieldConfig, FieldConfigSource, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
+import { FieldConfig, FieldConfigSource, GrafanaTheme2, LogsSortOrder, shallowCompare } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   DeepPartial,
@@ -24,7 +24,7 @@ import {
 import { AdHocFilterItem, PanelContext, useStyles2 } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
-import { areArraysEqual } from '../../services/comparison';
+import { areArraysEqual, areArraysStrictlyEqual } from '../../services/comparison';
 import { getAllLabelsFromDataFrame } from '../../services/labels';
 import { setControlsExpandedStateFromLocalStorage } from '../../services/scenes';
 import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from '../../services/store';
@@ -57,8 +57,7 @@ interface LogsTablePanelSceneState extends SceneObjectState {
 }
 export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, {
-    // urlColumns are options.displayedFields
-    keys: ['sortOrder', 'urlColumns'],
+    keys: ['sortOrder'],
   });
 
   constructor(state: Partial<LogsTablePanelSceneState>) {
@@ -120,6 +119,9 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     if (options.sortOrder && options.sortOrder !== this.state.sortOrder) {
       this.handleSortChange(options.sortOrder);
     }
+    if (options.displayedFields) {
+      this.updateDisplayedFields(options.displayedFields);
+    }
   }
 
   public onActivate() {
@@ -147,7 +149,9 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     });
 
     panel.subscribeToState((newState, prevState) => {
-      this.onOptionsChange(newState.options, prevState.options);
+      if (!shallowCompare(newState.options, prevState.options)) {
+        this.onOptionsChange(newState.options, prevState.options);
+      }
     });
 
     panel.setState({
@@ -166,13 +170,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     });
     setControlsExpandedStateFromLocalStorage(this.getParentScene());
     this.setStateFromUrl();
-
-    // Subscribe to location changes to detect URL parameter changes
-    this._subs.add(
-      locationService.getHistory().listen(() => {
-        this.subscribeFromUrl();
-      })
-    );
 
     this._subs.add(
       this.getParentScene().subscribeToState((newState, prevState) => {
@@ -225,24 +222,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     return sceneGraph.getAncestor(this, LogsListScene);
   }
 
-  subscribeFromUrl = () => {
-    const searchParams = new URLSearchParams(locationService.getLocation().search);
-    // Check URL columns for body parameter and update isDisabledLineState accordingly
-    let urlColumns: string[] | null = [];
-    try {
-      urlColumns = unknownToStrings(JSON.parse(decodeURIComponent(searchParams.get('urlColumns') ?? '')));
-
-      // If body or line is in the url columns, show the line state controls
-      if (urlColumns.includes(DATAPLANE_BODY_NAME_LEGACY) || urlColumns.includes(DATAPLANE_LINE_NAME)) {
-        this.setState({ isDisabledLineState: true });
-      } else {
-        this.setState({ isDisabledLineState: false });
-      }
-    } catch (e) {
-      console.error('Error parsing urlColumns:', e);
-    }
-  };
-
   onLoadSyncDisplayedFieldsWithUrlColumns = () => {
     const searchParams = new URLSearchParams(locationService.getLocation().search);
     let urlColumns: string[] | null = [];
@@ -257,60 +236,25 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     }
     const parentModel = this.getParentScene();
 
-    const displayedFields = parentModel.state.displayedFields.filter(
-      (field) => field !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME
-    );
-
-    // Add displayed fields to url columns
-    if (urlColumns.length > 0 && parentModel.state.displayedFields.length > 0) {
+    // Sync displayed fields and remove urlColumns (deprecated)
+    if (urlColumns.length > 0) {
       parentModel.setState({
-        urlColumns: Array.from(new Set([...urlColumns, ...displayedFields])),
+        displayedFields: Array.from(new Set([...urlColumns])),
       });
+      locationService.partial({ urlColumns: null }, true);
     }
   };
 
   // Update displayed fields in the parent scene
-  updateDisplayedFields = (urlColumns: string[]) => {
+  updateDisplayedFields = (displayedFields: string[]) => {
     const parentModel = this.getParentScene();
-    // Remove any default columns that are no longer in urlColumns, if the user has un-selected the default columns
-    const defaultUrlColumns = this.findDefaultUrlColumns(urlColumns);
-    // If body or line is in the url columns, show the line state controls
-    if (defaultUrlColumns.includes(DATAPLANE_BODY_NAME_LEGACY) || defaultUrlColumns.includes(DATAPLANE_LINE_NAME)) {
-      this.setState({ isDisabledLineState: true });
-    } else {
-      this.setState({ isDisabledLineState: false });
+
+    if (!areArraysEqual(displayedFields, parentModel.state.displayedFields)) {
+      parentModel.setState({
+        displayedFields: displayedFields,
+      });
+      setDisplayedFieldsInStorage(this, displayedFields);
     }
-
-    // Remove any default urlColumn for displayedFields
-    const levelFieldName = this.hasDetectedLevel();
-    const allDefaultColumns = [...defaultUrlColumns];
-    if (levelFieldName) {
-      allDefaultColumns.push(levelFieldName);
-    }
-    const newDisplayedFields = Array.from(new Set([...(urlColumns || [])])).filter(
-      (field) => !allDefaultColumns.includes(field)
-    );
-    // sync state displayedFields for LogsPanelScene
-    parentModel.setState({
-      displayedFields: newDisplayedFields,
-    });
-    // sync LocalStorage displayedFields for Go to explore
-    setDisplayedFieldsInStorage(this, parentModel.state.displayedFields);
-  };
-
-  // find defaultUrlColumns and match order
-  findDefaultUrlColumns = (urlColumns: string[]) => {
-    let defaultUrlColumns = DEFAULT_URL_COLUMNS;
-    defaultUrlColumns = defaultUrlColumns.reduce<string[]>((acc, col) => {
-      // return the column in the same index position as urlColumns
-      if (urlColumns.includes(col)) {
-        const urlIndex = urlColumns.indexOf(col);
-        acc[urlIndex] = col;
-      }
-      return acc;
-    }, []);
-
-    return defaultUrlColumns;
   };
 
   // check if the data has a detected_level or level field

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -66,7 +66,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
       ...state,
       sortOrder: getLogOption<LogsSortOrder>('sortOrder', LogsSortOrder.Descending),
       isDisabledLineState: false,
-      // @todo override from local storage
     });
 
     this.addActivationHandler(this.onActivate.bind(this));

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -233,7 +233,7 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
         this.setState({ isDisabledLineState: true });
       }
     } catch (e) {
-      console.error(e);
+      logger.error(e);
     }
     const parentModel = this.getParentScene();
 

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -124,11 +124,9 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
   }
 
   public onActivate() {
-    // @todo add from local storage, url
     const parentScene = this.getParentScene();
     const panelBuilder = new VizConfigBuilder<Options, {}>('logstable', pluginVersion, () => ({
       ...defaultOptions,
-      // Could do url columns
       displayedFields: parentScene.state.displayedFields,
       wrapText: getBooleanLogOption('wrapText', true),
     }));
@@ -176,17 +174,19 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
       })
     );
 
-    this.getParentScene().subscribeToState((newState, prevState) => {
-      const options = this.getPanelOptions();
-      if (!areArraysEqual(newState.displayedFields, prevState.displayedFields)) {
-        this.state.panel?.setState({
-          options: {
-            ...options,
-            displayedFields: newState.displayedFields,
-          },
-        });
-      }
-    });
+    this._subs.add(
+      this.getParentScene().subscribeToState((newState, prevState) => {
+        const options = this.getPanelOptions();
+        if (!areArraysEqual(newState.displayedFields, prevState.displayedFields)) {
+          this.state.panel?.setState({
+            options: {
+              ...options,
+              displayedFields: newState.displayedFields,
+            },
+          });
+        }
+      })
+    );
 
     this.onLoadSyncDisplayedFieldsWithUrlColumns();
 
@@ -337,10 +337,7 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
 
   public static Component = ({ model }: SceneComponentProps<LogsTablePanelScene>) => {
     const styles = useStyles2(getStyles);
-    // Get state from parent model
-    // const parentModel = sceneGraph.getAncestor(model, LogsListScene);
     const { error, errorType, canClearFilters, panel } = model.useState();
-    // const { displayedFields } = parentModel.useState();
 
     return (
       <div className={styles.panelWrapper}>

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -166,7 +166,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
 
     this.setState({
       emptyScene: new NoMatchingLabelsScene({ clearCallback: () => clearVariables(this) }),
-      menu: new PanelMenu({}),
       panel,
     });
     setControlsExpandedStateFromLocalStorage(this.getParentScene());

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -299,18 +299,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  container: css({
-    display: 'flex',
-    flexDirection: 'row-reverse',
-    justifyContent: 'space-between',
-    height: '100%',
-    flex: 1,
-  }),
-  tableContainer: css({
-    overflow: 'hidden',
-    flex: '1 1 auto',
-    minWidth: 0,
-  }),
   panelWrapper: css({
     height: '100%',
     label: 'panel-wrapper-table',

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -328,15 +328,6 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
     // const parentModel = sceneGraph.getAncestor(model, LogsListScene);
     const { error, errorType, canClearFilters, panel } = model.useState();
     // const { displayedFields } = parentModel.useState();
-    // const { data } = sceneGraph.getData(model).useState();
-
-    // const dataFrame = getLogsPanelFrame(data);
-
-    // Define callback function to update filters in react
-    // const addFilter = (filter: AdHocVariableFilter) => {
-    //   const variableType = getVariableForLabel(dataFrame, filter.key, model);
-    //   addAdHocFilter(filter, parentModel, variableType);
-    // };
 
     return (
       <div className={styles.panelWrapper}>

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -253,7 +253,7 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
       parentModel.setState({
         displayedFields: displayedFields,
       });
-      setDisplayedFieldsInStorage(this, displayedFields);
+      setDisplayedFieldsInStorage(this, displayedFields, true);
     }
   };
 

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -23,27 +23,27 @@ import {
 } from '@grafana/schema/dist/esm/raw/composable/logstable/panelcfg/x/LogsTablePanelCfg_types.gen';
 import { AdHocFilterItem, PanelContext, useStyles2 } from '@grafana/ui';
 
-import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../services/analytics';
-import { areArraysEqual } from '../../services/comparison';
-import { getAllLabelsFromDataFrame } from '../../services/labels';
-import { setControlsExpandedStateFromLocalStorage } from '../../services/scenes';
-import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from '../../services/store';
-import { clearVariables } from '../../services/variableHelpers';
-import { PanelMenu } from '../Panels/PanelMenu';
-import { DETECTED_LEVEL, LEVEL } from '../Table/constants';
 import { addToFilters } from './Breakdowns/AddToFiltersButton';
 import { NoMatchingLabelsScene } from './Breakdowns/NoMatchingLabelsScene';
 import { LogOptionsScene } from './LogOptionsScene';
 import { LogsListScene } from './LogsListScene';
 import { ErrorType, LogsPanelError } from './LogsPanelError';
 import { ServiceScene } from './ServiceScene';
+import { PanelMenu } from 'Components/Panels/PanelMenu';
+import { DETECTED_LEVEL, LEVEL } from 'Components/Table/constants';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
+import { areArraysEqual } from 'services/comparison';
 import { getVariableForLabel } from 'services/fields';
 import { FilterOp } from 'services/filterTypes';
+import { getAllLabelsFromDataFrame } from 'services/labels';
 import { logger } from 'services/logger';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
 import { setTableFieldOverrides, storeTableFieldConfig } from 'services/logsTable';
 import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
 import { runSceneQueries } from 'services/query';
+import { setControlsExpandedStateFromLocalStorage } from 'services/scenes';
+import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from 'services/store';
+import { clearVariables } from 'services/variableHelpers';
 
 interface LogsTablePanelSceneState extends SceneObjectState {
   canClearFilters?: boolean;

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -43,6 +43,7 @@ import { logger } from 'services/logger';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
 import { setTableFieldOverrides, storeTableFieldConfig } from 'services/logsTable';
 import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
+import { runSceneQueries } from 'services/query';
 
 interface LogsTableSceneState extends SceneObjectState {
   canClearFilters?: boolean;
@@ -103,10 +104,22 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTableSceneState> {
     }
   }
 
+  handleSortChange = (newOrder: LogsSortOrder) => {
+    if (newOrder === this.state.sortOrder) {
+      return;
+    }
+    setLogOption('sortOrder', newOrder);
+    runSceneQueries(this);
+    this.setState({ sortOrder: newOrder });
+  };
+
   protected onOptionsChange(options: DeepPartial<Options>, prevOptions: DeepPartial<Options>) {
     // todo: Update after Grafana >= 13.1
     if ('wrapText' in options && 'wrapText' in prevOptions && options.wrapText !== prevOptions.wrapText) {
       setLogOption('wrapText', Boolean(options.wrapText));
+    }
+    if (options.sortOrder && options.sortOrder !== this.state.sortOrder) {
+      this.handleSortChange(options.sortOrder);
     }
   }
 

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -30,12 +30,10 @@ import { LogsListScene } from './LogsListScene';
 import { ErrorType, LogsPanelError } from './LogsPanelError';
 import { ServiceScene } from './ServiceScene';
 import { PanelMenu } from 'Components/Panels/PanelMenu';
-import { DETECTED_LEVEL, LEVEL } from 'Components/Table/constants';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { areArraysEqual } from 'services/comparison';
 import { getVariableForLabel } from 'services/fields';
 import { FilterOp } from 'services/filterTypes';
-import { getAllLabelsFromDataFrame } from 'services/labels';
 import { logger } from 'services/logger';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
 import { setTableFieldOverrides, storeTableFieldConfig } from 'services/logsTable';
@@ -43,6 +41,7 @@ import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
 import { runSceneQueries } from 'services/query';
 import { setControlsExpandedStateFromLocalStorage } from 'services/scenes';
 import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from 'services/store';
+import { copyText, generateLogShortlink } from 'services/text';
 import { clearVariables } from 'services/variableHelpers';
 
 interface LogsTablePanelSceneState extends SceneObjectState {
@@ -128,6 +127,8 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     const parentScene = this.getParentScene();
     const panelBuilder = new VizConfigBuilder<Options, {}>('logstable', pluginVersion, () => ({
       ...defaultOptions,
+      buildLinkToLogLine: this.buildLinkToLogLine,
+      showCopyLogLink: true,
       sortOrder: this.state.sortOrder,
       displayedFields: parentScene.state.displayedFields,
       wrapText: getBooleanLogOption('wrapText', true),
@@ -257,26 +258,25 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
     }
   };
 
-  // check if the data has a detected_level or level field
-  hasDetectedLevel = () => {
-    const dataProvider = sceneGraph.getData(this);
-    const data = dataProvider.state.data;
-    if (!data?.series?.length) {
-      return null;
-    }
+  buildLinkToLogLine = (uid: string) => {
+    const parent = this.getParentScene();
+    const timeRange = sceneGraph.getTimeRange(parent).state.value;
+    console.log(parent.state.displayedFields);
+    const link = generateLogShortlink(
+      'panelState',
+      {
+        logs: {
+          displayedFields: parent.state.displayedFields,
+          id: uid,
+          sortOrder: this.state.sortOrder,
+        },
+      },
+      timeRange
+    );
 
-    // Get all available labels from the series
-    const allLabels = getAllLabelsFromDataFrame(data.series);
+    copyText(link);
 
-    // Check if detected_level or level exists in the labels
-    if (allLabels.includes(DETECTED_LEVEL)) {
-      return DETECTED_LEVEL;
-    }
-    if (allLabels.includes(LEVEL)) {
-      return LEVEL;
-    }
-
-    return null;
+    return link;
   };
 
   public static Component = ({ model }: SceneComponentProps<LogsTablePanelScene>) => {

--- a/src/featureFlags/openFeature.ts
+++ b/src/featureFlags/openFeature.ts
@@ -129,6 +129,12 @@ const goffFeatureFlags = {
     reason: 'static provider evaluation result',
     variant: 'default',
   },
+  logsTablePanelNG: {
+    valueType: 'boolean',
+    value: false,
+    reason: 'static provider evaluation result',
+    variant: 'default',
+  },
   'drilldown.logs.fake_flag': {
     valueType: 'string',
     values: [
@@ -295,6 +301,13 @@ function getConfigToggleFallback(flagName: string): boolean | undefined {
     'kgAnnotationsInLokiExplore' in config.featureToggles
   ) {
     return Boolean(config.featureToggles.kgAnnotationsInLokiExplore);
+  }
+  if (flagName === 'exploreLogsShardSplitting') {
+    return config.featureToggles.exploreLogsShardSplitting;
+  }
+  if (flagName === 'logsTablePanelNG') {
+    // @ts-expect-error Remove with grafana/data@13
+    return config.featureToggles.logsTablePanelNG;
   }
   return undefined;
 }

--- a/src/featureFlags/openFeature.ts
+++ b/src/featureFlags/openFeature.ts
@@ -306,7 +306,6 @@ function getConfigToggleFallback(flagName: string): boolean | undefined {
     return config.featureToggles.exploreLogsShardSplitting;
   }
   if (flagName === 'logsTablePanelNG') {
-    // @ts-expect-error Remove with grafana/data@13
     return config.featureToggles.logsTablePanelNG;
   }
   return undefined;

--- a/src/featureFlags/openFeature.ts
+++ b/src/featureFlags/openFeature.ts
@@ -302,9 +302,6 @@ function getConfigToggleFallback(flagName: string): boolean | undefined {
   ) {
     return Boolean(config.featureToggles.kgAnnotationsInLokiExplore);
   }
-  if (flagName === 'exploreLogsShardSplitting') {
-    return config.featureToggles.exploreLogsShardSplitting;
-  }
   if (flagName === 'logsTablePanelNG') {
     return config.featureToggles.logsTablePanelNG;
   }

--- a/src/services/logsTable.ts
+++ b/src/services/logsTable.ts
@@ -1,0 +1,37 @@
+import { FieldConfig, FieldConfigSource } from '@grafana/data';
+import { FieldConfigOverridesBuilder, SceneObject } from '@grafana/scenes';
+
+import { getTableColumnWidths, saveTableColumnWidths } from './store';
+
+/** Logs table column sizing lives under field override property `custom.width`. */
+interface LogsTableFieldConfig extends FieldConfig {
+  width?: number;
+}
+
+export function storeTableFieldConfig(config: FieldConfigSource, sceneRef: SceneObject) {
+  const widthOverrides = config.overrides
+    .filter((override) => override.matcher.id === 'byName')
+    .filter((override) => override.properties.some((property) => property.id === 'custom.width' && property.value > 0))
+    .map((override) => {
+      const field = override.matcher.options;
+      const width = override.properties.find((property) => property.id === 'custom.width' && property.value > 0)?.value;
+      return {
+        field,
+        width,
+      };
+    });
+  saveTableColumnWidths(sceneRef, widthOverrides);
+}
+
+export function setTableFieldOverrides(
+  builder: FieldConfigOverridesBuilder<LogsTableFieldConfig>,
+  sceneRef: SceneObject
+) {
+  const columnWidths = getTableColumnWidths(sceneRef);
+
+  columnWidths.forEach((columnWidth) => {
+    builder
+      .matchFieldsWithName(columnWidth.field)
+      .overrideCustomFieldConfig<LogsTableFieldConfig, 'width'>('width', columnWidth.width);
+  });
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -268,6 +268,37 @@ export function getDisplayedFieldsInStorage(
   return [];
 }
 
+export type TableColumnWidth = { field: string; width: number };
+
+export function saveTableColumnWidths(sceneRef: SceneObject, columnWidths: TableColumnWidth[]) {
+  const key = `${pluginJson.id}.${getExplorationPrefix(sceneRef)}.table.columnWidths`;
+  localStorage.setItem(key, JSON.stringify(columnWidths));
+}
+
+export function getTableColumnWidths(sceneRef: SceneObject): TableColumnWidth[] {
+  const key = `${pluginJson.id}.${getExplorationPrefix(sceneRef)}.table.columnWidths`;
+  let stored: unknown;
+  try {
+    stored = JSON.parse(localStorage.getItem(key) ?? '[]');
+  } catch (e) {
+    logger.error(e);
+  }
+
+  let columnWidths = Array.isArray(stored)
+    ? stored.filter(
+        (columnWidth: unknown): columnWidth is TableColumnWidth =>
+          typeof columnWidth === 'object' &&
+          columnWidth !== null &&
+          'field' in columnWidth &&
+          'width' in columnWidth &&
+          typeof columnWidth.width === 'number' &&
+          typeof columnWidth.field === 'string'
+      )
+    : [];
+
+  return columnWidths;
+}
+
 export function setDisplayedFieldsInStorage(sceneRef: SceneObject, fields: string[] | null, userAdded = false) {
   const key = getDisplayedFieldsKey(sceneRef, userAdded);
   localStorage.setItem(key, JSON.stringify(fields));

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -296,7 +296,10 @@ export function getLogOption<T>(option: keyof Options, defaultValue: T): T {
   return localStorageResult ? (localStorageResult as T) : defaultValue;
 }
 
-export function getBooleanLogOption(option: keyof Options | 'controlsExpanded', defaultValue: boolean): boolean {
+export function getBooleanLogOption(
+  option: keyof Options | 'controlsExpanded' | 'wrapText',
+  defaultValue: boolean
+): boolean {
   const localStorageResult = localStorage.getItem(`${LOG_OPTIONS_LOCALSTORAGE_KEY}.${option}`);
   if (localStorageResult === null) {
     return defaultValue;
@@ -305,7 +308,7 @@ export function getBooleanLogOption(option: keyof Options | 'controlsExpanded', 
 }
 
 export function setLogOption(
-  option: keyof Options | 'maxLines' | 'controlsExpanded',
+  option: keyof Options | 'maxLines' | 'controlsExpanded' | 'wrapText',
   value: string | number | boolean
 ) {
   let storedValue = value.toString();


### PR DESCRIPTION
This PR adds support to use the new Logs Table visualization.

Requires the `logsTablePanelNG` feature flag.

### What to test

- Displayed fields persistence
- Backend configured displayed fields
- Add filters from the table
- Sort order updates
- Wrapping controls