### PR TITLE
fix(Feature Flags): remove logsPanelControls

### DIFF
--- a/src/featureFlags/openFeature.test.ts
+++ b/src/featureFlags/openFeature.test.ts
@@ -13,7 +13,6 @@ jest.mock('@grafana/runtime', () => ({
       exploreLogsAggregatedMetrics: false,
       exploreLogsShardSplitting: false,
       kubernetesLogsDrilldown: false,
-      logsPanelControls: false,
       otelLogsFormatting: false,
       queryLibrary: false,
     },

--- a/src/featureFlags/openFeature.ts
+++ b/src/featureFlags/openFeature.ts
@@ -99,12 +99,6 @@ const goffFeatureFlags = {
     reason: 'static provider evaluation result',
     variant: 'default',
   },
-  logsPanelControls: {
-    valueType: 'boolean',
-    value: false,
-    reason: 'static provider evaluation result',
-    variant: 'default',
-  },
   otelLogsFormatting: {
     valueType: 'boolean',
     value: false,
@@ -283,9 +277,6 @@ function getFlagDefaultValue(flagDef: FeatureFlag): boolean | number | string | 
 function getConfigToggleFallback(flagName: string): boolean | undefined {
   if (flagName === 'kubernetesLogsDrilldown') {
     return config.featureToggles.kubernetesLogsDrilldown;
-  }
-  if (flagName === 'logsPanelControls') {
-    return config.featureToggles.logsPanelControls;
   }
   if (flagName === 'otelLogsFormatting') {
     return config.featureToggles.otelLogsFormatting;

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -27,7 +27,6 @@ import { HideSeriesConfig } from '@grafana/schema';
 import { DrawStyle, StackingMode } from '@grafana/ui';
 
 import { LOGS_COUNT_QUERY_REFID, LOGS_PANEL_QUERY_REFID } from '../Components/ServiceScene/ServiceScene';
-import { getFeatureFlag } from '../featureFlags/openFeature';
 import { WRAPPED_LOKI_DS_UID } from './datasource';
 import { getParserForField } from './fields';
 import { getLabelsFromSeries, getVisibleFields, getVisibleLabels, getVisibleMetadata } from './labels';

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -362,5 +362,4 @@ export function setPanelNotices(result: SceneDataProviderResult, panel: VizPanel
 }
 
 export const logsControlsSupported = () =>
-  getFeatureFlag('logsPanelControls') &&
-  (config.buildInfo.version > '12.1' || config.buildInfo.version.includes('12.1'));
+  config.buildInfo.version > '12.1' || config.buildInfo.version.includes('12.1');


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/117687

Since we're still compatible with 11.6, we'll continue using the version check, without looking at the feature toggle state.