### PR TITLE
chore(e2e): increase Playwright CI workers to 2

### DIFF
--- a/playwright.base.config.ts
+++ b/playwright.base.config.ts
@@ -29,7 +29,7 @@ export const baseConfig = {
     // },
   },
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
 };
 
 /**

--- a/playwright.base.config.ts
+++ b/playwright.base.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig, devices } from '@playwright/test';
+import { devices } from '@playwright/test';
 import { dirname } from 'node:path';
-
-import type { PluginOptions } from '@grafana/plugin-e2e';
 
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 
@@ -28,8 +26,8 @@ export const baseConfig = {
     //   mode: 'on',
     // },
   },
-  /* Limit CI workers to 4. */
-  workers: process.env.CI ? 4 : undefined,
+  /* Limit CI workers to 2. */
+  workers: process.env.CI ? 2 : 4,
 };
 
 /**

--- a/playwright.base.config.ts
+++ b/playwright.base.config.ts
@@ -28,7 +28,7 @@ export const baseConfig = {
     //   mode: 'on',
     // },
   },
-  /* Opt out of parallel tests on CI. */
+  /* Limit CI workers to 4. */
   workers: process.env.CI ? 4 : undefined,
 };
 


### PR DESCRIPTION
## Summary
- Increases Playwright CI workers from 1 to 2. And locally bump to 4
- About 50% gains in wait times for CI runs

## Test plan
- [ ] CI Playwright tests pass with 4 workers