### PR TITLE
fix(renonvate): prCreation: not-pending

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "extends": ["config:best-practices"],
   "schedule": ["on the first day of the month"],
+  "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "rebaseWhen": "behind-base-branch",
   "packageRules": [


### PR DESCRIPTION
This change updates Renovate behavior so dependency PRs are not opened while updates are still within the minimum release age stability days window. Set prCreation: "not-pending"