### PR TITLE
fix(Config): initialize feature flags in the configuration page

### DIFF
--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -1,13 +1,19 @@
-import React, { lazy } from 'react';
+import React, { lazy, useEffect } from 'react';
 
 import { AppRootProps } from '@grafana/data';
 
 import { FeatureFlagContext } from './FeatureFlagContext';
+import { logger } from 'services/logger';
 
 const LogExplorationView = lazy(() => import('./LogExplorationPage'));
 const PluginPropsContext = React.createContext<AppRootProps | null>(null);
 
 const App = (props: AppRootProps) => {
+  useEffect(() => {
+    // Log plugin loading success for SLO monitoring
+    logger.info('Plugin loaded successfully');
+  }, []);
+
   return (
     <FeatureFlagContext>
       <PluginPropsContext.Provider value={props}>

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -1,44 +1,19 @@
-import React, { lazy, useEffect, useState } from 'react';
+import React, { lazy } from 'react';
 
 import { AppRootProps } from '@grafana/data';
-import { t } from '@grafana/i18n';
-import { LoadingPlaceholder } from '@grafana/ui';
 
-import { initializeFeatureFlags, initOpenFeatureProvider } from 'featureFlags/openFeature';
-import { logger } from 'services/logger';
+import { FeatureFlagContext } from './FeatureFlagContext';
 
 const LogExplorationView = lazy(() => import('./LogExplorationPage'));
 const PluginPropsContext = React.createContext<AppRootProps | null>(null);
 
-// Initialize OpenFeature provider and populate flag cache
-const featureFlagsReady = initOpenFeatureProvider().then(() => initializeFeatureFlags());
-
 const App = (props: AppRootProps) => {
-  const [isReady, setIsReady] = useState(false);
-
-  useEffect(() => {
-    // Initialize and cache the feature flags for use in the app
-    featureFlagsReady
-      .then(() => {
-        setIsReady(true);
-      })
-      .catch((err) => {
-        logger.error(err, { msg: 'Feature flags failed to load' });
-        setIsReady(true);
-      });
-    // Log plugin loading success for SLO monitoring
-    logger.info('Plugin loaded successfully');
-  }, []);
-
-  // Show a loading spinner until the feature flags are ready
-  if (!isReady) {
-    return <LoadingPlaceholder text={t('components.app.text-loading', 'Loading...')} />;
-  }
-
   return (
-    <PluginPropsContext.Provider value={props}>
-      <LogExplorationView />
-    </PluginPropsContext.Provider>
+    <FeatureFlagContext>
+      <PluginPropsContext.Provider value={props}>
+        <LogExplorationView />
+      </PluginPropsContext.Provider>
+    </FeatureFlagContext>
   );
 };
 

--- a/src/Components/AppConfig/AppConfig.test.tsx
+++ b/src/Components/AppConfig/AppConfig.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { of } from 'rxjs';
@@ -8,6 +8,10 @@ import { getBackendSrv, locationService } from '@grafana/runtime';
 
 import { getDefaultDatasourceFromDatasourceSrv, getLastUsedDataSourceFromStorage } from '../../services/store';
 import AppConfig, { updatePlugin, type JsonData } from './AppConfig';
+
+jest.mock('Components/FeatureFlagContext', () => ({
+  FeatureFlagContext: ({ children }: { children: ReactNode }) => children,
+}));
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),

--- a/src/Components/AppConfig/AppConfig.tsx
+++ b/src/Components/AppConfig/AppConfig.tsx
@@ -19,6 +19,7 @@ import { Alert, Button, Checkbox, Field, FieldSet, Input, useStyles2 } from '@gr
 
 import { logger } from '../../services/logger';
 import { getDefaultDatasourceFromDatasourceSrv, getLastUsedDataSourceFromStorage } from '../../services/store';
+import { FeatureFlagContext } from 'Components/FeatureFlagContext';
 import { isValidTimeRange } from 'services/utils';
 
 export type JsonData = {
@@ -139,195 +140,197 @@ const AppConfig = ({ plugin }: Props) => {
     !state.defaultTimeRangeEnabled || (defaultTimeRangeValidation !== null && defaultTimeRangeValidation.valid);
 
   return (
-    <div data-testid={testIds.appConfig.container}>
-      <FieldSet label={t('components.app-config.label-settings', 'Settings')}>
-        <Field
-          description={
-            <span>
-              <Trans i18nKey="components.app-config.default-data-source-description">
-                The default data source to be used for new Logs Drilldown users. Each user can override their default by
-                setting another data source in Logs Drilldown.
-              </Trans>
-            </span>
-          }
-          label={t('components.app-config.label-default-data-source', 'Default data source')}
-        >
-          <DataSourcePicker
-            width={60}
-            filter={(ds) => ds.type === 'loki'}
-            current={state.dataSource}
-            onChange={onChangeDatasource}
-          />
-        </Field>
-
-        <Field
-          className={styles.marginTop}
-          description={
-            <span>
-              <Trans i18nKey="components.app-config.default-time-range-description">
-                When enabled, this time range is used when users open Logs Drilldown for the first time, and without a
-                time range in the URL. When disabled, the app uses its built-in default (last 15 minutes).
-              </Trans>
-            </span>
-          }
-          label={t('components.app-config.label-default-time-range', 'Default time range')}
-        >
-          <Checkbox
-            id="default-time-range-enabled"
-            data-testid={testIds.appConfig.defaultTimeRangeEnabled}
-            label={t(
-              'components.app-config.default-time-range-enabled-label-use-custom-default-time-range',
-              'Use custom default time range'
-            )}
-            value={state.defaultTimeRangeEnabled}
-            onChange={onChangeDefaultTimeRangeEnabled}
-          />
-        </Field>
-
-        {state.defaultTimeRangeEnabled && (
-          <div className={styles.defaultTimeRangeInputs}>
-            <Field
-              invalid={defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid}
-              error={
-                defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid
-                  ? defaultTimeRangeValidation.error
-                  : undefined
-              }
-              description={t(
-                'components.app-config.description-start-range',
-                'Start of the range (e.g. now-15m, now-1h, now-24h)'
-              )}
-              label={t('components.app-config.label-from', 'From')}
-            >
-              <Input
-                width={40}
-                id="default-time-range-from"
-                data-testid={testIds.appConfig.defaultTimeRangeFrom}
-                value={state.defaultTimeRangeFrom}
-                placeholder={t('components.app-config.default-time-range-from-placeholder-now-15m', 'now-15m')}
-                onChange={onChangeDefaultTimeRangeFrom}
-              />
-            </Field>
-            <Field
-              className={styles.marginTop}
-              invalid={defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid}
-              error={
-                defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid
-                  ? defaultTimeRangeValidation.error
-                  : undefined
-              }
-              description={t(
-                'components.app-config.description-end-of-the-range-eg-now',
-                'End of the range (e.g. now)'
-              )}
-              label={t('components.app-config.label-to', 'To')}
-            >
-              <Input
-                width={40}
-                id="default-time-range-to"
-                data-testid={testIds.appConfig.defaultTimeRangeTo}
-                value={state.defaultTimeRangeTo}
-                placeholder={t('components.app-config.default-time-range-to-placeholder-now', 'now')}
-                onChange={onChangeDefaultTimeRangeTo}
-              />
-            </Field>
-          </div>
-        )}
-
-        <Field
-          invalid={!isValid(state.interval)}
-          error={t(
-            'components.app-config.interval-invalid-error',
-            'Interval is invalid. Please enter an interval longer than "60m". For example: 3d, 1w, 1m'
-          )}
-          description={
-            <span>
-              <Trans i18nKey="components.app-config.max-interval-description">
-                The maximum interval that can be selected in the time picker within the Grafana Logs Drilldown app. If
-                empty, users can select any time range interval in Grafana Logs Drilldown. <br />
-                Example values: 7d, 24h, 2w
-              </Trans>
-            </span>
-          }
-          label={t('components.app-config.label-maximum-time-picker-interval', 'Maximum time picker interval')}
-          className={styles.marginTop}
-        >
-          <Input
-            width={60}
-            id="interval"
-            data-testid={testIds.appConfig.interval}
-            label={t('components.app-config.label-max-interval', 'Max interval')}
-            value={state?.interval}
-            placeholder={t('components.app-config.interval-placeholder', '7d')}
-            onChange={onChangeInterval}
-          />
-        </Field>
-
-        <Field
-          className={styles.marginTop}
-          description={
-            <span>
-              <Trans i18nKey="components.app-config.disable-patterns-description">
-                Disables Logs Drilldown&apos;s usage of the{' '}
-                <a
-                  className="external-link"
-                  href="https://grafana.com/docs/loki/latest/reference/loki-http-api/#patterns-detection"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Loki Patterns API
-                </a>{' '}
-                endpoint, and removes the Patterns tab.
-              </Trans>
-            </span>
-          }
-          label={t('components.app-config.label-disable-loki-patterns', 'Disable Loki patterns')}
-        >
-          <Checkbox
-            id="disable-patterns"
-            data-testid={testIds.appConfig.interval}
-            label={t('components.app-config.label-disable-patterns', 'Disable patterns')}
-            value={state?.patternsDisabled}
-            placeholder={t('components.app-config.patterns-placeholder', '7d')}
-            onChange={onChangePatternsDisabled}
-          />
-        </Field>
-
-        <div className={styles.marginTop}>
-          <Button
-            type="submit"
-            data-testid={testIds.appConfig.submit}
-            onClick={() =>
-              updatePluginAndReload(plugin.meta.id, {
-                enabled,
-                jsonData: {
-                  dataSource: state.dataSource,
-                  interval: state.interval,
-                  patternsDisabled: state.patternsDisabled,
-                  defaultTimeRange:
-                    state.defaultTimeRangeEnabled &&
-                    state.defaultTimeRangeFrom.trim() &&
-                    state.defaultTimeRangeTo.trim()
-                      ? { from: state.defaultTimeRangeFrom.trim(), to: state.defaultTimeRangeTo.trim() }
-                      : undefined,
-                },
-                pinned,
-              })
+    <FeatureFlagContext>
+      <div data-testid={testIds.appConfig.container}>
+        <FieldSet label={t('components.app-config.label-settings', 'Settings')}>
+          <Field
+            description={
+              <span>
+                <Trans i18nKey="components.app-config.default-data-source-description">
+                  The default data source to be used for new Logs Drilldown users. Each user can override their default
+                  by setting another data source in Logs Drilldown.
+                </Trans>
+              </span>
             }
-            disabled={!isValid(state.interval) || !isDefaultTimeRangeValid}
+            label={t('components.app-config.label-default-data-source', 'Default data source')}
           >
-            <Trans i18nKey="components.app-config.save-settings">Save settings</Trans>
-          </Button>
-        </div>
-        <div className={styles.note}>
-          <Alert severity="info" title="">
-            <Trans i18nKey="components.app-config.active-users-reload-reflect-configuration-changes">
-              Active users must reload the app to reflect configuration changes.
-            </Trans>
-          </Alert>
-        </div>
-      </FieldSet>
-    </div>
+            <DataSourcePicker
+              width={60}
+              filter={(ds) => ds.type === 'loki'}
+              current={state.dataSource}
+              onChange={onChangeDatasource}
+            />
+          </Field>
+
+          <Field
+            className={styles.marginTop}
+            description={
+              <span>
+                <Trans i18nKey="components.app-config.default-time-range-description">
+                  When enabled, this time range is used when users open Logs Drilldown for the first time, and without a
+                  time range in the URL. When disabled, the app uses its built-in default (last 15 minutes).
+                </Trans>
+              </span>
+            }
+            label={t('components.app-config.label-default-time-range', 'Default time range')}
+          >
+            <Checkbox
+              id="default-time-range-enabled"
+              data-testid={testIds.appConfig.defaultTimeRangeEnabled}
+              label={t(
+                'components.app-config.default-time-range-enabled-label-use-custom-default-time-range',
+                'Use custom default time range'
+              )}
+              value={state.defaultTimeRangeEnabled}
+              onChange={onChangeDefaultTimeRangeEnabled}
+            />
+          </Field>
+
+          {state.defaultTimeRangeEnabled && (
+            <div className={styles.defaultTimeRangeInputs}>
+              <Field
+                invalid={defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid}
+                error={
+                  defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid
+                    ? defaultTimeRangeValidation.error
+                    : undefined
+                }
+                description={t(
+                  'components.app-config.description-start-range',
+                  'Start of the range (e.g. now-15m, now-1h, now-24h)'
+                )}
+                label={t('components.app-config.label-from', 'From')}
+              >
+                <Input
+                  width={40}
+                  id="default-time-range-from"
+                  data-testid={testIds.appConfig.defaultTimeRangeFrom}
+                  value={state.defaultTimeRangeFrom}
+                  placeholder={t('components.app-config.default-time-range-from-placeholder-now-15m', 'now-15m')}
+                  onChange={onChangeDefaultTimeRangeFrom}
+                />
+              </Field>
+              <Field
+                className={styles.marginTop}
+                invalid={defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid}
+                error={
+                  defaultTimeRangeValidation !== null && !defaultTimeRangeValidation.valid
+                    ? defaultTimeRangeValidation.error
+                    : undefined
+                }
+                description={t(
+                  'components.app-config.description-end-of-the-range-eg-now',
+                  'End of the range (e.g. now)'
+                )}
+                label={t('components.app-config.label-to', 'To')}
+              >
+                <Input
+                  width={40}
+                  id="default-time-range-to"
+                  data-testid={testIds.appConfig.defaultTimeRangeTo}
+                  value={state.defaultTimeRangeTo}
+                  placeholder={t('components.app-config.default-time-range-to-placeholder-now', 'now')}
+                  onChange={onChangeDefaultTimeRangeTo}
+                />
+              </Field>
+            </div>
+          )}
+
+          <Field
+            invalid={!isValid(state.interval)}
+            error={t(
+              'components.app-config.interval-invalid-error',
+              'Interval is invalid. Please enter an interval longer than "60m". For example: 3d, 1w, 1m'
+            )}
+            description={
+              <span>
+                <Trans i18nKey="components.app-config.max-interval-description">
+                  The maximum interval that can be selected in the time picker within the Grafana Logs Drilldown app. If
+                  empty, users can select any time range interval in Grafana Logs Drilldown. <br />
+                  Example values: 7d, 24h, 2w
+                </Trans>
+              </span>
+            }
+            label={t('components.app-config.label-maximum-time-picker-interval', 'Maximum time picker interval')}
+            className={styles.marginTop}
+          >
+            <Input
+              width={60}
+              id="interval"
+              data-testid={testIds.appConfig.interval}
+              label={t('components.app-config.label-max-interval', 'Max interval')}
+              value={state?.interval}
+              placeholder={t('components.app-config.interval-placeholder', '7d')}
+              onChange={onChangeInterval}
+            />
+          </Field>
+
+          <Field
+            className={styles.marginTop}
+            description={
+              <span>
+                <Trans i18nKey="components.app-config.disable-patterns-description">
+                  Disables Logs Drilldown&apos;s usage of the{' '}
+                  <a
+                    className="external-link"
+                    href="https://grafana.com/docs/loki/latest/reference/loki-http-api/#patterns-detection"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Loki Patterns API
+                  </a>{' '}
+                  endpoint, and removes the Patterns tab.
+                </Trans>
+              </span>
+            }
+            label={t('components.app-config.label-disable-loki-patterns', 'Disable Loki patterns')}
+          >
+            <Checkbox
+              id="disable-patterns"
+              data-testid={testIds.appConfig.interval}
+              label={t('components.app-config.label-disable-patterns', 'Disable patterns')}
+              value={state?.patternsDisabled}
+              placeholder={t('components.app-config.patterns-placeholder', '7d')}
+              onChange={onChangePatternsDisabled}
+            />
+          </Field>
+
+          <div className={styles.marginTop}>
+            <Button
+              type="submit"
+              data-testid={testIds.appConfig.submit}
+              onClick={() =>
+                updatePluginAndReload(plugin.meta.id, {
+                  enabled,
+                  jsonData: {
+                    dataSource: state.dataSource,
+                    interval: state.interval,
+                    patternsDisabled: state.patternsDisabled,
+                    defaultTimeRange:
+                      state.defaultTimeRangeEnabled &&
+                      state.defaultTimeRangeFrom.trim() &&
+                      state.defaultTimeRangeTo.trim()
+                        ? { from: state.defaultTimeRangeFrom.trim(), to: state.defaultTimeRangeTo.trim() }
+                        : undefined,
+                  },
+                  pinned,
+                })
+              }
+              disabled={!isValid(state.interval) || !isDefaultTimeRangeValid}
+            >
+              <Trans i18nKey="components.app-config.save-settings">Save settings</Trans>
+            </Button>
+          </div>
+          <div className={styles.note}>
+            <Alert severity="info" title="">
+              <Trans i18nKey="components.app-config.active-users-reload-reflect-configuration-changes">
+                Active users must reload the app to reflect configuration changes.
+              </Trans>
+            </Alert>
+          </div>
+        </FieldSet>
+      </div>
+    </FeatureFlagContext>
   );
 };
 

--- a/src/Components/AppConfig/DefaultColumns/Config.test.tsx
+++ b/src/Components/AppConfig/DefaultColumns/Config.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { fireEvent, render, RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,6 +18,10 @@ import { DataSourceWithBackend, getDataSourceSrv, locationService, LocationServi
 import Config from './Config';
 import { DefaultColumnsContextProvider } from './Context';
 import { LocalLogsDrilldownDefaultColumnsLogsDefaultColumnsRecords } from './types';
+
+jest.mock('Components/FeatureFlagContext', () => ({
+  FeatureFlagContext: ({ children }: { children: ReactNode }) => children,
+}));
 
 // Constants
 const DEBUG = false;

--- a/src/Components/AppConfig/DefaultColumns/Config.tsx
+++ b/src/Components/AppConfig/DefaultColumns/Config.tsx
@@ -12,10 +12,19 @@ import { DefaultColumns } from './DefaultColumns';
 import { Footer } from './Footer';
 import { isDefaultColumnsSupported } from './isSupported';
 import { Unsupported } from './Unsupported';
+import { FeatureFlagContext } from 'Components/FeatureFlagContext';
 import { NoLokiSplash } from 'Components/NoLokiSplash';
 import { getDefaultDatasourceFromDatasourceSrv, getLastUsedDataSourceFromStorage } from 'services/store';
 
 const Config = () => {
+  return (
+    <FeatureFlagContext>
+      <DefaultColumnsConfig />
+    </FeatureFlagContext>
+  );
+};
+
+const DefaultColumnsConfig = () => {
   const dsUID = getLastUsedDataSourceFromStorage() ?? getDefaultDatasourceFromDatasourceSrv();
   const styles = useStyles2(getStyles);
   if (!dsUID) {

--- a/src/Components/AppConfig/DefaultColumns/ConfigUnsupported.test.tsx
+++ b/src/Components/AppConfig/DefaultColumns/ConfigUnsupported.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { render, RenderResult, screen } from '@testing-library/react';
 
@@ -6,6 +6,10 @@ import { DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import Config from './Config';
+
+jest.mock('Components/FeatureFlagContext', () => ({
+  FeatureFlagContext: ({ children }: { children: ReactNode }) => children,
+}));
 
 const debug = false;
 

--- a/src/Components/AppConfig/ServiceSelection/Config.test.tsx
+++ b/src/Components/AppConfig/ServiceSelection/Config.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -8,6 +8,10 @@ import 'jest-canvas-mock';
 
 import Config from './Config';
 import { getDefaultDatasourceFromDatasourceSrv, getLastUsedDataSourceFromStorage } from 'services/store';
+
+jest.mock('Components/FeatureFlagContext', () => ({
+  FeatureFlagContext: ({ children }: { children: ReactNode }) => children,
+}));
 
 const MOCK_DS_UID = 'test-datasource-uid';
 const DEBUG = false;

--- a/src/Components/AppConfig/ServiceSelection/Config.tsx
+++ b/src/Components/AppConfig/ServiceSelection/Config.tsx
@@ -35,30 +35,28 @@ const ServiceSelectionConfig = () => {
   }
 
   return (
-    <FeatureFlagContext>
-      <main className={styles.main}>
-        <div className={styles.introText}>
-          <Badge color={'blue'} text={t('components.app-config.service-selection.config.text-beta', 'Beta')} />
-          <span>
-            <Trans i18nKey="components.app-config.service-selection.config.service-selection-description">
-              Configure which labels and label values appear by default on the Logs Drilldown landing page.
-            </Trans>
-          </span>
-        </div>
+    <main className={styles.main}>
+      <div className={styles.introText}>
+        <Badge color={'blue'} text={t('components.app-config.service-selection.config.text-beta', 'Beta')} />
+        <span>
+          <Trans i18nKey="components.app-config.service-selection.config.service-selection-description">
+            Configure which labels and label values appear by default on the Logs Drilldown landing page.
+          </Trans>
+        </span>
+      </div>
 
-        <ErrorBoundaryAlert>
-          <ServiceSelectionContextProvider initialDSUID={dsUID}>
-            <header>
-              <DataSource />
-            </header>
+      <ErrorBoundaryAlert>
+        <ServiceSelectionContextProvider initialDSUID={dsUID}>
+          <header>
+            <DataSource />
+          </header>
 
-            <DefaultLabels />
+          <DefaultLabels />
 
-            <Footer />
-          </ServiceSelectionContextProvider>
-        </ErrorBoundaryAlert>
-      </main>
-    </FeatureFlagContext>
+          <Footer />
+        </ServiceSelectionContextProvider>
+      </ErrorBoundaryAlert>
+    </main>
   );
 };
 

--- a/src/Components/AppConfig/ServiceSelection/Config.tsx
+++ b/src/Components/AppConfig/ServiceSelection/Config.tsx
@@ -12,10 +12,19 @@ import { DefaultLabels } from './DefaultLabels';
 import { Footer } from './Footer';
 import { isDefaultLabelsSupported } from './isSupported';
 import { Unsupported } from './Unsupported';
+import { FeatureFlagContext } from 'Components/FeatureFlagContext';
 import { NoLokiSplash } from 'Components/NoLokiSplash';
 import { getDefaultDatasourceFromDatasourceSrv, getLastUsedDataSourceFromStorage } from 'services/store';
 
 const Config = () => {
+  return (
+    <FeatureFlagContext>
+      <ServiceSelectionConfig />
+    </FeatureFlagContext>
+  );
+};
+
+const ServiceSelectionConfig = () => {
   const dsUID = getLastUsedDataSourceFromStorage() ?? getDefaultDatasourceFromDatasourceSrv();
   const styles = useStyles2(getStyles);
   if (!dsUID) {
@@ -26,28 +35,30 @@ const Config = () => {
   }
 
   return (
-    <main className={styles.main}>
-      <div className={styles.introText}>
-        <Badge color={'blue'} text={t('components.app-config.service-selection.config.text-beta', 'Beta')} />
-        <span>
-          <Trans i18nKey="components.app-config.service-selection.config.service-selection-description">
-            Configure which labels and label values appear by default on the Logs Drilldown landing page.
-          </Trans>
-        </span>
-      </div>
+    <FeatureFlagContext>
+      <main className={styles.main}>
+        <div className={styles.introText}>
+          <Badge color={'blue'} text={t('components.app-config.service-selection.config.text-beta', 'Beta')} />
+          <span>
+            <Trans i18nKey="components.app-config.service-selection.config.service-selection-description">
+              Configure which labels and label values appear by default on the Logs Drilldown landing page.
+            </Trans>
+          </span>
+        </div>
 
-      <ErrorBoundaryAlert>
-        <ServiceSelectionContextProvider initialDSUID={dsUID}>
-          <header>
-            <DataSource />
-          </header>
+        <ErrorBoundaryAlert>
+          <ServiceSelectionContextProvider initialDSUID={dsUID}>
+            <header>
+              <DataSource />
+            </header>
 
-          <DefaultLabels />
+            <DefaultLabels />
 
-          <Footer />
-        </ServiceSelectionContextProvider>
-      </ErrorBoundaryAlert>
-    </main>
+            <Footer />
+          </ServiceSelectionContextProvider>
+        </ErrorBoundaryAlert>
+      </main>
+    </FeatureFlagContext>
   );
 };
 

--- a/src/Components/FeatureFlagContext.tsx
+++ b/src/Components/FeatureFlagContext.tsx
@@ -22,8 +22,6 @@ export const FeatureFlagContext = ({ children }: { children: ReactNode }) => {
         logger.error(err, { msg: 'Feature flags failed to load' });
         setIsReady(true);
       });
-    // Log plugin loading success for SLO monitoring
-    logger.info('Plugin loaded successfully');
   }, []);
 
   // Show a loading spinner until the feature flags are ready

--- a/src/Components/FeatureFlagContext.tsx
+++ b/src/Components/FeatureFlagContext.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode, useEffect, useState } from 'react';
+
+import { t } from '@grafana/i18n';
+import { LoadingPlaceholder } from '@grafana/ui';
+
+import { initializeFeatureFlags, initOpenFeatureProvider } from 'featureFlags/openFeature';
+import { logger } from 'services/logger';
+
+// Initialize OpenFeature provider and populate flag cache
+const featureFlagsReady = initOpenFeatureProvider().then(() => initializeFeatureFlags());
+
+export const FeatureFlagContext = ({ children }: { children: ReactNode }) => {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    // Initialize and cache the feature flags for use in the app
+    featureFlagsReady
+      .then(() => {
+        setIsReady(true);
+      })
+      .catch((err) => {
+        logger.error(err, { msg: 'Feature flags failed to load' });
+        setIsReady(true);
+      });
+    // Log plugin loading success for SLO monitoring
+    logger.info('Plugin loaded successfully');
+  }, []);
+
+  // Show a loading spinner until the feature flags are ready
+  if (!isReady) {
+    return <LoadingPlaceholder text={t('components.app.text-loading', 'Loading...')} />;
+  }
+
+  return children;
+};

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -71,7 +71,7 @@ const ServiceSelectionConfig = lazy(async () => {
 
 export const plugin = new AppPlugin<JsonData>()
   .setRootPage(App)
-  // For new config pages, specially if they require feature flags, make sure they are wrapped in a <FeatureFlagContext> component.
+  // For new config pages, especially if they require feature flags, make sure they are wrapped in a <FeatureFlagContext> component.
   .addConfigPage({
     body: AppConfig,
     icon: 'cog',

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -71,6 +71,7 @@ const ServiceSelectionConfig = lazy(async () => {
 
 export const plugin = new AppPlugin<JsonData>()
   .setRootPage(App)
+  // For new config pages, specially if they require feature flags, make sure they are wrapped in a <FeatureFlagContext> component.
   .addConfigPage({
     body: AppConfig,
     icon: 'cog',


### PR DESCRIPTION
If the user visited Logs Drilldown, where the feature flags are initialized, and then the Drilldown configuration, the settings page would work as expected.

But if the user started from any Drilldown configuration page, without loading Logs Drilldown first, then the feature flags were never initialized, showing incorrect states in the UI.

Addresses several escalations and questions.