### PR TITLE
chore(grafanaDeps): update grafanaDependency version

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -53,7 +53,7 @@
   ],
   "roles": [],
   "dependencies": {
-    "grafanaDependency": ">=11.6.11 <12 || >=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5",
+    "grafanaDependency": ">=11.6.11",
     "plugins": [],
     "extensions": {
       "exposedComponents": [


### PR DESCRIPTION
Logs Drilldown ci/cd.yml is failing to [publish in ops](https://github.com/grafana/logs-drilldown/actions/runs/22768868824/job/66051854746#step:10:67) it does successfully publish to dev.
```
Response:
{
  "code": "InvalidArgument",
  "message": "plugin.json invalid: data/dependencies/grafanaDependency must match pattern \"^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)?(\\.[0-9x\\*]+)?(-[0-9A-Za-z-.]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x\\*]+)?(\\.[0-9x\\*]+)?(-[0-9A-Za-z-.]+)?)?$\"",
  "requestId": "70b01047-9b31-4548-886c-b3bee572228b"
}
```
I'm surprised because a few other plugins are already using these versions, [example](https://github.com/grafana/grafana-csp-app/blob/95c9555c692a06e3f3610fd71b6e10e52a886e0f/src/plugin.json#L292). Perhaps they are not using the auto argo workflows. I'm asking about it in plugins-platform [here](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1772813876945339?thread_ts=1772658706.822029&cid=C01C4K8DETW). 

Meanwhile, this PR uses an acceptable format for ops, to bring back auto publishing.  Unfortunately it does not fully capture all the compatible versions.   