### PR TITLE
fix(augurs): fallback if wasm fails

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -26,7 +26,11 @@ const App = lazy(async () => {
   initRuntimeDs();
 
   if (wasmSupported()) {
-    await Promise.all([initChangepoint(), initOutlier()]);
+    try {
+      await Promise.all([initChangepoint(), initOutlier()]);
+    } catch (e) {
+      console.warn('grafana-lokiexplore-app: WebAssembly init failed, ML sorting disabled.', e);
+    }
   }
 
   return import('Components/App');


### PR DESCRIPTION
https://raintank-corp.slack.com/archives/C075BDBTX96/p1771844319780149
This will unblock the plugin to load if there is an error in wasm, but is not the long-term fix. 

#### Problem
Thank @sd2k for figuring this one out 🙏 
The Proxy issue comes from OpenTelemetry’s @opentelemetry/instrumentation-fetch, which Faro wires up when tracing is enabled. OpenTelemetry's @opentelemetry/instrumentation-fetch wraps globalThis.fetch via this._wrap(globalThis, 'fetch', ...) Grafana instances with Faro/OpenTelemetry tracing enabled have the fetch instrumentation active, which wraps globalThis.fetch. Instances without tracing use the native fetch and work fine. 