### PR TITLE
chore(renovate): use strict

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "extends": ["config:best-practices"],
   "schedule": ["on the first day of the month"],
+  "internalChecksFilter": "strict",
   "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {


### PR DESCRIPTION
Use "strict" avoid opening PRs that will immediately fail CI. Right now we are opening PRs on the first of the month that do not pass the 'stability days'.
