### PR TITLE
chore(deps): upgrade to combobox, silence warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
 
       # Same settings as publish
       run-playwright: ${{ github.event_name == 'pull_request' }} # Run playwright tests for PRs only
-      run-playwright-with-grafana-dependency: '>=11.6 <13.0.0 || >13.0.0'
+      # Run playwright tests for Grafana versions 11.6.11 to 13.0.0 and 13.0.1 and later
+      # TODO: remove skipping 13.0.0 once it runs again in ci
+      run-playwright-with-grafana-dependency: '>=11.6 <13.0.0 || >13.0.1'
       upload-playwright-artifacts: true
       playwright-docker-compose-file: docker-compose.dev.yaml
       playwright-grafana-url: http://localhost:3001/grafana

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
 
       # Same settings as publish
       run-playwright: ${{ github.event_name == 'pull_request' }} # Run playwright tests for PRs only
-      # Run playwright tests for Grafana versions 11.6.11 to 13.0.0 and 13.0.1 and later
-      # TODO: remove skipping 13.0.0 once it runs again in ci
-      run-playwright-with-grafana-dependency: '>=11.6 <13.0.0 || >13.0.1'
+      run-playwright-with-grafana-dependency: '>=11.6 <13.0.0 || >13.0.0'
       upload-playwright-artifacts: true
       playwright-docker-compose-file: docker-compose.dev.yaml
       playwright-grafana-url: http://localhost:3001/grafana

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@ Refer to `.config/AGENTS/instructions.md` for Grafana plugin–specific rules. N
 
 - **Frontend security** — Follow workspace rules for HTML sanitization (DOMPurify), URLs (`textUtil.sanitizeUrl`), and avoiding unsafe DOM APIs.
 
+### TypeScript and DOM events
+
+- **No `unknown` double-casts for events** — Do not recover legacy fields with `(e as unknown as { srcElement?: … }).srcElement`. Prefer `event.currentTarget`, typed handlers, `instanceof` checks, or a small well-named helper with a real type guard.
+- **No non-null assertions (`!`) to silence indexing** — Do not use `arr[arr.length - 1]!.value` or similar. After checking length, bind the last element to a variable (`const last = options[options.length - 1]`) and narrow with an explicit guard (`if (last == null) return;`) so TypeScript and readers see the same contract.
+- **Avoid redundant or contradictory guards** — Do not repeat the same emptiness check or stack unrelated conditions in one `if` (e.g. `options.length === 0` twice, or mixing length checks with a redundant `=== undefined` on the same path). Prefer one early return and a single, clear invariant for “last option exists.”
+
 ### Grafana Scenes
 
 Logs Drilldown uses [@grafana/scenes](https://grafana.com/developers/scenes/) for app structure, routing, and interactive UI. When working on scenes-related code, follow the [Grafana Scenes documentation](https://grafana.com/developers/scenes/) and [demos](https://github.com/grafana/scenes/tree/main/packages/scenes-app/src/demos)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,11 @@ Logs Drilldown uses [@grafana/scenes](https://grafana.com/developers/scenes/) fo
 - **Data and time range** — Use `$data` (e.g. `SceneQueryRunner`) and `$timeRange` (e.g. `SceneTimeRange`) on scene objects. These propagate to descendants in the object tree.
 
 - **Layout** — Use `SceneFlexLayout`, `SceneFlexItem`, `EmbeddedScene`, and `SceneAppPage` for structure. For app pages, use `SceneAppPage` for drill-downs, tabs, breadcrumbs, and routing.
+
+### Playwright E2E
+
+- **Centralize selectors** — Define stable `data-testid` values in **`src/services/testIds.ts`** (nested object grouped by feature area). Do not scatter raw `'data-testid …'` strings across components or tests.
+- **Wire in components** — For any **new** interactive control that E2E tests need to target (primary buttons, tabs, comboboxes, filters, drilldown affordances), add `data-testid={testIds…}` on the focusable control or its root (follow existing patterns in the repo; Grafana `@grafana/ui` components usually accept `data-testid` on inputs and comboboxes).
+- **Write tests against `testIds`** — In Playwright specs, use `page.getByTestId(testIds.some.path)` (or the project’s equivalent) instead of brittle locators such as concatenated visible text (`FieldAll`), placeholder-only queries, or `getByText` for strings that depend on layout or i18n.
+- **When to add IDs** — Add or extend `testIds` when you introduce new UI that should be covered by E2E, or when a test would otherwise rely on implementation details of `@grafana/ui` (e.g. tooltip vs dialog, label + value split across nodes).
+- **Naming** — Keep the same string style as existing entries (e.g. `'data-testid search-fields'`). Prefer descriptive, stable slugs over feature-coupled names that will churn on every copy change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Logs Drilldown uses [@grafana/scenes](https://grafana.com/developers/scenes/) fo
 ### Playwright E2E
 
 - **Centralize selectors** — Define stable `data-testid` values in **`src/services/testIds.ts`** (nested object grouped by feature area). Do not scatter raw `'data-testid …'` strings across components or tests.
-- **Wire in components** — For any **new** interactive control that E2E tests need to target (primary buttons, tabs, comboboxes, filters, drilldown affordances), add `data-testid={testIds…}` on the focusable control or its root (follow existing patterns in the repo; Grafana `@grafana/ui` components usually accept `data-testid` on inputs and comboboxes).
+- **Wire in components** — For any **new** interactive control that E2E tests need to target (primary buttons, tabs, comboboxes, filters), add `data-testid={testIds…}` on the focusable control or its root (follow existing patterns in the repo; Grafana `@grafana/ui` components usually accept `data-testid` on inputs and comboboxes).
 - **Write tests against `testIds`** — In Playwright specs, use `page.getByTestId(testIds.some.path)` (or the project’s equivalent) instead of brittle locators such as concatenated visible text (`FieldAll`), placeholder-only queries, or `getByText` for strings that depend on layout or i18n.
 - **When to add IDs** — Add or extend `testIds` when you introduce new UI that should be covered by E2E, or when a test would otherwise rely on implementation details of `@grafana/ui` (e.g. tooltip vs dialog, label + value split across nodes).
 - **Naming** — Keep the same string style as existing entries (e.g. `'data-testid search-fields'`). Prefer descriptive, stable slugs over feature-coupled names that will churn on every copy change.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,6 @@ import importPlugin from 'eslint-plugin-import';
 import jsxa11y from 'eslint-plugin-jsx-a11y';
 import sortPlugin from 'eslint-plugin-sort';
 
-// eslint-disable-next-line import/no-unresolved -- package.json exports field not recognized by import plugin
 import grafanaI18nPlugin from '@grafana/i18n/eslint-plugin';
 
 import baseConfig from './.config/eslint.config.mjs';

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,7 +1,9 @@
 // Jest setup provided by Grafana scaffolding
 import { TextDecoder, TextEncoder } from 'util';
 
+// After .config/jest-setup (which stubs HTMLCanvasElement.getContext) so Combobox measureText works in tests
 import './.config/jest-setup';
+import 'jest-canvas-mock';
 
 import { toEmitValuesWith } from './tests/matchers';
 

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,6 @@ const PRETTIER_WRITE = 'prettier --write --ignore-path .prettierignore';
 module.exports = {
   'src/**/*.{js,jsx,ts,tsx}': 'yarn lint',
   '**/*': ['eslint --fix', 'bash -c tsc-files --noEmit', PRETTIER_WRITE],
-  // Matches staged files with these extensions except under tests/ (cspell ignores tests/; checking them exits 1 with 0 files).
   '!(tests/**/*).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
     'cspell -c cspell.config.json --no-progress --no-summary',
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,6 +3,6 @@ const PRETTIER_WRITE = 'prettier --write --ignore-path .prettierignore';
 module.exports = {
   'src/**/*.{js,jsx,ts,tsx}': 'yarn lint',
   '**/*': ['eslint --fix', 'bash -c tsc-files --noEmit', PRETTIER_WRITE],
-  '!(tests/**/*).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
+  '!(tests/**/*|src/locales/**/*).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
     'cspell -c cspell.config.json --no-progress --no-summary',
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,4 +3,10 @@ const PRETTIER_WRITE = 'prettier --write --ignore-path .prettierignore';
 module.exports = {
   'src/**/*.{js,jsx,ts,tsx}': 'yarn lint',
   '**/*': ['eslint --fix', 'bash -c tsc-files --noEmit', PRETTIER_WRITE],
+  '*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}': (filenames) => {
+    if (filenames.length === 0) {
+      return [];
+    }
+    return `cspell -c cspell.config.json --no-progress --no-summary ${filenames.join(' ')}`;
+  },
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,10 +3,7 @@ const PRETTIER_WRITE = 'prettier --write --ignore-path .prettierignore';
 module.exports = {
   'src/**/*.{js,jsx,ts,tsx}': 'yarn lint',
   '**/*': ['eslint --fix', 'bash -c tsc-files --noEmit', PRETTIER_WRITE],
-  '*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}': (filenames) => {
-    if (filenames.length === 0) {
-      return [];
-    }
-    return `cspell -c cspell.config.json --no-progress --no-summary ${filenames.join(' ')}`;
-  },
+  // Matches staged files with these extensions except under tests/ (cspell ignores tests/; checking them exits 1 with 0 files).
+  '!(tests/**/*).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
+    'cspell -c cspell.config.json --no-progress --no-summary',
 };

--- a/src/Components/AppConfig/DefaultColumns/Columns.tsx
+++ b/src/Components/AppConfig/DefaultColumns/Columns.tsx
@@ -66,8 +66,14 @@ export function Columns({ recordIndex, containerDragging }: Props) {
                 className={cx(styles.column, snapshot.isDropAnimating ? styles['column--drop-animating'] : undefined)}
               >
                 <Icon
-                  aria-label={t('components.app-config.default-columns.columns.aria-label-drag-and-drop-icon', 'Drag and drop icon')}
-                  title={t('components.app-config.default-columns.columns.title-drag-and-drop-to-reorder', 'Drag and drop to reorder')}
+                  aria-label={t(
+                    'components.app-config.default-columns.columns.aria-label-drag-and-drop-icon',
+                    'Drag and drop icon'
+                  )}
+                  title={t(
+                    'components.app-config.default-columns.columns.title-drag-and-drop-to-reorder',
+                    'Drag and drop to reorder'
+                  )}
                   name="draggabledots"
                   size="lg"
                   className={styles.column__dragIcon}
@@ -78,10 +84,12 @@ export function Columns({ recordIndex, containerDragging }: Props) {
                     value: column,
                     label: getNormalizedFieldName(column),
                   }}
-                  placeholder={t('components.app-config.default-columns.columns.placeholder-select-column', 'Select column')}
+                  placeholder={t(
+                    'components.app-config.default-columns.columns.placeholder-select-column',
+                    'Select column'
+                  )}
                   width={'auto'}
                   minWidth={30}
-                  isClearable={false}
                   onChange={(column) => onSelectColumn(column?.value, colIdx)}
                   createCustomValue={true}
                   options={(typeAhead) =>
@@ -91,9 +99,13 @@ export function Columns({ recordIndex, containerDragging }: Props) {
                 {columns.length > 1 && (
                   <IconButton
                     variant={'destructive'}
-                    tooltip={t('components.app-config.default-columns.columns.tooltip-remove-column', 'Remove {{column}}', {
-                      column: getNormalizedFieldName(column),
-                    })}
+                    tooltip={t(
+                      'components.app-config.default-columns.columns.tooltip-remove-column',
+                      'Remove {{column}}',
+                      {
+                        column: getNormalizedFieldName(column),
+                      }
+                    )}
                     name="trash-alt"
                     size={'lg'}
                     className={styles.column__removeIcon}

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -165,7 +165,6 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
           options={model.getTagValues}
           createCustomValue={true}
           loading={isLoading}
-          isClearable={true}
           value={options?.filter((v) => v.selected).map((v) => String(v.value))}
           width="auto"
           minWidth={20}

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -161,7 +161,6 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
           prefixIcon="filter"
           placeholder={t('components.index-scene.levels-variable-scene.placeholder-all-levels', 'All levels')}
           onChange={model.onChangeOptions}
-          onBlur={() => model.onCloseMenu()}
           options={model.getTagValues}
           createCustomValue={true}
           loading={isLoading}

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -24,14 +24,13 @@ import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
 type ChipOption = MetricFindValue & { selected?: boolean };
 export interface LevelsVariableSceneState extends SceneObjectState {
   isLoading: boolean;
-  isOpen: boolean;
   options?: ChipOption[];
   visible: boolean;
 }
 export const LEVELS_VARIABLE_SCENE_KEY = 'levels-var-custom-renderer';
 export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneState> {
   constructor(state: Partial<LevelsVariableSceneState>) {
-    super({ ...state, isLoading: false, isOpen: false, key: LEVELS_VARIABLE_SCENE_KEY, visible: false });
+    super({ ...state, isLoading: false, key: LEVELS_VARIABLE_SCENE_KEY, visible: false });
 
     this.addActivationHandler(this.onActivate.bind(this));
   }
@@ -57,38 +56,39 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
     });
   }
 
-  getTagValues = async (typeAhead: string) => {
+  getTagValues = async (typeAhead: string): Promise<Array<ComboboxOption<string>>> => {
     this.setState({ isLoading: true });
     const levelsVar = getLevelsVariable(this);
     const levelsKeys = levelsVar?.state?.getTagValuesProvider?.(
       levelsVar,
       levelsVar.state.filters[0] ?? { key: LEVEL_VARIABLE_VALUE }
     );
-    const response = await levelsKeys;
-    if (!response || !Array.isArray(response.values)) {
-      this.setState({ isLoading: false });
-      return [];
-    }
 
-    const newOptions = response.values.map((value) => {
-      return {
+    try {
+      const response = await levelsKeys;
+      if (!response || !Array.isArray(response.values)) {
+        return [];
+      }
+
+      const newOptions = response.values.map((value) => ({
         selected: levelsVar.state.filters.some((filter) => filter.value === value.text),
         text: value.text,
         value: value.value ?? value.text,
-      };
-    });
-    const existingSelectedOptions = this.state.options?.filter(
-      (existingOption) =>
-        existingOption.selected && !newOptions.some((newOption) => newOption.value === existingOption.value)
-    );
-    const options = existingSelectedOptions ? [...newOptions, ...existingSelectedOptions] : [...newOptions];
-    this.setState({
-      isLoading: false,
-      options,
-    });
-    return options
-      .map((option) => ({ label: option.text, value: String(option.value ?? option.text) }))
-      .filter((option) => option.label?.includes(typeAhead));
+      }));
+      const existingSelectedOptions = this.state.options?.filter(
+        (existingOption) =>
+          existingOption.selected && !newOptions.some((newOption) => newOption.value === existingOption.value)
+      );
+      const options = existingSelectedOptions ? [...newOptions, ...existingSelectedOptions] : [...newOptions];
+      this.setState({ options });
+      return options
+        .map((option) => ({ label: option.text, value: String(option.value ?? option.text) }))
+        .filter((option) => option.label?.includes(typeAhead));
+    } catch (err) {
+      return [];
+    } finally {
+      this.setState({ isLoading: false });
+    }
   };
 
   updateFilters = (skipPublish: boolean, forcePublish?: boolean) => {
@@ -127,19 +127,12 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
       }),
     });
 
-    if (!this.state.isOpen) {
-      this.updateFilters(false);
-    } else {
-      this.updateFilters(true);
-    }
-  };
-
-  openSelect = (isOpen: boolean) => {
-    this.setState({ isOpen });
+    // Updates filters on selection not on dropdown close
+    // Combobox does not provide a way to know if the menu is open or closed
+    this.updateFilters(false);
   };
 
   onCloseMenu = () => {
-    this.openSelect(false);
     // Update filters and run queries on close
     this.updateFilters(false, true);
   };

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { MetricFindValue, SelectableValue } from '@grafana/data';
+import { MetricFindValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   ControlsLabel,
@@ -13,7 +13,7 @@ import {
   SceneObjectState,
   SceneVariableValueChangedEvent,
 } from '@grafana/scenes';
-import { Icon, MultiSelect, useStyles2 } from '@grafana/ui';
+import { ComboboxOption, MultiCombobox, useStyles2 } from '@grafana/ui';
 
 import { FilterOp } from '../../services/filterTypes';
 import { addCurrentUrlToHistory } from '../../services/navigate';
@@ -57,33 +57,38 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
     });
   }
 
-  getTagValues = () => {
+  getTagValues = async (typeAhead: string) => {
     this.setState({ isLoading: true });
     const levelsVar = getLevelsVariable(this);
     const levelsKeys = levelsVar?.state?.getTagValuesProvider?.(
       levelsVar,
       levelsVar.state.filters[0] ?? { key: LEVEL_VARIABLE_VALUE }
     );
-    levelsKeys?.then((response) => {
-      if (Array.isArray(response.values)) {
-        const newOptions = response.values.map((value) => {
-          return {
-            selected: levelsVar.state.filters.some((filter) => filter.value === value.text),
-            text: value.text,
-            value: value.value ?? value.text,
-          };
-        });
-        const existingSelectedOptions = this.state.options?.filter(
-          (existingOption) =>
-            existingOption.selected && !newOptions.some((newOption) => newOption.value === existingOption.value)
-        );
-        const options = existingSelectedOptions ? [...newOptions, ...existingSelectedOptions] : [...newOptions];
-        this.setState({
-          isLoading: false,
-          options,
-        });
-      }
+    const response = await levelsKeys;
+    if (!response || !Array.isArray(response.values)) {
+      this.setState({ isLoading: false });
+      return [];
+    }
+
+    const newOptions = response.values.map((value) => {
+      return {
+        selected: levelsVar.state.filters.some((filter) => filter.value === value.text),
+        text: value.text,
+        value: value.value ?? value.text,
+      };
     });
+    const existingSelectedOptions = this.state.options?.filter(
+      (existingOption) =>
+        existingOption.selected && !newOptions.some((newOption) => newOption.value === existingOption.value)
+    );
+    const options = existingSelectedOptions ? [...newOptions, ...existingSelectedOptions] : [...newOptions];
+    this.setState({
+      isLoading: false,
+      options,
+    });
+    return options
+      .map((option) => ({ label: option.text, value: String(option.value ?? option.text) }))
+      .filter((option) => option.label?.includes(typeAhead));
   };
 
   updateFilters = (skipPublish: boolean, forcePublish?: boolean) => {
@@ -100,13 +105,22 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
     );
   };
 
-  onChangeOptions = (options: SelectableValue[]) => {
+  onChangeOptions = (options: Array<ComboboxOption<string>>) => {
     // Save current url to history before the filter change
     addCurrentUrlToHistory();
+    const selectedValues = new Set(options.map((option) => option.value));
+    const optionValues = new Set((this.state.options ?? []).map((option) => String(option.value)));
+    const customOptions = options
+      .filter((option) => !optionValues.has(option.value))
+      .map((option) => ({
+        selected: true,
+        text: option.label ?? option.value,
+        value: option.value,
+      }));
 
     this.setState({
-      options: this.state.options?.map((value) => {
-        if (options.some((opt) => opt.value === value.value)) {
+      options: [...(this.state.options ?? []), ...customOptions].map((value) => {
+        if (selectedValues.has(String(value.value))) {
           return { ...value, selected: true };
         }
         return { ...value, selected: false };
@@ -131,7 +145,7 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
   };
 
   static Component = ({ model }: SceneComponentProps<LevelsVariableScene>) => {
-    const { isLoading, isOpen, options, visible } = model.useState();
+    const { isLoading, options, visible } = model.useState();
     const styles = useStyles2(getStyles);
     const levelsVar = getLevelsVariable(model);
     levelsVar.useState();
@@ -142,42 +156,29 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
 
     return (
       <div data-testid={testIds.variables.levels.inputWrap} className={styles.wrapper}>
-        <ControlsLabel layout="vertical" label={t('components.index-scene.levels-variable-scene.label-log-levels', 'Log levels')} />
-        <MultiSelect
-          aria-label={t('components.index-scene.levels-variable-scene.aria-label-log-level-filters', 'Log level filters')}
-          prefix={<Icon size={'lg'} name={'filter'} />}
+        <ControlsLabel
+          layout="vertical"
+          label={t('components.index-scene.levels-variable-scene.label-log-levels', 'Log levels')}
+        />
+        <MultiCombobox<string>
+          aria-label={t(
+            'components.index-scene.levels-variable-scene.aria-label-log-level-filters',
+            'Log level filters'
+          )}
+          prefixIcon="filter"
           placeholder={t('components.index-scene.levels-variable-scene.placeholder-all-levels', 'All levels')}
-          className={styles.control}
           onChange={model.onChangeOptions}
-          onCloseMenu={() => model.onCloseMenu()}
-          onOpenMenu={model.getTagValues}
-          onFocus={() => model.openSelect(true)}
-          menuShouldPortal={true}
-          allowCustomValue={true}
-          onCreateOption={model.onCreateCustomOption}
-          isOpen={isOpen}
-          isLoading={isLoading}
+          onBlur={() => model.onCloseMenu()}
+          options={model.getTagValues}
+          createCustomValue={true}
+          loading={isLoading}
           isClearable={true}
-          blurInputOnSelect={false}
-          closeMenuOnSelect={false}
-          openMenuOnFocus={true}
-          showAllSelectedWhenOpen={true}
-          hideSelectedOptions={false}
-          value={options?.filter((v) => v.selected)}
-          options={options?.map((val) => ({
-            label: val.text,
-            value: val.value,
-          }))}
+          value={options?.filter((v) => v.selected).map((v) => String(v.value))}
+          width="auto"
+          minWidth={20}
         />
       </div>
     );
-  };
-
-  private onCreateCustomOption = (value: string) => {
-    const newOption: ChipOption = { selected: true, text: value, value };
-    this.setState({
-      options: this.state.options ? [...this.state.options, newOption] : [newOption],
-    });
   };
 }
 export function syncLevelsVariable(sceneRef: SceneObject) {
@@ -188,9 +189,6 @@ export function syncLevelsVariable(sceneRef: SceneObject) {
 }
 
 const getStyles = () => ({
-  control: css({
-    flex: '1',
-  }),
   wrapper: css({
     flex: '0 0 auto',
     whiteSpace: 'nowrap',

--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -72,7 +72,12 @@ export function ServiceFieldSelector({
       : selectableOptions;
   const selectableValueSet = new Set(selectableOptions.map((option) => option.value));
 
-  const applyServiceSelection = (selected: ComboboxOption<string>) => {
+  const applyServiceSelection = (selected: ComboboxOption<string> | null) => {
+    if (selected == null || selected.value === '') {
+      setCustomOption(initialFilter);
+      onChange('');
+      return;
+    }
     if (!selectableValueSet.has(selected.value)) {
       setCustomOption({ label: selected.label ?? selected.value, value: selected.value, icon: 'filter' });
       return onChange(wrapWildcardSearch(selected.value));
@@ -93,6 +98,7 @@ export function ServiceFieldSelector({
           'Filter values by'
         )}
         value={value}
+        isClearable={true}
         onChange={applyServiceSelection}
         prefixIcon="search"
       />

--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { VariableValueOption } from '@grafana/scenes';
-import { ActionMeta, Icon, InlineField, InputActionMeta, Select, useStyles2 } from '@grafana/ui';
+import { Combobox, ComboboxOption, InlineField, useStyles2 } from '@grafana/ui';
 
 import { wrapWildcardSearch } from '../../../services/query';
 import { testIds } from '../../../services/testIds';
@@ -23,25 +23,26 @@ export type AsyncFieldSelectorProps = {
   selectOption: (value: string) => void;
 } & Props<string>;
 
-export function FieldSelector<T>({ label, onChange, options, value }: Props<T>) {
+export function FieldSelector<T extends string | number>({ label, onChange, options, value }: Props<T>) {
   const styles = useStyles2(getStyles);
-  const [selected, setSelected] = useState(false);
 
-  const selectableOptions: SelectableValue[] = options.map((option) => {
+  const selectableOptions: Array<ComboboxOption<T>> = options.map((option) => {
     return {
       label: option.label,
-      value: option.value,
+      value: option.value as T,
     };
   });
+
   return (
     <InlineField className={styles.selectWrapper} label={label}>
-      <Select
-        {...{ options: selectableOptions, value }}
-        onOpenMenu={() => setSelected(true)}
-        onCloseMenu={() => setSelected(false)}
-        onChange={(selected: SelectableValue<T>) => onChange(selected.value)}
-        className={styles.select}
-        prefix={selected ? undefined : <Icon name={'search'} />}
+      <Combobox<T>
+        options={selectableOptions}
+        value={value}
+        onChange={(selected) => onChange(selected?.value)}
+        prefixIcon="search"
+        isClearable
+        width="auto"
+        minWidth={20}
       />
     </InlineField>
   );
@@ -57,71 +58,42 @@ export function ServiceFieldSelector({
   value,
 }: AsyncFieldSelectorProps) {
   const styles = useStyles2(getStyles);
-  const [selected, setSelected] = useState(false);
   const [customOption, setCustomOption] = useState<SelectableValue<string>>(initialFilter);
 
-  const selectableOptions: SelectableValue[] = options.map((option) => {
+  const selectableOptions: Array<ComboboxOption<string>> = options.map((option) => {
     return {
       label: option.label,
-      value: option.value,
+      value: String(option.value),
     };
   });
   const allOptions =
     customOption && value && customOption.value?.includes(value)
-      ? [customOption, ...selectableOptions]
+      ? [{ label: customOption.label, value: String(customOption.value) }, ...selectableOptions]
       : selectableOptions;
-
-  const selectedOption = allOptions?.find((opt) => opt.value === value);
+  const selectableValueSet = new Set(selectableOptions.map((option) => option.value));
 
   return (
     <InlineField className={styles.serviceSceneSelectWrapper} label={label}>
-      <Select
-        isLoading={isLoading}
+      <Combobox<string>
+        loading={isLoading}
         data-testid={testIds.exploreServiceSearch.search}
         placeholder={t('components.service-scene.breakdowns.field-selector.placeholder-search-values', 'Search values')}
         options={allOptions}
-        isClearable={true}
+        createCustomValue
         value={value}
-        onOpenMenu={() => setSelected(true)}
-        onCloseMenu={() => setSelected(false)}
-        allowCustomValue={true}
-        prefix={selected || selectedOption?.__isNew__ ? undefined : <Icon name={'search'} />}
-        onChange={(value: SelectableValue<string>, actionMeta: ActionMeta) => {
-          // Custom added value
-          if (value?.__isNew__ || value?.icon) {
-            setCustomOption({ ...value, icon: 'filter' });
-            return onChange(value.value);
-          }
-
-          // If the user clears the search
-          if (actionMeta.action === 'clear') {
+        isClearable
+        prefixIcon="search"
+        onChange={(value) => {
+          if (!value?.value) {
             return onChange('');
           }
 
-          // Select the service is the value is not a custom filter
-          if (actionMeta.action === 'select-option' && value.value && !value.__isNew__) {
-            selectOption(value.value);
-          }
-        }}
-        onInputChange={(value: string | undefined, actionMeta: InputActionMeta) => {
-          // Grafana/grafana doesn't have types from react-select, but we need the prevInput to add custom value when user clicks off with active search string
-          const meta = actionMeta as InputActionMeta & { prevInputValue: string };
-
-          // The user is typing
-          if (meta.action === 'input-change') {
-            return onChange(value);
+          if (!selectableValueSet.has(value.value)) {
+            setCustomOption({ label: value.label ?? value.value, value: value.value, icon: 'filter' });
+            return onChange(wrapWildcardSearch(value.value));
           }
 
-          // the user closed the menu, with text in search box
-          if (meta.action === 'menu-close' && meta.prevInputValue) {
-            setCustomOption({
-              __isNew__: true,
-              icon: 'filter',
-              label: meta.prevInputValue,
-              value: wrapWildcardSearch(meta.prevInputValue),
-            });
-            return onChange(meta.prevInputValue);
-          }
+          selectOption(value.value);
         }}
       />
     </InlineField>

--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -7,8 +7,8 @@ import { t } from '@grafana/i18n';
 import { VariableValueOption } from '@grafana/scenes';
 import { Combobox, ComboboxOption, InlineField, useStyles2 } from '@grafana/ui';
 
-import { wrapWildcardSearch } from '../../../services/query';
-import { testIds } from '../../../services/testIds';
+import { wrapWildcardSearch } from 'services/query';
+import { testIds } from 'services/testIds';
 
 type Props<T> = {
   label: string;
@@ -43,6 +43,7 @@ export function FieldSelector<T extends string | number>({ label, onChange, opti
         isClearable
         width="auto"
         minWidth={20}
+        data-testid={testIds.breakdowns.labelFieldSearch}
       />
     </InlineField>
   );

--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -40,7 +40,6 @@ export function FieldSelector<T extends string | number>({ label, onChange, opti
         value={value}
         onChange={(selected) => onChange(selected?.value)}
         prefixIcon="search"
-        isClearable
         width="auto"
         minWidth={20}
         data-testid={testIds.breakdowns.labelFieldSearch}
@@ -73,6 +72,14 @@ export function ServiceFieldSelector({
       : selectableOptions;
   const selectableValueSet = new Set(selectableOptions.map((option) => option.value));
 
+  const applyServiceSelection = (selected: ComboboxOption<string>) => {
+    if (!selectableValueSet.has(selected.value)) {
+      setCustomOption({ label: selected.label ?? selected.value, value: selected.value, icon: 'filter' });
+      return onChange(wrapWildcardSearch(selected.value));
+    }
+    selectOption(selected.value);
+  };
+
   return (
     <InlineField className={styles.serviceSceneSelectWrapper} label={label}>
       <Combobox<string>
@@ -81,21 +88,13 @@ export function ServiceFieldSelector({
         placeholder={t('components.service-scene.breakdowns.field-selector.placeholder-search-values', 'Search values')}
         options={allOptions}
         createCustomValue
+        customValueDescription={t(
+          'components.service-scene.breakdowns.field-selector.custom-value-search-or-filter',
+          'Filter values by'
+        )}
         value={value}
-        isClearable
+        onChange={applyServiceSelection}
         prefixIcon="search"
-        onChange={(value) => {
-          if (!value?.value) {
-            return onChange('');
-          }
-
-          if (!selectableValueSet.has(value.value)) {
-            setCustomOption({ label: value.label ?? value.value, value: value.value, icon: 'filter' });
-            return onChange(wrapWildcardSearch(value.value));
-          }
-
-          selectOption(value.value);
-        }}
       />
     </InlineField>
   );

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -1,27 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import {
-  Button,
-  ClickOutsideWrapper,
-  Combobox,
-  ComboboxOption,
-  Field,
-  FieldSet,
-  Input,
-  Label,
-  Stack,
-  useStyles2,
-} from '@grafana/ui';
+import { Button, Combobox, ComboboxOption, Field, FieldSet, Input, Label, Stack, useStyles2 } from '@grafana/ui';
 
-import { FilterOp } from '../../../services/filterTypes';
-import { logger } from '../../../services/logger';
-import { testIds } from '../../../services/testIds';
-import { getAdHocFiltersVariable, getValueFromFieldsFilter } from '../../../services/variableGetters';
 import {
   addNumericFilter,
   InterpolatedFilterType,
@@ -29,6 +14,10 @@ import {
   validateVariableNameForField,
 } from './AddToFiltersButton';
 import { SelectLabelActionScene } from './SelectLabelActionScene';
+import { FilterOp } from 'services/filterTypes';
+import { logger } from 'services/logger';
+import { testIds } from 'services/testIds';
+import { getAdHocFiltersVariable, getValueFromFieldsFilter } from 'services/variableGetters';
 
 type ComparisonOperatorTypes = 'bytes' | 'duration' | 'float' | 'int';
 
@@ -119,6 +108,21 @@ interface ByteUnitTypes {
 
 interface ByteTypes extends ByteUnitTypes {
   fieldType: 'bytes';
+}
+
+/**
+ * Combobox option menus from @grafana/ui often portal to document.body / #grafana-portal-container.
+ * Those clicks are outside our card body for contains(), but must not close the numeric popover.
+ */
+function isEventTargetInsideGrafanaComboboxMenu(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return (
+    target.closest('[role="listbox"]') != null ||
+    target.closest('[role="option"]') != null ||
+    target.closest('[data-testid="combobox-option-group"]') != null
+  );
 }
 
 export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopoverSceneStateTotal> {
@@ -250,226 +254,243 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
 
     const selectLabelActionScene = sceneGraph.getAncestor(model, SelectLabelActionScene);
     const formDisabled = gt === undefined && lt === undefined;
-    // Combobox menus render in a Portal; mount them inside this node so ClickOutsideWrapper
-    // still contains the menu DOM and choosing an option does not close the popover.
+    // Combobox menus render in a Portal
     const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
+
+    // Close the parent popover on document clicks
+    useEffect(() => {
+      if (!comboboxMenuContainer) {
+        return;
+      }
+      const onDocumentClick = (event: MouseEvent) => {
+        if (!(event.target instanceof Node)) {
+          return;
+        }
+        // Skip close when the click is on Grafana Combobox
+        if (isEventTargetInsideGrafanaComboboxMenu(event.target)) {
+          return;
+        }
+        if (!comboboxMenuContainer.contains(event.target)) {
+          selectLabelActionScene.togglePopover();
+        }
+      };
+      document.addEventListener('click', onDocumentClick, false);
+      return () => document.removeEventListener('click', onDocumentClick, false);
+    }, [comboboxMenuContainer, selectLabelActionScene]);
+
     const comboboxPortalProps = { portalContainer: comboboxMenuContainer ?? undefined };
 
     return (
-      <ClickOutsideWrapper useCapture={true} onClick={() => selectLabelActionScene.togglePopover()}>
-        <Stack direction="column" gap={0} role="tooltip">
-          <div ref={setComboboxMenuContainer} className={popoverStyles.card.body}>
-            <div className={popoverStyles.card.title}>
-              {labelName} {subTitle}
-            </div>
-
-            <div className={popoverStyles.card.fieldWrap}>
-              {/* greater than */}
-              <FieldSet className={popoverStyles.card.fieldset}>
-                <Field
-                  data-testid={testIds.breakdowns.common.filterNumericPopover.inputGreaterThanInclusive}
-                  horizontal={true}
-                  className={cx(popoverStyles.card.field, popoverStyles.card.inclusiveField)}
-                >
-                  <Combobox<string>
-                    {...comboboxPortalProps}
-                    value={gte !== undefined ? gte.toString() : 'false'}
-                    options={[
-                      {
-                        label: t(
-                          'components.service-scene.breakdowns.numeric-filter-popover-scene.label.greater-than',
-                          'Greater than'
-                        ),
-                        value: 'false',
-                      },
-                      {
-                        label: t(
-                          'components.service-scene.breakdowns.numeric-filter-popover-scene.label.greater-than-or-equal',
-                          'Greater than or equal'
-                        ),
-                        value: 'true',
-                      },
-                    ]}
-                    onChange={(value) => model.setState({ gte: value.value === 'true' })}
-                    width="auto"
-                    minWidth={17}
-                  />
-                </Field>
-                <Field
-                  data-testid={testIds.breakdowns.common.filterNumericPopover.inputGreaterThan}
-                  horizontal={true}
-                  className={popoverStyles.card.field}
-                >
-                  <Input
-                    onKeyDownCapture={model.onInputKeydown}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus={true}
-                    onChange={(e) => {
-                      model.setState({
-                        gt: e.currentTarget.value !== '' ? Number(e.currentTarget.value) : undefined,
-                      });
-                    }}
-                    className={popoverStyles.card.numberInput}
-                    value={gt}
-                    type={'number'}
-                  />
-                </Field>
-                {fieldType !== 'float' && fieldType !== 'int' && (
-                  <Label>
-                    <Field
-                      data-testid={testIds.breakdowns.common.filterNumericPopover.inputGreaterThanUnit}
-                      horizontal={true}
-                      className={popoverStyles.card.field}
-                      label={
-                        <span className={popoverStyles.card.unitFieldLabel}>
-                          <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">
-                            Unit
-                          </Trans>
-                        </span>
-                      }
-                    >
-                      <Combobox<DisplayDurationUnits | DisplayByteUnits>
-                        {...comboboxPortalProps}
-                        onChange={(e) => {
-                          model.setState({
-                            gtu: e.value,
-                          });
-                        }}
-                        options={getUnitOptions(fieldType)}
-                        value={gtu}
-                        width="auto"
-                        minWidth={8}
-                      />
-                    </Field>
-                  </Label>
-                )}
-              </FieldSet>
-
-              {/* less than */}
-              <FieldSet className={popoverStyles.card.fieldset}>
-                <Field
-                  data-testid={testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive}
-                  horizontal={true}
-                  className={cx(popoverStyles.card.field, popoverStyles.card.inclusiveField)}
-                >
-                  <Combobox<string>
-                    {...comboboxPortalProps}
-                    value={lte !== undefined ? lte.toString() : 'false'}
-                    options={[
-                      {
-                        label: t(
-                          'components.service-scene.breakdowns.numeric-filter-popover-scene.label.less-than',
-                          'Less than'
-                        ),
-                        value: 'false',
-                      },
-                      {
-                        label: t(
-                          'components.service-scene.breakdowns.numeric-filter-popover-scene.label.less-than-or-equal',
-                          'Less than or equal'
-                        ),
-                        value: 'true',
-                      },
-                    ]}
-                    onChange={(value) => model.setState({ lte: value.value === 'true' })}
-                    width="auto"
-                    minWidth={17}
-                  />
-                </Field>
-                <Field
-                  data-testid={testIds.breakdowns.common.filterNumericPopover.inputLessThan}
-                  horizontal={true}
-                  className={popoverStyles.card.field}
-                >
-                  <Input
-                    onKeyDownCapture={model.onInputKeydown}
-                    onChange={(e) =>
-                      model.setState({ lt: e.currentTarget.value !== '' ? Number(e.currentTarget.value) : undefined })
-                    }
-                    className={popoverStyles.card.numberInput}
-                    value={lt}
-                    type={'number'}
-                  />
-                </Field>
-                {fieldType !== 'float' && fieldType !== 'int' && (
-                  <Label>
-                    <Field
-                      data-testid={testIds.breakdowns.common.filterNumericPopover.inputLessThanUnit}
-                      horizontal={true}
-                      className={popoverStyles.card.field}
-                      label={
-                        <span className={popoverStyles.card.unitFieldLabel}>
-                          <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">
-                            Unit
-                          </Trans>
-                        </span>
-                      }
-                    >
-                      <Combobox<DisplayDurationUnits | DisplayByteUnits>
-                        {...comboboxPortalProps}
-                        onChange={(e) => {
-                          model.setState({
-                            ltu: e.value,
-                          });
-                        }}
-                        options={getUnitOptions(fieldType)}
-                        value={ltu}
-                        width="auto"
-                        minWidth={8}
-                      />
-                    </Field>
-                  </Label>
-                )}
-              </FieldSet>
-            </div>
-
-            {/* buttons */}
-            <div className={popoverStyles.card.buttons}>
-              {hasExistingFilter && (
-                <Button
-                  data-testid={testIds.breakdowns.common.filterNumericPopover.removeButton}
-                  disabled={!hasExistingFilter}
-                  onClick={() => {
-                    model.setState({
-                      gt: undefined,
-                      lt: undefined,
-                    });
-                    model.onSubmit();
-                  }}
-                  size={'sm'}
-                  variant={'destructive'}
-                  fill={'outline'}
-                >
-                  <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.remove">
-                    Remove
-                  </Trans>
-                </Button>
-              )}
-              <Button
-                data-testid={testIds.breakdowns.common.filterNumericPopover.submitButton}
-                disabled={formDisabled}
-                onClick={() => model.onSubmit()}
-                size={'sm'}
-                variant={'primary'}
-                fill={'outline'}
-                type={'submit'}
-              >
-                <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.add">Add</Trans>
-              </Button>
-
-              <Button
-                data-testid={testIds.breakdowns.common.filterNumericPopover.cancelButton}
-                onClick={() => selectLabelActionScene.togglePopover()}
-                size={'sm'}
-                variant={'secondary'}
-                fill={'outline'}
-              >
-                <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.cancel">Cancel</Trans>
-              </Button>
-            </div>
+      <Stack direction="column" gap={0} role="tooltip">
+        <div ref={setComboboxMenuContainer} className={popoverStyles.card.body}>
+          <div className={popoverStyles.card.title}>
+            {labelName} {subTitle}
           </div>
-        </Stack>
-      </ClickOutsideWrapper>
+
+          <div className={popoverStyles.card.fieldWrap}>
+            {/* greater than */}
+            <FieldSet className={popoverStyles.card.fieldset}>
+              <Field
+                data-testid={testIds.breakdowns.common.filterNumericPopover.inputGreaterThanInclusive}
+                horizontal={true}
+                className={cx(popoverStyles.card.field, popoverStyles.card.inclusiveField)}
+              >
+                <Combobox<string>
+                  {...comboboxPortalProps}
+                  value={gte !== undefined ? gte.toString() : 'false'}
+                  options={[
+                    {
+                      label: t(
+                        'components.service-scene.breakdowns.numeric-filter-popover-scene.label.greater-than',
+                        'Greater than'
+                      ),
+                      value: 'false',
+                    },
+                    {
+                      label: t(
+                        'components.service-scene.breakdowns.numeric-filter-popover-scene.label.greater-than-or-equal',
+                        'Greater than or equal'
+                      ),
+                      value: 'true',
+                    },
+                  ]}
+                  onChange={(value) => model.setState({ gte: value.value === 'true' })}
+                  width="auto"
+                  minWidth={17}
+                />
+              </Field>
+              <Field
+                data-testid={testIds.breakdowns.common.filterNumericPopover.inputGreaterThan}
+                horizontal={true}
+                className={popoverStyles.card.field}
+              >
+                <Input
+                  onKeyDownCapture={model.onInputKeydown}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus={true}
+                  onChange={(e) => {
+                    model.setState({
+                      gt: e.currentTarget.value !== '' ? Number(e.currentTarget.value) : undefined,
+                    });
+                  }}
+                  className={popoverStyles.card.numberInput}
+                  value={gt}
+                  type={'number'}
+                />
+              </Field>
+              {fieldType !== 'float' && fieldType !== 'int' && (
+                <Label>
+                  <Field
+                    data-testid={testIds.breakdowns.common.filterNumericPopover.inputGreaterThanUnit}
+                    horizontal={true}
+                    className={popoverStyles.card.field}
+                    label={
+                      <span className={popoverStyles.card.unitFieldLabel}>
+                        <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">
+                          Unit
+                        </Trans>
+                      </span>
+                    }
+                  >
+                    <Combobox<DisplayDurationUnits | DisplayByteUnits>
+                      {...comboboxPortalProps}
+                      onChange={(e) => {
+                        model.setState({
+                          gtu: e.value,
+                        });
+                      }}
+                      options={getUnitOptions(fieldType)}
+                      value={gtu}
+                      width="auto"
+                      minWidth={8}
+                    />
+                  </Field>
+                </Label>
+              )}
+            </FieldSet>
+
+            {/* less than */}
+            <FieldSet className={popoverStyles.card.fieldset}>
+              <Field
+                data-testid={testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive}
+                horizontal={true}
+                className={cx(popoverStyles.card.field, popoverStyles.card.inclusiveField)}
+              >
+                <Combobox<string>
+                  {...comboboxPortalProps}
+                  value={lte !== undefined ? lte.toString() : 'false'}
+                  options={[
+                    {
+                      label: t(
+                        'components.service-scene.breakdowns.numeric-filter-popover-scene.label.less-than',
+                        'Less than'
+                      ),
+                      value: 'false',
+                    },
+                    {
+                      label: t(
+                        'components.service-scene.breakdowns.numeric-filter-popover-scene.label.less-than-or-equal',
+                        'Less than or equal'
+                      ),
+                      value: 'true',
+                    },
+                  ]}
+                  onChange={(value) => model.setState({ lte: value.value === 'true' })}
+                  width="auto"
+                  minWidth={17}
+                />
+              </Field>
+              <Field
+                data-testid={testIds.breakdowns.common.filterNumericPopover.inputLessThan}
+                horizontal={true}
+                className={popoverStyles.card.field}
+              >
+                <Input
+                  onKeyDownCapture={model.onInputKeydown}
+                  onChange={(e) =>
+                    model.setState({ lt: e.currentTarget.value !== '' ? Number(e.currentTarget.value) : undefined })
+                  }
+                  className={popoverStyles.card.numberInput}
+                  value={lt}
+                  type={'number'}
+                />
+              </Field>
+              {fieldType !== 'float' && fieldType !== 'int' && (
+                <Label>
+                  <Field
+                    data-testid={testIds.breakdowns.common.filterNumericPopover.inputLessThanUnit}
+                    horizontal={true}
+                    className={popoverStyles.card.field}
+                    label={
+                      <span className={popoverStyles.card.unitFieldLabel}>
+                        <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">
+                          Unit
+                        </Trans>
+                      </span>
+                    }
+                  >
+                    <Combobox<DisplayDurationUnits | DisplayByteUnits>
+                      {...comboboxPortalProps}
+                      onChange={(e) => {
+                        model.setState({
+                          ltu: e.value,
+                        });
+                      }}
+                      options={getUnitOptions(fieldType)}
+                      value={ltu}
+                      width="auto"
+                      minWidth={8}
+                    />
+                  </Field>
+                </Label>
+              )}
+            </FieldSet>
+          </div>
+
+          {/* buttons */}
+          <div className={popoverStyles.card.buttons}>
+            {hasExistingFilter && (
+              <Button
+                data-testid={testIds.breakdowns.common.filterNumericPopover.removeButton}
+                disabled={!hasExistingFilter}
+                onClick={() => {
+                  model.setState({
+                    gt: undefined,
+                    lt: undefined,
+                  });
+                  model.onSubmit();
+                }}
+                size={'sm'}
+                variant={'destructive'}
+                fill={'outline'}
+              >
+                <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.remove">Remove</Trans>
+              </Button>
+            )}
+            <Button
+              data-testid={testIds.breakdowns.common.filterNumericPopover.submitButton}
+              disabled={formDisabled}
+              onClick={() => model.onSubmit()}
+              size={'sm'}
+              variant={'primary'}
+              fill={'outline'}
+              type={'submit'}
+            >
+              <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.add">Add</Trans>
+            </Button>
+
+            <Button
+              data-testid={testIds.breakdowns.common.filterNumericPopover.cancelButton}
+              onClick={() => selectLabelActionScene.togglePopover()}
+              size={'sm'}
+              variant={'secondary'}
+              fill={'outline'}
+            >
+              <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.cancel">Cancel</Trans>
+            </Button>
+          </div>
+        </div>
+      </Stack>
     );
   };
 }

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -1,11 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { css, cx } from '@emotion/css';
 
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Button, ClickOutsideWrapper, Field, FieldSet, Input, Label, Select, Stack, useStyles2 } from '@grafana/ui';
+import {
+  Button,
+  ClickOutsideWrapper,
+  Combobox,
+  ComboboxOption,
+  Field,
+  FieldSet,
+  Input,
+  Label,
+  Stack,
+  useStyles2,
+} from '@grafana/ui';
 
 import { FilterOp } from '../../../services/filterTypes';
 import { logger } from '../../../services/logger';
@@ -239,11 +250,15 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
 
     const selectLabelActionScene = sceneGraph.getAncestor(model, SelectLabelActionScene);
     const formDisabled = gt === undefined && lt === undefined;
+    // Combobox menus render in a Portal; mount them inside this node so ClickOutsideWrapper
+    // still contains the menu DOM and choosing an option does not close the popover.
+    const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
+    const comboboxPortalProps = { portalContainer: comboboxMenuContainer ?? undefined };
 
     return (
       <ClickOutsideWrapper useCapture={true} onClick={() => selectLabelActionScene.togglePopover()}>
         <Stack direction="column" gap={0} role="tooltip">
-          <div className={popoverStyles.card.body}>
+          <div ref={setComboboxMenuContainer} className={popoverStyles.card.body}>
             <div className={popoverStyles.card.title}>
               {labelName} {subTitle}
             </div>
@@ -256,14 +271,15 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                   horizontal={true}
                   className={cx(popoverStyles.card.field, popoverStyles.card.inclusiveField)}
                 >
-                  <Select<string>
-                    className={popoverStyles.card.inclusiveInput}
-                    menuShouldPortal={false}
-                    menuPosition={'absolute'}
+                  <Combobox<string>
+                    {...comboboxPortalProps}
                     value={gte !== undefined ? gte.toString() : 'false'}
                     options={[
                       {
-                        label: t('components.service-scene.breakdowns.numeric-filter-popover-scene.label.greater-than', 'Greater than'),
+                        label: t(
+                          'components.service-scene.breakdowns.numeric-filter-popover-scene.label.greater-than',
+                          'Greater than'
+                        ),
                         value: 'false',
                       },
                       {
@@ -275,6 +291,8 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                       },
                     ]}
                     onChange={(value) => model.setState({ gte: value.value === 'true' })}
+                    width="auto"
+                    minWidth={17}
                   />
                 </Field>
                 <Field
@@ -304,21 +322,23 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                       className={popoverStyles.card.field}
                       label={
                         <span className={popoverStyles.card.unitFieldLabel}>
-                          <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">Unit</Trans>
+                          <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">
+                            Unit
+                          </Trans>
                         </span>
                       }
                     >
-                      <Select
+                      <Combobox<DisplayDurationUnits | DisplayByteUnits>
+                        {...comboboxPortalProps}
                         onChange={(e) => {
                           model.setState({
                             gtu: e.value,
                           });
                         }}
-                        menuShouldPortal={false}
-                        menuPosition={'absolute'}
                         options={getUnitOptions(fieldType)}
-                        className={popoverStyles.card.selectInput}
                         value={gtu}
+                        width="auto"
+                        minWidth={8}
                       />
                     </Field>
                   </Label>
@@ -332,14 +352,15 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                   horizontal={true}
                   className={cx(popoverStyles.card.field, popoverStyles.card.inclusiveField)}
                 >
-                  <Select<string>
-                    className={popoverStyles.card.inclusiveInput}
-                    menuShouldPortal={false}
-                    menuPosition={'absolute'}
+                  <Combobox<string>
+                    {...comboboxPortalProps}
                     value={lte !== undefined ? lte.toString() : 'false'}
                     options={[
                       {
-                        label: t('components.service-scene.breakdowns.numeric-filter-popover-scene.label.less-than', 'Less than'),
+                        label: t(
+                          'components.service-scene.breakdowns.numeric-filter-popover-scene.label.less-than',
+                          'Less than'
+                        ),
                         value: 'false',
                       },
                       {
@@ -351,6 +372,8 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                       },
                     ]}
                     onChange={(value) => model.setState({ lte: value.value === 'true' })}
+                    width="auto"
+                    minWidth={17}
                   />
                 </Field>
                 <Field
@@ -376,21 +399,23 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                       className={popoverStyles.card.field}
                       label={
                         <span className={popoverStyles.card.unitFieldLabel}>
-                          <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">Unit</Trans>
+                          <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.unit">
+                            Unit
+                          </Trans>
                         </span>
                       }
                     >
-                      <Select
+                      <Combobox<DisplayDurationUnits | DisplayByteUnits>
+                        {...comboboxPortalProps}
                         onChange={(e) => {
                           model.setState({
                             ltu: e.value,
                           });
                         }}
-                        menuShouldPortal={false}
-                        menuPosition={'absolute'}
                         options={getUnitOptions(fieldType)}
-                        className={popoverStyles.card.selectInput}
                         value={ltu}
+                        width="auto"
+                        minWidth={8}
                       />
                     </Field>
                   </Label>
@@ -415,7 +440,9 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
                   variant={'destructive'}
                   fill={'outline'}
                 >
-                  <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.remove">Remove</Trans>
+                  <Trans i18nKey="components.service-scene.breakdowns.numeric-filter-popover-scene.remove">
+                    Remove
+                  </Trans>
                 </Button>
               )}
               <Button
@@ -498,13 +525,12 @@ export function extractValueFromString(
 
 function getUnitOptions(
   fieldType: 'bytes' | 'duration'
-): Array<SelectableValue<DisplayDurationUnits | DisplayByteUnits>> {
+): Array<ComboboxOption<DisplayDurationUnits | DisplayByteUnits>> {
   if (fieldType === 'duration') {
     const keys = Object.keys(DisplayDurationUnits) as Array<keyof typeof DisplayDurationUnits>;
     return keys.map((key) => {
       return {
         label: key,
-        text: key,
         value: DisplayDurationUnits[key],
       };
     });
@@ -515,7 +541,6 @@ function getUnitOptions(
     return keys.map((key) => {
       return {
         label: key,
-        text: key,
         value: DisplayByteUnits[key],
       };
     });

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { render, screen, waitFor } from '@testing-library/react';
-import { select } from 'react-select-event';
+import { render, screen } from '@testing-library/react';
+
+import { ReducerID } from '@grafana/data';
 
 import { SortByScene, SortCriteriaChanged } from './SortByScene';
 import { DEFAULT_SORT_BY, setWasmSortInit } from 'services/sorting';
@@ -18,8 +19,8 @@ describe('SortByScene', () => {
   test('Shows changepoint as default when WASM init succeeded', () => {
     render(<scene.Component model={scene} />);
 
-    expect(screen.getByText('Most relevant')).toBeInTheDocument();
-    expect(screen.getByText('Desc')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Most relevant')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Desc')).toBeInTheDocument();
   });
 
   test('Hides changepoint and outliers when WASM init failed', () => {
@@ -27,10 +28,10 @@ describe('SortByScene', () => {
     scene = new SortByScene({ target: 'fields' });
     render(<scene.Component model={scene} />);
 
-    expect(screen.queryByText('Most relevant')).not.toBeInTheDocument();
-    expect(screen.queryByText('Outlying values')).not.toBeInTheDocument();
-    expect(screen.getByText('Widest spread')).toBeInTheDocument();
-    expect(screen.getByText('Desc')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Most relevant')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Outlying values')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Widest spread')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Desc')).toBeInTheDocument();
   });
 
   test('Retrieves stored sorting preferences', () => {
@@ -39,26 +40,22 @@ describe('SortByScene', () => {
     scene = new SortByScene({ target: 'fields' });
     render(<scene.Component model={scene} />);
 
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Asc')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Name')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Asc')).toBeInTheDocument();
   });
 
-  test('Reports sort-by criteria changes', async () => {
+  test('Reports sort-by criteria changes', () => {
     const eventSpy = jest.spyOn(scene, 'publishEvent');
 
-    render(<scene.Component model={scene} />);
-
-    await waitFor(() => select(screen.getByLabelText('Sort by'), 'Highest spike', { container: document.body }));
+    scene.onCriteriaChange({ label: 'Highest spike', value: ReducerID.max });
 
     expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('fields', 'max', 'desc'), true);
   });
 
-  test('Reports sort-direction criteria changes', async () => {
+  test('Reports sort-direction criteria changes', () => {
     const eventSpy = jest.spyOn(scene, 'publishEvent');
 
-    render(<scene.Component model={scene} />);
-
-    await waitFor(() => select(screen.getByLabelText('Sort direction'), 'Asc', { container: document.body }));
+    scene.onDirectionChange({ label: 'Asc', value: 'asc' });
 
     expect(eventSpy).toHaveBeenCalledWith(new SortCriteriaChanged('fields', DEFAULT_SORT_BY, 'asc'), true);
   });
@@ -69,7 +66,7 @@ describe('SortByScene', () => {
     scene = new SortByScene({ target: 'fields' });
     render(<scene.Component model={scene} />);
 
-    expect(screen.getByText('Widest spread')).toBeInTheDocument();
-    expect(screen.queryByText('Most relevant')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Widest spread')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Most relevant')).not.toBeInTheDocument();
   });
 });

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -168,6 +168,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
           )}
         >
           <Combobox<SortBy>
+            id="sort-by-criteria"
             data-testid={testIds.breakdowns.common.sortByFunction}
             value={sortByValue}
             width="auto"

--- a/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/SortByScene.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BusEventBase, DataFrame, FieldReducerInfo, fieldReducers, ReducerID, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { InlineField, Select } from '@grafana/ui';
+import { Combobox, InlineField } from '@grafana/ui';
 
 import { getLabelValueFromDataFrame } from 'services/levels';
 import {
@@ -65,7 +65,10 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
           value: ReducerID.stdDev,
         },
         {
-          description: t('components.service-scene.breakdowns.sort-by-scene.description.alphabetical-order', 'Alphabetical order'),
+          description: t(
+            'components.service-scene.breakdowns.sort-by-scene.description.alphabetical-order',
+            'Alphabetical order'
+          ),
           label: t('components.service-scene.breakdowns.sort-by-scene.label.name', 'Name'),
           value: 'alphabetical',
         },
@@ -142,12 +145,18 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
             (opt: SelectableValue<SortBy>) => opt.value !== DEFAULT_SORT_BY && opt.value !== SORT_BY_OUTLIERS
           ),
         }));
-    const group = defaultOptions.find((g) =>
-      g.options.find((option: SelectableValue<SortBy>) => option.value === sortBy)
+    const sortByOptions = defaultOptions.flatMap((group) =>
+      group.options
+        .filter(
+          (option: SelectableValue<SortBy>): option is SelectableValue<SortBy> & { value: SortBy } =>
+            option.value !== undefined
+        )
+        .map((option: SelectableValue<SortBy> & { value: SortBy }) => ({
+          ...option,
+          group: group.label || undefined,
+        }))
     );
-    const sortByValue: SelectableValue<SortBy> | undefined = group?.options.find(
-      (option: SelectableValue<SortBy>) => option.value === sortBy
-    );
+    const sortByValue = sortByOptions.find((option) => option.value === sortBy);
     return (
       <>
         <InlineField
@@ -158,22 +167,27 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
             'Calculate a derived quantity from the values in your time series and sort by this criteria. Defaults to standard deviation.'
           )}
         >
-          <Select
+          <Combobox<SortBy>
             data-testid={testIds.breakdowns.common.sortByFunction}
             value={sortByValue}
-            width={20}
-            isSearchable={true}
-            options={defaultOptions}
-            placeholder={t('components.service-scene.breakdowns.sort-by-scene.placeholder-choose-criteria', 'Choose criteria')}
+            width="auto"
+            minWidth={20}
+            options={sortByOptions}
+            placeholder={t(
+              'components.service-scene.breakdowns.sort-by-scene.placeholder-choose-criteria',
+              'Choose criteria'
+            )}
             onChange={model.onCriteriaChange}
-            inputId="sort-by-criteria"
           />
         </InlineField>
         <InlineField>
-          <Select
+          <Combobox<SortDirection>
             data-testid={testIds.breakdowns.common.sortByDirection}
             onChange={model.onDirectionChange}
-            aria-label={t('components.service-scene.breakdowns.sort-by-scene.aria-label-sort-direction', 'Sort direction')}
+            aria-label={t(
+              'components.service-scene.breakdowns.sort-by-scene.aria-label-sort-direction',
+              'Sort direction'
+            )}
             placeholder=""
             value={direction}
             options={[
@@ -186,7 +200,9 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
                 value: DEFAULT_SORT_DIRECTION,
               },
             ]}
-          ></Select>
+            width="auto"
+            minWidth={10}
+          />
         </InlineField>
       </>
     );

--- a/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
+++ b/src/Components/ServiceScene/LineFilter/LineFilterEditor.tsx
@@ -4,7 +4,7 @@ import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Button, Field, Select, useStyles2 } from '@grafana/ui';
+import { Button, Combobox, Field, useStyles2 } from '@grafana/ui';
 
 import { testIds } from '../../../services/testIds';
 import { LineFilterProps } from '../../IndexScene/LineFilterVariable';
@@ -54,22 +54,24 @@ export function LineFilterEditor({
   return (
     <div className={styles.wrapper}>
       {!onSubmitLineFilter && (
-        <Select
-          prefix={null}
-          className={styles.select}
-          value={exclusive ? 'exclusive' : 'inclusive'}
-          options={[
-            {
-              label: t('components.service-scene.line-filter.line-filter-editor.label.exclude', 'Exclude'),
-              value: 'exclusive',
-            },
-            {
-              label: t('components.service-scene.line-filter.line-filter-editor.label.include', 'Include'),
-              value: 'inclusive',
-            },
-          ]}
-          onChange={() => setExclusive(!exclusive)}
-        />
+        <div className={styles.operatorComboboxWrap}>
+          <Combobox<string>
+            value={exclusive ? 'exclusive' : 'inclusive'}
+            options={[
+              {
+                label: t('components.service-scene.line-filter.line-filter-editor.label.exclude', 'Exclude'),
+                value: 'exclusive',
+              },
+              {
+                label: t('components.service-scene.line-filter.line-filter-editor.label.include', 'Include'),
+                value: 'inclusive',
+              },
+            ]}
+            onChange={(option) => setExclusive(option.value === 'exclusive')}
+            width="auto"
+            minWidth={12}
+          />
+        </div>
       )}
       <Field className={styles.field}>
         <LineFilterInput
@@ -91,7 +93,10 @@ export function LineFilterEditor({
             </span>
           }
           prefix={null}
-          placeholder={t('components.service-scene.line-filter.line-filter-editor.placeholder-filter-logs-by-string', 'Filter logs by string')}
+          placeholder={t(
+            'components.service-scene.line-filter.line-filter-editor.placeholder-filter-logs-by-string',
+            'Filter logs by string'
+          )}
           onClear={onClearLineFilter}
           onKeyUp={(e) => {
             handleEnter(e, lineFilter);
@@ -132,6 +137,18 @@ export function LineFilterEditor({
 }
 
 const getStyles = (theme: GrafanaTheme2, type: 'editor' | 'variable') => ({
+  /** Join Include/Exclude combobox flush with line filter input (square right edge, like legacy Select). */
+  operatorComboboxWrap: css({
+    '& div[data-testid="input-wrapper"]': {
+      borderBottomRightRadius: 0,
+      borderTopRightRadius: 0,
+    },
+    '& div[data-testid="input-wrapper"] input': {
+      borderBottomRightRadius: 0,
+      borderRight: 'none',
+      borderTopRightRadius: 0,
+    },
+  }),
   buttonWrap: css({
     display: 'flex',
     justifyContent: 'center',

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -302,6 +302,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
   }
 
   handleLogsError(data: PanelData) {
+    /* eslint-disable-next-line @typescript-eslint/no-deprecated */
     const error = data.errors?.length ? data.errors[0] : data.error;
     const errorResponse = error?.message;
     if (errorResponse) {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
@@ -25,7 +25,10 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
       if (options.length === 0) {
         return;
       }
-      const maxPageSize = parseInt(options[options.length - 1]!.value, 10);
+      if (options.length === 0 || options[options.length - 1] === undefined) {
+        return;
+      }
+      const maxPageSize = parseInt(options[options.length - 1].value, 10);
       if (countPerPage > maxPageSize) {
         serviceSelectionScene.setState({ countPerPage: maxPageSize });
       }

--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
@@ -22,9 +22,12 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
     const { countPerPage } = serviceSelectionScene.useState();
     const options = getCountOptionsFromTotal(totalCount);
     useEffect(() => {
-      const lastOptionValue = options[options.length - 1]?.value ?? countPerPage.toString();
-      if (countPerPage.toString() > lastOptionValue) {
-        serviceSelectionScene.setState({ countPerPage: parseInt(lastOptionValue, 10) });
+      if (options.length === 0) {
+        return;
+      }
+      const maxPageSize = parseInt(options[options.length - 1]!.value, 10);
+      if (countPerPage > maxPageSize) {
+        serviceSelectionScene.setState({ countPerPage: maxPageSize });
       }
     }, [countPerPage, options, serviceSelectionScene]);
     const countSelect = (

--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
@@ -2,10 +2,10 @@ import React, { useEffect } from 'react';
 
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { IconButton, Pagination, Select, useStyles2 } from '@grafana/ui';
+import { Combobox, ComboboxOption, IconButton, Pagination, useStyles2 } from '@grafana/ui';
 
 import { setServiceSelectionPageCount } from '../../services/store';
 import { ServiceSelectionScene } from './ServiceSelectionScene';
@@ -27,34 +27,52 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
         serviceSelectionScene.setState({ countPerPage: parseInt(lastOptionValue, 10) });
       }
     }, [countPerPage, options, serviceSelectionScene]);
+    const countSelect = (
+      <span className={styles.countSelect}>
+        <Combobox<string>
+          onChange={(value) => {
+            const countValue = value?.value;
+            if (!countValue) {
+              return;
+            }
+            const nextCountPerPage = parseInt(countValue, 10);
+            serviceSelectionScene.setState({ countPerPage: nextCountPerPage, currentPage: 1 });
+            serviceSelectionScene.updateBody();
+            setServiceSelectionPageCount(nextCountPerPage);
+          }}
+          options={options}
+          value={countPerPage.toString()}
+          width="auto"
+          minWidth={4}
+        />
+      </span>
+    );
+
+    const infoButton = (
+      <IconButton
+        className={styles.icon}
+        aria-label={t(
+          'components.service-selection-scene.service-selection-pagination-scene.aria-label-count-info',
+          'Count info'
+        )}
+        name="info-circle"
+        tooltip={t(
+          'components.service-selection-scene.service-selection-pagination-scene.tooltip.count-info',
+          '{{totalCount}} labels have values for the selected time range. Total label count may differ',
+          { totalCount }
+        )}
+      />
+    );
+
     return (
       <span className={styles.searchPageCountWrap}>
         <span className={styles.searchFieldPlaceholderText}>
-          {t('components.service-selection-scene.service-selection-pagination-scene.showing', 'Showing')}{' '}
-          <Select
-            className={styles.select}
-            onChange={(value) => {
-              if (value.value) {
-                const countPerPage = parseInt(value.value, 10);
-                serviceSelectionScene.setState({ countPerPage, currentPage: 1 });
-                serviceSelectionScene.updateBody();
-                setServiceSelectionPageCount(countPerPage);
-              }
-            }}
-            options={options}
-            value={countPerPage.toString()}
-          />{' '}
-          {t('components.service-selection-scene.service-selection-pagination-scene.of-total', 'of {{totalCount}}', { totalCount })}{' '}
-          <IconButton
-            className={styles.icon}
-            aria-label={t('components.service-selection-scene.service-selection-pagination-scene.aria-label-count-info', 'Count info')}
-            name={'info-circle'}
-            tooltip={t(
-              'components.service-selection-scene.service-selection-pagination-scene.tooltip.count-info',
-              '{{totalCount}} labels have values for the selected time range. Total label count may differ',
-              { totalCount }
-            )}
-          />
+          {t('components.service-selection-scene.service-selection-pagination-scene.showing', 'Showing')}
+          {countSelect}
+          {t('components.service-selection-scene.service-selection-pagination-scene.of-total', ' of {{totalCount}}', {
+            totalCount,
+          })}
+          {infoButton}
         </span>
       </span>
     );
@@ -129,6 +147,12 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
 
 function getPageCountStyles(theme: GrafanaTheme2) {
   return {
+    countSelect: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(1),
+    }),
     icon: css({
       color: theme.colors.text.disabled,
       marginLeft: theme.spacing.x1,
@@ -145,11 +169,6 @@ function getPageCountStyles(theme: GrafanaTheme2) {
       alignItems: 'center',
       display: 'flex',
     }),
-    select: css({
-      marginLeft: theme.spacing(1),
-      marginRight: theme.spacing(1),
-      maxWidth: '65px',
-    }),
   };
 }
 
@@ -158,7 +177,7 @@ export function getCountOptionsFromTotal(totalCount: number) {
   const end = 60;
   const roundedTotalCount = Math.ceil(totalCount / delta) * delta;
 
-  const options: Array<SelectableValue<string>> = [];
+  const options: Array<ComboboxOption<string>> = [];
   for (let count = delta; count <= end && count <= roundedTotalCount; count += delta) {
     let label = count.toString();
     if (count < delta) {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { css } from '@emotion/css';
 
@@ -20,15 +20,16 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
     const styles = useStyles2(getPageCountStyles);
     const serviceSelectionScene = sceneGraph.getAncestor(model, ServiceSelectionScene);
     const { countPerPage } = serviceSelectionScene.useState();
-    const options = getCountOptionsFromTotal(totalCount);
+    const options = useMemo(() => getCountOptionsFromTotal(totalCount), [totalCount]);
     useEffect(() => {
       if (options.length === 0) {
         return;
       }
-      if (options.length === 0 || options[options.length - 1] === undefined) {
+      const lastOption = options[options.length - 1];
+      if (lastOption === undefined) {
         return;
       }
-      const maxPageSize = parseInt(options[options.length - 1].value, 10);
+      const maxPageSize = parseInt(lastOption.value, 10);
       if (countPerPage > maxPageSize) {
         serviceSelectionScene.setState({ countPerPage: maxPageSize });
       }

--- a/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionPaginationScene.tsx
@@ -72,7 +72,7 @@ export class ServiceSelectionPaginationScene extends SceneObjectBase<ServiceSele
         <span className={styles.searchFieldPlaceholderText}>
           {t('components.service-selection-scene.service-selection-pagination-scene.showing', 'Showing')}
           {countSelect}
-          {t('components.service-selection-scene.service-selection-pagination-scene.of-total', ' of {{totalCount}}', {
+          {t('components.service-selection-scene.service-selection-pagination-scene.of-total', 'of {{totalCount}}', {
             totalCount,
           })}
           {infoButton}

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -219,8 +219,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const selectedTab = model.getSelectedTab();
 
     const serviceStringVariable = getServiceSelectionSearchVariable(model);
-    const { label: searchLabel, value: searchValue } = serviceStringVariable.useState();
-    const hasSearch = Boolean(searchLabel?.length) || (Boolean(searchValue) && String(searchValue) !== '.+');
+    const { label: searchLabel } = serviceStringVariable.useState();
+    const hasSearch = Boolean(searchLabel?.length);
 
     const { labelsByVolume, labelsToQuery } = model.getLabels(data?.series);
     const isLogVolumeLoading =

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -11,7 +11,6 @@ import {
   GrafanaTheme2,
   LoadingState,
 } from '@grafana/data';
-import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -146,10 +145,10 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       }),
       $variables: new SceneVariableSet({
         variables: [
-          // Service search variable
+          // Service search variable — `label` is the draft search string for the combobox (must start empty).
           new CustomConstantVariable({
             hide: VariableHide.hideVariable,
-            label: t('components.service-selection-scene.label.service', 'Service'),
+            label: '',
             name: VAR_PRIMARY_LABEL_SEARCH,
             skipUrlSync: true,
             value: '.+',
@@ -220,8 +219,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const selectedTab = model.getSelectedTab();
 
     const serviceStringVariable = getServiceSelectionSearchVariable(model);
-    const { label, value: searchValue } = serviceStringVariable.useState();
-    const hasSearch = searchValue && searchValue !== '.+';
+    const { label: searchLabel, value: searchValue } = serviceStringVariable.useState();
+    const hasSearch = Boolean(searchLabel?.length) || (Boolean(searchValue) && String(searchValue) !== '.+');
 
     const { labelsByVolume, labelsToQuery } = model.getLabels(data?.series);
     const isLogVolumeLoading =
@@ -229,6 +228,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const volumeApiError = $data.state.data?.state === LoadingState.Error;
 
     const onSearchChange = (serviceName?: string) => {
+      // Keep label in sync on every keystroke so the controlled Combobox matches typing; debounced handler updates value/query.
+      getServiceSelectionSearchVariable(model).setState({ label: serviceName ?? '' });
       model.onSearchServicesChange(serviceName);
     };
 
@@ -259,7 +260,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
                   value: customValue,
                 }}
                 isLoading={isLogVolumeLoading}
-                value={customValue ? customValue : label}
+                value={hasSearch ? searchLabel || customLabel : undefined}
                 onChange={(serviceName) => onSearchChange(serviceName)}
                 selectOption={(value: string) => {
                   goToLabelDrillDownLink(selectedTab, value, model);

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Select, Stack, useStyles2 } from '@grafana/ui';
+import { Icon, Input, ScrollContainer, Stack, useStyles2 } from '@grafana/ui';
 
 import { ServiceSelectionScene } from './ServiceSelectionScene';
-import { ServiceSelectionTabsScene, TabOption } from './ServiceSelectionTabsScene';
+import { ServiceSelectionTabsScene } from './ServiceSelectionTabsScene';
 
 export interface TabPopoverSceneState extends SceneObjectState {}
 
@@ -18,42 +18,90 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
     const serviceSelectionTabsScene = sceneGraph.getAncestor(model, ServiceSelectionTabsScene);
     const { showPopover, tabOptions } = serviceSelectionTabsScene.useState();
     const popoverStyles = useStyles2(getPopoverStyles);
+    const popoverBodyRef = useRef<HTMLDivElement>(null);
+    const [filter, setFilter] = useState('');
 
-    const tabOptionsWithIcon: TabOption[] = tabOptions.map((opt) => {
-      return {
-        ...opt,
-        icon: opt.saved ? 'save' : undefined,
-        label: `${opt.label}`,
-      };
-    });
+    useEffect(() => {
+      if (showPopover) {
+        setFilter('');
+      }
+    }, [showPopover]);
+
+    const filteredTabOptions = useMemo(() => {
+      const q = filter.trim().toLowerCase();
+      if (!q) {
+        return tabOptions;
+      }
+      return tabOptions.filter((opt) => opt.label.toLowerCase().includes(q));
+    }, [tabOptions, filter]);
+
+    const searchLabelsPlaceholder = t(
+      'components.service-selection-scene.tab-popover-scene.placeholder-search-labels',
+      'Search labels'
+    );
+
+    const savedTabIconTitle = t(
+      'components.service-selection-scene.tab-popover-scene.icon-saved-tab',
+      'Previously selected label'
+    );
+
+    const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      const next = event.relatedTarget as Node | null;
+      if (next && popoverBodyRef.current?.contains(next)) {
+        return;
+      }
+      serviceSelectionTabsScene.toggleShowPopover();
+    };
+
+    const selectTab = (value: string) => {
+      serviceSelectionTabsScene.toggleShowPopover();
+      serviceSelectionScene.setSelectedTab(value);
+    };
+
+    if (!showPopover) {
+      return null;
+    }
 
     return (
       <Stack direction="column" gap={0} role="tooltip">
-        <div className={popoverStyles.card.body}>
-          <Select<string, { options: TabOption[] }>
-            menuShouldPortal={false}
-            menuPosition={'absolute'}
-            width={50}
-            onBlur={() => {
-              serviceSelectionTabsScene.toggleShowPopover();
-            }}
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus={true}
-            isOpen={showPopover}
-            placeholder={t('components.service-selection-scene.tab-popover-scene.placeholder-search-labels', 'Search labels')}
-            options={tabOptionsWithIcon}
-            isSearchable={true}
-            openMenuOnFocus={true}
-            onChange={(option) => {
-              // Add value to variable
-              if (option.value) {
-                // Hide the popover
-                serviceSelectionTabsScene.toggleShowPopover();
-                // Set new tab
-                serviceSelectionScene.setSelectedTab(option.value);
-              }
-            }}
-          />
+        <div ref={popoverBodyRef} className={popoverStyles.card.body}>
+          <Stack direction="column" gap={0}>
+            <Input
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus={true}
+              placeholder={searchLabelsPlaceholder}
+              value={filter}
+              onChange={(e) => setFilter(e.currentTarget.value)}
+              onBlur={handleInputBlur}
+              suffix={<Icon name="search" />}
+            />
+            <ScrollContainer maxHeight="50vh">
+              <div role="listbox" aria-label={searchLabelsPlaceholder} className={popoverStyles.list.inner}>
+                {filteredTabOptions.map((opt) => (
+                  <div
+                    key={opt.value}
+                    role="option"
+                    aria-selected={false}
+                    tabIndex={0}
+                    className={popoverStyles.list.option}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => selectTab(opt.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        selectTab(opt.value);
+                      }
+                    }}
+                  >
+                    <Stack direction="row" gap={1} alignItems="center" justifyContent="flex-start">
+                      {opt.saved === true && <Icon name="save" size="sm" title={savedTabIconTitle} />}
+                      <span className={popoverStyles.list.optionLabel}>{opt.label}</span>
+                    </Stack>
+                  </div>
+                ))}
+              </div>
+            </ScrollContainer>
+          </Stack>
         </div>
       </Stack>
     );
@@ -64,9 +112,34 @@ const getPopoverStyles = (theme: GrafanaTheme2) => ({
   card: {
     body: css({
       padding: theme.spacing(1),
+      minWidth: theme.spacing(30),
     }),
     p: css({
       maxWidth: 300,
+    }),
+  },
+  list: {
+    inner: css({
+      paddingBottom: theme.spacing(0.5),
+    }),
+    option: css({
+      cursor: 'pointer',
+      borderRadius: theme.shape.radius.default,
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      outline: 'none',
+      '&:hover, &:focus-visible': {
+        background: theme.colors.action.hover,
+      },
+    }),
+    optionLabel: css({
+      flex: 1,
+      minWidth: 0,
+      wordBreak: 'break-word',
+    }),
+    optionIconSpacer: css({
+      display: 'inline-block',
+      width: theme.spacing(2),
+      flexShrink: 0,
     }),
   },
 });

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Icon, Input, ScrollContainer, Stack, useStyles2 } from '@grafana/ui';
+import { Combobox, ComboboxOption, Stack, useStyles2 } from '@grafana/ui';
 
 import { ServiceSelectionScene } from './ServiceSelectionScene';
 import { ServiceSelectionTabsScene } from './ServiceSelectionTabsScene';
@@ -18,22 +18,8 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
     const serviceSelectionTabsScene = sceneGraph.getAncestor(model, ServiceSelectionTabsScene);
     const { showPopover, tabOptions } = serviceSelectionTabsScene.useState();
     const popoverStyles = useStyles2(getPopoverStyles);
-    const popoverBodyRef = useRef<HTMLDivElement>(null);
-    const [filter, setFilter] = useState('');
-
-    useEffect(() => {
-      if (showPopover) {
-        setFilter('');
-      }
-    }, [showPopover]);
-
-    const filteredTabOptions = useMemo(() => {
-      const q = filter.trim().toLowerCase();
-      if (!q) {
-        return tabOptions;
-      }
-      return tabOptions.filter((opt) => opt.label.toLowerCase().includes(q));
-    }, [tabOptions, filter]);
+    // Combobox menus render in a portal; mount them inside this node so focus and click handling
+    const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
 
     const searchLabelsPlaceholder = t(
       'components.service-selection-scene.tab-popover-scene.placeholder-search-labels',
@@ -45,65 +31,76 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
       'Previously selected label'
     );
 
-    const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-      const next = event.relatedTarget as Node | null;
-      if (next && popoverBodyRef.current?.contains(next)) {
-        return;
-      }
-      serviceSelectionTabsScene.toggleShowPopover();
-    };
+    const comboboxOptions: Array<ComboboxOption<string>> = useMemo(
+      () =>
+        tabOptions.map((opt) => ({
+          label: opt.label,
+          value: opt.value,
+          ...(opt.saved ? { description: savedTabIconTitle } : {}),
+        })),
+      [tabOptions, savedTabIconTitle]
+    );
 
     const selectTab = (value: string) => {
       serviceSelectionTabsScene.toggleShowPopover();
       serviceSelectionScene.setSelectedTab(value);
     };
 
+    // Close the popover when the user clicks outside of the combobox
+    useEffect(() => {
+      if (!showPopover || !comboboxMenuContainer) {
+        return;
+      }
+      const el = comboboxMenuContainer;
+      const onFocusOut = (event: FocusEvent) => {
+        const next = event.relatedTarget as Node | null;
+        if (next && el.contains(next)) {
+          return;
+        }
+        serviceSelectionTabsScene.setState({ showPopover: false });
+      };
+      el.addEventListener('focusout', onFocusOut);
+      return () => el.removeEventListener('focusout', onFocusOut);
+    }, [showPopover, comboboxMenuContainer, serviceSelectionTabsScene]);
+
+    // Combobox does not expose defaultIsOpen; Downshift opens the list on ArrowDown from a focused input.
+    useLayoutEffect(() => {
+      if (!showPopover || !comboboxMenuContainer) {
+        return;
+      }
+      const input = comboboxMenuContainer.querySelector<HTMLInputElement>('input');
+      if (!input) {
+        return;
+      }
+      input.focus();
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          code: 'ArrowDown',
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    }, [showPopover, comboboxMenuContainer]);
+
     if (!showPopover) {
       return null;
     }
 
-    const selectedTabKey = serviceSelectionScene.getSelectedTab();
-
     return (
       <Stack direction="column" gap={0} role="tooltip">
-        <div ref={popoverBodyRef} className={popoverStyles.card.body}>
-          <Stack direction="column" gap={0}>
-            <Input
-              // eslint-disable-next-line jsx-a11y/no-autofocus
-              autoFocus={true}
-              placeholder={searchLabelsPlaceholder}
-              value={filter}
-              onChange={(e) => setFilter(e.currentTarget.value)}
-              onBlur={handleInputBlur}
-              suffix={<Icon name="search" />}
-            />
-            <ScrollContainer maxHeight="50vh">
-              <div role="listbox" aria-label={searchLabelsPlaceholder} className={popoverStyles.list.inner}>
-                {filteredTabOptions.map((opt) => (
-                  <div
-                    key={opt.value}
-                    role="option"
-                    tabIndex={selectedTabKey === opt.value ? 0 : -1}
-                    aria-selected={selectedTabKey === opt.value}
-                    className={popoverStyles.list.option}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => selectTab(opt.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        selectTab(opt.value);
-                      }
-                    }}
-                  >
-                    <Stack direction="row" gap={1} alignItems="center" justifyContent="flex-start">
-                      {opt.saved === true && <Icon name="save" size="sm" title={savedTabIconTitle} />}
-                      <span className={popoverStyles.list.optionLabel}>{opt.label}</span>
-                    </Stack>
-                  </div>
-                ))}
-              </div>
-            </ScrollContainer>
-          </Stack>
+        <div ref={setComboboxMenuContainer} className={popoverStyles.card.body}>
+          <Combobox<string>
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus={true}
+            placeholder={searchLabelsPlaceholder}
+            options={comboboxOptions}
+            prefixIcon="search"
+            onChange={(option) => selectTab(option.value)}
+            width="auto"
+            minWidth={52}
+            maxWidth={90}
+          />
         </div>
       </Stack>
     );
@@ -114,34 +111,7 @@ const getPopoverStyles = (theme: GrafanaTheme2) => ({
   card: {
     body: css({
       padding: theme.spacing(1),
-      minWidth: theme.spacing(30),
-    }),
-    p: css({
-      maxWidth: 300,
-    }),
-  },
-  list: {
-    inner: css({
-      paddingBottom: theme.spacing(0.5),
-    }),
-    option: css({
-      cursor: 'pointer',
-      borderRadius: theme.shape.radius.default,
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
-      outline: 'none',
-      '&:hover, &:focus-visible': {
-        background: theme.colors.action.hover,
-      },
-    }),
-    optionLabel: css({
-      flex: 1,
-      minWidth: 0,
-      wordBreak: 'break-word',
-    }),
-    optionIconSpacer: css({
-      display: 'inline-block',
-      width: theme.spacing(2),
-      flexShrink: 0,
+      minWidth: theme.spacing(52),
     }),
   },
 });

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -1,104 +1,62 @@
-import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import React from 'react';
 
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Combobox, ComboboxOption, Stack, useStyles2 } from '@grafana/ui';
+import { Select, Stack, useStyles2 } from '@grafana/ui';
 
 import { ServiceSelectionScene } from './ServiceSelectionScene';
-import { ServiceSelectionTabsScene } from './ServiceSelectionTabsScene';
+import { ServiceSelectionTabsScene, TabOption } from './ServiceSelectionTabsScene';
 
 export interface TabPopoverSceneState extends SceneObjectState {}
 
+// TODO: update combobox to auto open in grafana/ui the update the select here to combobox
 export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
   public static Component = ({ model }: SceneComponentProps<TabPopoverScene>) => {
     const serviceSelectionScene = sceneGraph.getAncestor(model, ServiceSelectionScene);
     const serviceSelectionTabsScene = sceneGraph.getAncestor(model, ServiceSelectionTabsScene);
     const { showPopover, tabOptions } = serviceSelectionTabsScene.useState();
     const popoverStyles = useStyles2(getPopoverStyles);
-    // Combobox menus render in a portal; mount them inside this node so focus and click handling
-    const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
-    const comboboxPortalProps = { portalContainer: comboboxMenuContainer ?? undefined };
 
-    const searchLabelsPlaceholder = t(
-      'components.service-selection-scene.tab-popover-scene.placeholder-search-labels',
-      'Search labels'
-    );
-
-    const savedTabIconTitle = t('components.service-selection-scene.tab-popover-scene.icon-saved-tab', 'Saved label');
-
-    const comboboxOptions: Array<ComboboxOption<string>> = useMemo(
-      () =>
-        tabOptions.map((opt) => ({
-          label: opt.label,
-          value: opt.value,
-          ...(opt.saved ? { description: savedTabIconTitle } : {}),
-        })),
-      [tabOptions, savedTabIconTitle]
-    );
-
-    const selectTab = (value: string) => {
-      serviceSelectionTabsScene.setState({ showPopover: false });
-      serviceSelectionScene.setSelectedTab(value);
-    };
-
-    // Close the popover when the user clicks outside of the combobox
-    useEffect(() => {
-      if (!showPopover || !comboboxMenuContainer) {
-        return;
-      }
-      const el = comboboxMenuContainer;
-      const onFocusOut = (event: FocusEvent) => {
-        const next = event.relatedTarget as Node | null;
-        if (next && el.contains(next)) {
-          return;
-        }
-        serviceSelectionTabsScene.setState({ showPopover: false });
+    const tabOptionsWithIcon: TabOption[] = tabOptions.map((opt) => {
+      return {
+        ...opt,
+        icon: opt.saved ? 'save' : undefined,
+        label: `${opt.label}`,
       };
-      el.addEventListener('focusout', onFocusOut);
-      return () => el.removeEventListener('focusout', onFocusOut);
-    }, [showPopover, comboboxMenuContainer, serviceSelectionTabsScene]);
-
-    // Combobox does not expose defaultIsOpen; Downshift opens the list on ArrowDown from a focused input.
-    useLayoutEffect(() => {
-      if (!showPopover || !comboboxMenuContainer) {
-        return;
-      }
-      const input = comboboxMenuContainer.querySelector<HTMLInputElement>('input');
-      if (!input) {
-        return;
-      }
-      input.focus();
-      input.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'ArrowDown',
-          code: 'ArrowDown',
-          bubbles: true,
-          cancelable: true,
-        })
-      );
-    }, [showPopover, comboboxMenuContainer]);
-
-    if (!showPopover) {
-      return null;
-    }
+    });
 
     return (
       <Stack direction="column" gap={0} role="tooltip">
-        <div ref={setComboboxMenuContainer} className={popoverStyles.card.body}>
-          <Combobox<string>
-            {...comboboxPortalProps}
+        <div className={popoverStyles.card.body}>
+          <Select<string, { options: TabOption[] }>
+            menuShouldPortal={false}
+            menuPosition={'absolute'}
+            width={50}
+            onBlur={() => {
+              serviceSelectionTabsScene.toggleShowPopover();
+            }}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={true}
-            placeholder={searchLabelsPlaceholder}
-            options={comboboxOptions}
-            prefixIcon="search"
-            onChange={(option) => selectTab(option.value)}
-            width="auto"
-            minWidth={52}
-            maxWidth={90}
+            isOpen={showPopover}
+            placeholder={t(
+              'components.service-selection-scene.tab-popover-scene.placeholder-search-labels',
+              'Search labels'
+            )}
+            options={tabOptionsWithIcon}
+            isSearchable={true}
+            openMenuOnFocus={true}
+            onChange={(option) => {
+              // Add value to variable
+              if (option.value) {
+                // Hide the popover
+                serviceSelectionTabsScene.toggleShowPopover();
+                // Set new tab
+                serviceSelectionScene.setSelectedTab(option.value);
+              }
+            }}
           />
         </div>
       </Stack>
@@ -110,7 +68,9 @@ const getPopoverStyles = (theme: GrafanaTheme2) => ({
   card: {
     body: css({
       padding: theme.spacing(1),
-      minWidth: theme.spacing(52),
+    }),
+    p: css({
+      maxWidth: 300,
     }),
   },
 });

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -62,6 +62,8 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
       return null;
     }
 
+    const selectedTabKey = serviceSelectionScene.getSelectedTab();
+
     return (
       <Stack direction="column" gap={0} role="tooltip">
         <div ref={popoverBodyRef} className={popoverStyles.card.body}>
@@ -81,8 +83,8 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
                   <div
                     key={opt.value}
                     role="option"
-                    aria-selected={false}
-                    tabIndex={0}
+                    tabIndex={selectedTabKey === opt.value ? 0 : -1}
+                    aria-selected={selectedTabKey === opt.value}
                     className={popoverStyles.list.option}
                     onMouseDown={(e) => e.preventDefault()}
                     onClick={() => selectTab(opt.value)}

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -20,6 +20,7 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
     const popoverStyles = useStyles2(getPopoverStyles);
     // Combobox menus render in a portal; mount them inside this node so focus and click handling
     const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
+    const comboboxPortalProps = { portalContainer: comboboxMenuContainer ?? undefined };
 
     const searchLabelsPlaceholder = t(
       'components.service-selection-scene.tab-popover-scene.placeholder-search-labels',
@@ -42,7 +43,7 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
     );
 
     const selectTab = (value: string) => {
-      serviceSelectionTabsScene.toggleShowPopover();
+      serviceSelectionTabsScene.setState({ showPopover: false });
       serviceSelectionScene.setSelectedTab(value);
     };
 
@@ -91,6 +92,7 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
       <Stack direction="column" gap={0} role="tooltip">
         <div ref={setComboboxMenuContainer} className={popoverStyles.card.body}>
           <Combobox<string>
+            {...comboboxPortalProps}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={true}
             placeholder={searchLabelsPlaceholder}

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -27,10 +27,7 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
       'Search labels'
     );
 
-    const savedTabIconTitle = t(
-      'components.service-selection-scene.tab-popover-scene.icon-saved-tab',
-      'Previously selected label'
-    );
+    const savedTabIconTitle = t('components.service-selection-scene.tab-popover-scene.icon-saved-tab', 'Saved label');
 
     const comboboxOptions: Array<ComboboxOption<string>> = useMemo(
       () =>

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -31,6 +31,7 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
     return (
       <Stack direction="column" gap={0} role="tooltip">
         <div className={popoverStyles.card.body}>
+          {/* eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: Combobox when grafana/ui supports open-on-focus in this popover */}
           <Select<string, { options: TabOption[] }>
             menuShouldPortal={false}
             menuPosition={'absolute'}

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -734,7 +734,7 @@
       },
       "service-selection-pagination-scene": {
         "aria-label-count-info": "Count info",
-        "of-total": " of {{totalCount}}",
+        "of-total": "of {{totalCount}}",
         "showing": "Showing",
         "tooltip": {
           "count-info": "{{totalCount}} labels have values for the selected time range. Total label count may differ"

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -357,6 +357,7 @@
           "title": "We did not find any {{type}} for the given time range."
         },
         "field-selector": {
+          "custom-value-search-or-filter": "Filter values by",
           "placeholder-search-values": "Search values"
         },
         "field-values-breakdown-scene": {

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -719,9 +719,6 @@
         "docs-link": "Instructions to enable volume in the Loki config:",
         "title": "Log volume has not been configured."
       },
-      "label": {
-        "service": "Service"
-      },
       "no-service-search-results": {
         "title": "No service matched your search."
       },

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -734,7 +734,7 @@
       },
       "service-selection-pagination-scene": {
         "aria-label-count-info": "Count info",
-        "of-total": "of {{totalCount}}",
+        "of-total": " of {{totalCount}}",
         "showing": "Showing",
         "tooltip": {
           "count-info": "{{totalCount}} labels have values for the selected time range. Total label count may differ"

--- a/src/services/KeybindingSet.ts
+++ b/src/services/KeybindingSet.ts
@@ -23,7 +23,6 @@ export class KeybindingSet {
       (evt) => {
         evt.preventDefault();
         evt.stopPropagation();
-        evt.returnValue = false;
         item.onTrigger();
       },
       'keydown'

--- a/src/services/Mousetrap.ts
+++ b/src/services/Mousetrap.ts
@@ -152,7 +152,7 @@ let SHIFT_MAP: Record<string, string> = {
 let SPECIAL_ALIASES: Record<string, string> = {
   command: 'meta',
   escape: 'esc',
-  mod: /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? 'meta' : 'ctrl',
+  mod: /Mac|iPod|iPhone|iPad/.test(navigator.userAgent) ? 'meta' : 'ctrl',
   option: 'alt',
   plus: '+',
   return: 'enter',
@@ -189,9 +189,17 @@ for (let i = 0; i <= 9; ++i) {
  * takes the event and returns the key character
  */
 function characterFromEvent(event: KeyboardEvent): string {
+  const eventRecord = event as unknown as Record<string, unknown>;
+  const keyCode =
+    typeof eventRecord.which === 'number'
+      ? eventRecord.which
+      : typeof eventRecord.keyCode === 'number'
+        ? eventRecord.keyCode
+        : undefined;
+
   // for keypress events we should return the character as is
   if (event.type === 'keypress') {
-    let character = String.fromCharCode(event.which);
+    let character = String.fromCharCode(keyCode ?? 0);
 
     // if the shift key is not pressed then it is safe to assume
     // that we want the character to be lowercase.  this means if
@@ -210,12 +218,12 @@ function characterFromEvent(event: KeyboardEvent): string {
   }
 
   // for non keypress events the special maps are needed
-  if (MAP[event.which]) {
-    return MAP[event.which];
+  if (keyCode !== undefined && MAP[keyCode]) {
+    return MAP[keyCode];
   }
 
-  if (KEYCODE_MAP[event.which]) {
-    return KEYCODE_MAP[event.which];
+  if (keyCode !== undefined && KEYCODE_MAP[keyCode]) {
+    return KEYCODE_MAP[keyCode];
   }
 
   // if it is not in the special map
@@ -223,7 +231,7 @@ function characterFromEvent(event: KeyboardEvent): string {
   // with keydown and keyup events the character seems to always
   // come in as an uppercase character whether you are pressing shift
   // or not.  we should make sure it is always lowercase for comparisons
-  return String.fromCharCode(event.which).toLowerCase();
+  return String.fromCharCode(keyCode ?? 0).toLowerCase();
 }
 
 /**
@@ -264,10 +272,7 @@ function eventModifiers(event: KeyboardEvent): string[] {
 function preventDefault(event: KeyboardEvent): void {
   if (event.preventDefault) {
     event.preventDefault();
-    return;
   }
-
-  event.returnValue = false;
 }
 
 /**
@@ -276,10 +281,7 @@ function preventDefault(event: KeyboardEvent): void {
 function stopPropagation(event: KeyboardEvent): void {
   if (event.stopPropagation) {
     event.stopPropagation();
-    return;
   }
-
-  event.cancelBubble = true;
 }
 
 /**
@@ -573,7 +575,8 @@ export class Mousetrap {
    */
   private _fireCallback = (callback: Function, e: KeyboardEvent, combo: string, sequence?: string) => {
     // if this event should not happen stop here
-    const target = e.target || e.srcElement;
+    const legacyTarget = (e as unknown as { srcElement?: EventTarget | null }).srcElement;
+    const target = e.target ?? legacyTarget;
     if (target && target instanceof HTMLElement && this.stopCallback(e, target, combo, sequence)) {
       return;
     }
@@ -698,13 +701,6 @@ export class Mousetrap {
     // Don't trigger shortcuts when a key is just held down
     if (event.repeat) {
       return;
-    }
-
-    // normalize e.which for key events
-    // @see http://stackoverflow.com/questions/4285627/javascript-keycode-vs-charcode-utter-confusion
-    if (typeof event.which !== 'number') {
-      // @ts-expect-error - TODO: determine what to do with this compat
-      event.which = event.keyCode;
     }
 
     let character = characterFromEvent(event);

--- a/src/services/Mousetrap.ts
+++ b/src/services/Mousetrap.ts
@@ -575,7 +575,8 @@ export class Mousetrap {
    */
   private _fireCallback = (callback: Function, e: KeyboardEvent, combo: string, sequence?: string) => {
     // if this event should not happen stop here
-    const legacyTarget = (e as unknown as { srcElement?: EventTarget | null }).srcElement;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const legacyTarget = 'srcElement' in e ? e.srcElement : null;
     const target = e.target ?? legacyTarget;
     if (target && target instanceof HTMLElement && this.stopCallback(e, target, combo, sequence)) {
       return;

--- a/src/services/Mousetrap.ts
+++ b/src/services/Mousetrap.ts
@@ -189,17 +189,10 @@ for (let i = 0; i <= 9; ++i) {
  * takes the event and returns the key character
  */
 function characterFromEvent(event: KeyboardEvent): string {
-  const eventRecord = event as unknown as Record<string, unknown>;
-  const keyCode =
-    typeof eventRecord.which === 'number'
-      ? eventRecord.which
-      : typeof eventRecord.keyCode === 'number'
-        ? eventRecord.keyCode
-        : undefined;
-
   // for keypress events we should return the character as is
   if (event.type === 'keypress') {
-    let character = String.fromCharCode(keyCode ?? 0);
+    /* eslint-disable @typescript-eslint/no-deprecated -- vendored mousetrap reads legacy key codes */
+    let character = String.fromCharCode(event.which);
 
     // if the shift key is not pressed then it is safe to assume
     // that we want the character to be lowercase.  this means if
@@ -218,12 +211,12 @@ function characterFromEvent(event: KeyboardEvent): string {
   }
 
   // for non keypress events the special maps are needed
-  if (keyCode !== undefined && MAP[keyCode]) {
-    return MAP[keyCode];
+  if (MAP[event.which]) {
+    return MAP[event.which];
   }
 
-  if (keyCode !== undefined && KEYCODE_MAP[keyCode]) {
-    return KEYCODE_MAP[keyCode];
+  if (KEYCODE_MAP[event.which]) {
+    return KEYCODE_MAP[event.which];
   }
 
   // if it is not in the special map
@@ -231,7 +224,7 @@ function characterFromEvent(event: KeyboardEvent): string {
   // with keydown and keyup events the character seems to always
   // come in as an uppercase character whether you are pressing shift
   // or not.  we should make sure it is always lowercase for comparisons
-  return String.fromCharCode(keyCode ?? 0).toLowerCase();
+  return String.fromCharCode(event.which).toLowerCase();
 }
 
 /**
@@ -575,7 +568,7 @@ export class Mousetrap {
    */
   private _fireCallback = (callback: Function, e: KeyboardEvent, combo: string, sequence?: string) => {
     // if this event should not happen stop here
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    /* eslint-disable @typescript-eslint/no-deprecated -- vendored mousetrap reads legacy target */
     const legacyTarget = 'srcElement' in e ? e.srcElement : null;
     const target = e.target ?? legacyTarget;
     if (target && target instanceof HTMLElement && this.stopCallback(e, target, combo, sequence)) {

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -71,8 +71,10 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
   // some grafana parts do not behave well.
   // we just choose the old error, if it exists,
   // otherwise the new error, if it exists.
+  /* eslint-disable-next-line @typescript-eslint/no-deprecated */
   const mergedError = currentResult.error ?? newResult.error;
   if (mergedError != null) {
+    /* eslint-disable-next-line @typescript-eslint/no-deprecated */
     currentResult.error = mergedError;
   }
 

--- a/src/services/highlight.test.tsx
+++ b/src/services/highlight.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-key -- expected JSX in toEqual() assertions */
 import React from 'react';
 
 import {

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -109,6 +109,7 @@ function splitQueriesByStreamShard(
         }
       } catch (e) {
         logger.error(e, {
+          /* eslint-disable-next-line @typescript-eslint/no-deprecated */
           error: errorResponse?.error?.message ?? '',
           errors: errorResponse?.errors?.map((e) => e.message).join(' | ') ?? '',
           msg: 'sharding retry error',
@@ -181,6 +182,7 @@ function splitQueriesByStreamShard(
         nextRequest();
       },
       next: (partialResponse: DataQueryResponse) => {
+        /* eslint-disable-next-line @typescript-eslint/no-deprecated */
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
           if (retry(partialResponse)) {
             return;
@@ -319,7 +321,8 @@ function getInitialGroupSize(shards: number[]) {
 function isRetriableError(errorResponse: DataQueryResponse) {
   const message = errorResponse.errors
     ? (errorResponse.errors[0].message ?? '').toLowerCase()
-    : (errorResponse.error?.message ?? '').toLowerCase();
+    : /* eslint-disable-next-line @typescript-eslint/no-deprecated */
+      (errorResponse.error?.message ?? '').toLowerCase();
   if (message.includes('timeout')) {
     return true;
   } else if (message.includes('parse error') || message.match(MaxSeriesRegex)) {

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -31,6 +31,7 @@ export const testIds = {
       sortByDirection: 'data-testid SortBy direction',
       sortByFunction: 'data-testid SortBy function',
     },
+    labelFieldSearch: 'data-testid search-label-field',
     fields: {},
     labels: {},
   },

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -15,6 +15,7 @@ export const copyText = (string: string) => {
     el.value = string;
     document.body.appendChild(el);
     el.select();
+    /* eslint-disable-next-line @typescript-eslint/no-deprecated -- execCommand is the standard pre-Clipboard fallback */
     document.execCommand('copy');
     document.body.removeChild(el);
   }

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -40,11 +40,11 @@ test.describe('navigating app', () => {
   test('mega menu click should persist url params', async ({ page }) => {
     await page.goto(`/a/${pluginJson.id}/explore`);
 
-    // Filter results to tempo-ingester to prevent flake
+    // Primary label search uses regex; type a substring then confirm via "Use custom value" (see wrapWildcardSearch in query.ts).
     await explorePage.servicesSearch.click();
-    await explorePage.servicesSearch.pressSequentially('Tempo-i');
-    await page.keyboard.press('Escape');
-    await expect(page.getByRole('listbox')).not.toBeVisible();
+    await explorePage.servicesSearch.pressSequentially('tempo-i');
+    await expect(page.getByRole('listbox')).toBeVisible();
+    await page.getByRole('option', { name: /Use custom value/ }).click();
     await expect(page.getByRole('heading', { name: 'tempo-ingester' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'tempo-distributor' })).not.toBeVisible();
 
@@ -55,12 +55,9 @@ test.describe('navigating app', () => {
 
     // assert panels are showing
     await expect(page.getByTestId('data-testid button-filter-include').first()).toHaveCount(1);
-    const actualSearchParams = new URLSearchParams(page.url().split('?')[1]);
-    const expectedSearchParams = new URLSearchParams(
-      '?patterns=%5B%5D&from=now-15m&to=now&var-all-fields=&var-ds=gdev-loki&var-filters=service_name%7C%3D%7Ctempo-ingester&var-lineFormat=&var-jsonFields=&var-fields=&var-filters_replica=&var-levels=&var-patterns=&var-lineFilterV2=&var-lineFilters=&var-metadata=&timezone=browser&var-primary_label=service_name%7C%3D~%7C%28%3Fi%29.%2ATempo-i.%2A'
-    );
-    actualSearchParams.sort();
-    expectedSearchParams.sort();
-    expect(actualSearchParams.toString()).toEqual(expectedSearchParams.toString());
+
+    // assert the var-filters param contains the service name
+    const varFilters = new URL(page.url()).searchParams.get('var-filters') ?? '';
+    expect(varFilters).toContain('tempo-ingester');
   });
 });

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -40,11 +40,11 @@ test.describe('navigating app', () => {
   test('mega menu click should persist url params', async ({ page }) => {
     await page.goto(`/a/${pluginJson.id}/explore`);
 
-    // Primary label search uses regex; type a substring then confirm via "Use custom value" (see wrapWildcardSearch in query.ts).
+    // Primary label search uses regex; type a substring then confirm via the custom-value row (see wrapWildcardSearch in query.ts).
     await explorePage.servicesSearch.click();
     await explorePage.servicesSearch.pressSequentially('tempo-i');
     await expect(page.getByRole('listbox')).toBeVisible();
-    await page.getByRole('option', { name: /Use custom value/ }).click();
+    await page.getByRole('option', { name: /Filter values by/ }).click();
     await expect(page.getByRole('heading', { name: 'tempo-ingester' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'tempo-distributor' })).not.toBeVisible();
 

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@grafana/plugin-e2e';
 
 import pluginJson from '../src/plugin.json';
 import { skipUnlessLatestGrafana } from './config/grafana-versions-supported';
-import { ExplorePage } from './fixtures/explore';
+import { E2EComboboxStrings, ExplorePage } from './fixtures/explore';
 
 test.describe('navigating app', () => {
   let explorePage: ExplorePage;
@@ -44,7 +44,7 @@ test.describe('navigating app', () => {
     await explorePage.servicesSearch.click();
     await explorePage.servicesSearch.pressSequentially('tempo-i');
     await expect(page.getByRole('listbox')).toBeVisible();
-    await page.getByRole('option', { name: /Filter values by/ }).click();
+    await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
     await expect(page.getByRole('heading', { name: 'tempo-ingester' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'tempo-distributor' })).not.toBeVisible();
 

--- a/tests/embed.spec.ts
+++ b/tests/embed.spec.ts
@@ -155,7 +155,7 @@ test.describe('embed', () => {
     await explorePage.assertNotLoading();
 
     // Click filters
-    await expect(page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude)).toHaveCount(8);
+    await expect(page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(3)).toBeVisible();
     await page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(0).click();
     await page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(1).click();
     await page.getByTestId(testIds.exploreServiceDetails.buttonFilterInclude).nth(2).click();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -462,7 +462,7 @@ test.describe('explore services page', () => {
       test.describe('navigation', () => {
         test('user can use browser history to navigate through tabs', async ({ page }) => {
           const addNewTab = page.getByTestId(testIds.index.addNewLabelTab);
-          // TabPopoverScene: popover is role="tooltip" with an input placeholder "Search labels"
+          // TabPopoverScene: Grafana Popover content uses role="tooltip"; Combobox input has placeholder "Search labels"
           const addLabelPopover = page.getByRole('tooltip').filter({
             has: page.getByPlaceholder('Search labels'),
           });
@@ -483,7 +483,7 @@ test.describe('explore services page', () => {
           await expect(addLabelPopover).toBeVisible();
 
           // Add "namespace" as a new tab
-          await page.getByText('namespace', { exact: true }).click();
+          await page.getByRole('option', { name: 'namespace', exact: true }).click();
           await expect(newNamespaceTabLoc).toHaveCount(1);
 
           // Click "New" tab
@@ -654,14 +654,14 @@ test.describe('explore services page', () => {
         await expect(addNewTab).toHaveCount(1);
         await addNewTab.click();
 
-        // Dropdown should be open (TabPopoverScene: tooltip + Search labels placeholder)
+        // Dropdown should be open (TabPopoverScene: tooltip + Combobox placeholder "Search labels")
         const addLabelPopover = page.getByRole('tooltip').filter({
           has: page.getByPlaceholder('Search labels'),
         });
         await expect(addLabelPopover).toBeVisible();
 
         // Add "namespace" as a new tab
-        await page.getByText('namespace', { exact: true }).click();
+        await page.getByRole('option', { name: 'namespace', exact: true }).click();
         const newNamespaceTabLoc = page.getByTestId('data-testid Tab namespace');
         await expect(newNamespaceTabLoc).toHaveCount(1);
 

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -57,18 +57,12 @@ test.describe('explore services page', () => {
       // Click on nav to return to service selection
       await page.getByRole('link', { name: 'Logs' }).first().click();
 
-      // Assert there is more then one result now
-      await expect(explorePage.getPanelHeaderLocator().nth(1)).toBeVisible();
-
       // Assert that the first element is nginx now
       await expect(explorePage.getPanelHeaderLocator().first()).toHaveText('nginxRemove');
       await explorePage.servicesSearch.click();
 
-      // Assert there is more than one element in the dropdown
-      await expect(page.getByRole('option').nth(1)).not.toContainText('nginx');
-
       // assert the first element is nginx now
-      await expect(firstResult).toHaveText('nginx');
+      await expect(firstResult).toHaveText('^nginx$');
     });
 
     test.describe('default labels', () => {

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -183,7 +183,8 @@ test.describe('explore services page', () => {
     test('should filter logs by clicking on the chart levels', async ({ page }) => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
-      await explorePage.servicesSearch.pressSequentially('tempo-distributor');
+      await explorePage.servicesSearch.pressSequentially('tempo-d');
+      await page.getByRole('option', { name: /Use custom value/ }).click();
 
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -44,7 +44,7 @@ test.describe('explore services page', () => {
       // Select nginx, as it has the lowest volume, and should otherwise show up last
       await explorePage.servicesSearch.pressSequentially('^nginx$');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
 
       // Assert the first is nginx, or we might click before it's done loading
       await expect(explorePage.getPanelHeaderLocator().first()).toHaveText('nginxIncludeShow logs');
@@ -112,7 +112,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('mimir');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
 
@@ -134,7 +134,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('mimir-i');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
 
       // service name should be in time series panel
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
@@ -148,7 +148,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('imi');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
       // service name should be in time series panel
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
       // service name should also be in logs panel, just not visible to the user
@@ -172,7 +172,7 @@ test.describe('explore services page', () => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-d');
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
 
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
@@ -238,7 +238,7 @@ test.describe('explore services page', () => {
       // Filter results for tempo-ingester
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-i');
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
 
       const tempoIngesterPanelHeader = explorePage.getPanelHeaderLocator().filter({
         has: page.getByRole('heading', { name: 'tempo-ingester' }),
@@ -269,7 +269,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-d');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+      await page.getByRole('option', { name: /Filter values by/ }).click();
 
       const tempoDistributorPanelHeader = explorePage.getPanelHeaderLocator().filter({
         has: page.getByRole('heading', { name: 'tempo-distributor' }),
@@ -666,7 +666,7 @@ test.describe('explore services page', () => {
         await explorePage.servicesSearch.click();
         await explorePage.servicesSearch.fill('Gate');
         await expect(page.getByRole('listbox')).toBeVisible();
-        await page.getByRole('option', { name: /Use custom value/ }).click();
+        await page.getByRole('option', { name: /Filter values by/ }).click();
 
         // Asser this filters down to only one result
         await expect(page.getByTestId(testIds.index.showLogsButton)).toHaveCount(1);

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -43,7 +43,8 @@ test.describe('explore services page', () => {
 
       // Select nginx, as it has the lowest volume, and should otherwise show up last
       await explorePage.servicesSearch.pressSequentially('^nginx$');
-      await page.keyboard.press('Escape');
+      await expect(page.getByRole('listbox')).toBeVisible();
+      await page.getByRole('option', { name: /Use custom value/ }).click();
 
       // Assert the first is nginx, or we might click before it's done loading
       await expect(explorePage.getPanelHeaderLocator().first()).toHaveText('nginxIncludeShow logs');
@@ -122,6 +123,8 @@ test.describe('explore services page', () => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('mimir');
+      await expect(page.getByRole('listbox')).toBeVisible();
+      await page.getByRole('option', { name: /Use custom value/ }).click();
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
 
@@ -136,29 +139,19 @@ test.describe('explore services page', () => {
       // Only the first title is visible
       await expect(page.getByText('mimir-ingester').nth(0)).toBeVisible();
       await expect(page.getByText('mimir-ingester').nth(1)).not.toBeVisible();
-      await expect(page.getByText('of 4')).toBeVisible();
     });
 
     test('should filter service labels on exact search', async ({ page }) => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
-      await explorePage.servicesSearch.pressSequentially('mimir-ingester');
-      // Volume can differ, scroll down so all of the panels are loaded
-      await explorePage.scrollToBottom();
+      await explorePage.servicesSearch.pressSequentially('mimir-i');
+      await expect(page.getByRole('listbox')).toBeVisible();
+      await page.getByRole('option', { name: /Use custom value/ }).click();
+
       // service name should be in time series panel
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
       // service name should also be in logs panel, just not visible to the user
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(1)).toBeVisible();
-
-      // Exit out of the dropdown
-      await page.keyboard.press('Escape');
-      // The matched string should exist in the search dropdown
-      await expect(page.getByText('mimir-ingester').nth(0)).toBeVisible();
-      // And the panel title
-      await expect(page.getByText('mimir-ingester').nth(1)).toBeVisible();
-      // And the logs panel title should be hidden
-      await expect(page.getByText('mimir-ingester').nth(2)).not.toBeVisible();
-      await expect(page.getByText('of 1')).toBeVisible();
     });
 
     test('should filter service labels on partial string', async ({ page }) => {
@@ -166,6 +159,8 @@ test.describe('explore services page', () => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('imi');
+      await expect(page.getByRole('listbox')).toBeVisible();
+      await page.getByRole('option', { name: /Use custom value/ }).click();
       // service name should be in time series panel
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
       // service name should also be in logs panel, just not visible to the user
@@ -176,7 +171,6 @@ test.describe('explore services page', () => {
       // Only the first title is visible
       await expect(page.getByText('mimir-ingester').nth(0)).toBeVisible();
       await expect(page.getByText('mimir-ingester').nth(1)).not.toBeVisible();
-      await expect(page.getByText('of 4')).toBeVisible();
     });
 
     test('should select a service label value and navigate to log view', async ({ page }) => {
@@ -190,7 +184,8 @@ test.describe('explore services page', () => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-distributor');
-      await page.keyboard.press('Escape');
+      await expect(page.getByRole('listbox')).toBeVisible();
+      await page.getByRole('option', { name: /Use custom value/ }).click();
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
       await expect(page.getByText('of 1')).toBeVisible();
@@ -278,6 +273,8 @@ test.describe('explore services page', () => {
       // Filter results for tempo-distributor
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-d');
+      await expect(page.getByRole('listbox')).toBeVisible();
+      await page.getByRole('option', { name: /Use custom value/ }).click();
 
       const tempoDistributorPanelHeader = explorePage.getPanelHeaderLocator();
       const tempoDistributorIncludeBtn = tempoDistributorPanelHeader.getByTestId('data-testid button-filter-include');
@@ -666,9 +663,11 @@ test.describe('explore services page', () => {
 
         // Assert results have loaded before we search or we'll cancel the ongoing volume query
         await expect(page.getByText('of 6')).toBeVisible();
-        // Search for "gateway"
-        await page.getByTestId(testIds.index.searchLabelValueInput).fill('Gate');
-        await page.getByTestId(testIds.index.searchLabelValueInput).press('Escape');
+        // Search for "gateway" (same Combobox pattern as service tab)
+        await explorePage.servicesSearch.click();
+        await explorePage.servicesSearch.fill('Gate');
+        await expect(page.getByRole('listbox')).toBeVisible();
+        await page.getByRole('option', { name: /Use custom value/ }).click();
 
         // Asser this filters down to only one result
         await expect(page.getByTestId(testIds.index.showLogsButton)).toHaveCount(1);

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -44,7 +44,7 @@ test.describe('explore services page', () => {
       // Select nginx, as it has the lowest volume, and should otherwise show up last
       await explorePage.servicesSearch.pressSequentially('^nginx$');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
 
       // Assert the first is nginx, or we might click before it's done loading
       await expect(explorePage.getPanelHeaderLocator().first()).toHaveText('nginxIncludeShow logs');
@@ -112,7 +112,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('mimir');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
 
@@ -134,7 +134,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('mimir-i');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
 
       // service name should be in time series panel
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
@@ -148,7 +148,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('imi');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
       // service name should be in time series panel
       await expect(page.getByTestId('data-testid Panel header mimir-ingester').nth(0)).toBeVisible();
       // service name should also be in logs panel, just not visible to the user
@@ -172,7 +172,7 @@ test.describe('explore services page', () => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-d');
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
 
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
@@ -238,7 +238,7 @@ test.describe('explore services page', () => {
       // Filter results for tempo-ingester
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-i');
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
 
       const tempoIngesterPanelHeader = explorePage.getPanelHeaderLocator().filter({
         has: page.getByRole('heading', { name: 'tempo-ingester' }),
@@ -269,7 +269,7 @@ test.describe('explore services page', () => {
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-d');
       await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Filter values by/ }).click();
+      await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
 
       const tempoDistributorPanelHeader = explorePage.getPanelHeaderLocator().filter({
         has: page.getByRole('heading', { name: 'tempo-distributor' }),
@@ -666,7 +666,7 @@ test.describe('explore services page', () => {
         await explorePage.servicesSearch.click();
         await explorePage.servicesSearch.fill('Gate');
         await expect(page.getByRole('listbox')).toBeVisible();
-        await page.getByRole('option', { name: /Filter values by/ }).click();
+        await page.getByRole('option').filter({ hasText: E2EComboboxStrings.customValueOptionHasText }).first().click();
 
         // Asser this filters down to only one result
         await expect(page.getByTestId(testIds.index.showLogsButton)).toHaveCount(1);

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -57,12 +57,6 @@ test.describe('explore services page', () => {
       // Click on nav to return to service selection
       await page.getByRole('link', { name: 'Logs' }).first().click();
 
-      // Conditional needed as the behavior is different depending on the Grafana version
-      if ((await explorePage.getPanelHeaderLocator().first().textContent()) !== 'nginxRemove') {
-        // Clear the existing search filter added above
-        await page.getByLabel('Clear value').click();
-      }
-
       // Assert there is more then one result now
       await expect(explorePage.getPanelHeaderLocator().nth(1)).toBeVisible();
 

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -61,8 +61,8 @@ test.describe('explore services page', () => {
       await expect(explorePage.getPanelHeaderLocator().first()).toHaveText('nginxRemove');
       await explorePage.servicesSearch.click();
 
-      // assert the first element is nginx now
-      await expect(firstResult).toHaveText('^nginx$');
+      // assert the first element has nginx
+      await expect(firstResult).toHaveText(/^(nginx|\^nginx\$)$/);
     });
 
     test.describe('default labels', () => {

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -184,8 +184,7 @@ test.describe('explore services page', () => {
       await explorePage.gotoServices();
       await explorePage.servicesSearch.click();
       await explorePage.servicesSearch.pressSequentially('tempo-distributor');
-      await expect(page.getByRole('listbox')).toBeVisible();
-      await page.getByRole('option', { name: /Use custom value/ }).click();
+
       // Volume can differ, scroll down so all of the panels are loaded
       await explorePage.scrollToBottom();
       await expect(page.getByText('of 1')).toBeVisible();
@@ -249,17 +248,24 @@ test.describe('explore services page', () => {
 
       // Filter results for tempo-ingester
       await explorePage.servicesSearch.click();
-      await explorePage.servicesSearch.pressSequentially('tempo-ingester');
+      await explorePage.servicesSearch.pressSequentially('tempo-i');
+      await page.getByRole('option', { name: /Use custom value/ }).click();
 
-      const tempoIngesterPanelHeader = explorePage.getPanelHeaderLocator();
-      const tempoIngesterIncludeBtn = tempoIngesterPanelHeader.getByTestId('data-testid button-filter-include');
+      const tempoIngesterPanelHeader = explorePage.getPanelHeaderLocator().filter({
+        has: page.getByRole('heading', { name: 'tempo-ingester' }),
+      });
+      const tempoIngesterIncludeBtn = tempoIngesterPanelHeader.getByTestId(
+        testIds.exploreServiceDetails.buttonFilterInclude
+      );
       await expect(tempoIngesterIncludeBtn).toHaveCount(1);
+      // Show logs button should be disabled until a filter is added
+      await expect(showLogsHeaderBtn).toBeDisabled();
       await page.keyboard.press('Escape');
 
       // Assert the portal closed
       await expect(page.getByRole('listbox')).not.toBeVisible();
 
-      // Assert the button is disabled
+      // Assert heading is visible
       await expect(page.getByRole('heading', { name: 'tempo-ingester' })).toBeVisible();
 
       // add positive include filter without navigating
@@ -276,8 +282,12 @@ test.describe('explore services page', () => {
       await expect(page.getByRole('listbox')).toBeVisible();
       await page.getByRole('option', { name: /Use custom value/ }).click();
 
-      const tempoDistributorPanelHeader = explorePage.getPanelHeaderLocator();
-      const tempoDistributorIncludeBtn = tempoDistributorPanelHeader.getByTestId('data-testid button-filter-include');
+      const tempoDistributorPanelHeader = explorePage.getPanelHeaderLocator().filter({
+        has: page.getByRole('heading', { name: 'tempo-distributor' }),
+      });
+      const tempoDistributorIncludeBtn = tempoDistributorPanelHeader.getByTestId(
+        testIds.exploreServiceDetails.buttonFilterInclude
+      );
       await expect(tempoDistributorIncludeBtn).toHaveCount(1);
       await page.keyboard.press('Escape');
 
@@ -463,7 +473,10 @@ test.describe('explore services page', () => {
       test.describe('navigation', () => {
         test('user can use browser history to navigate through tabs', async ({ page }) => {
           const addNewTab = page.getByTestId(testIds.index.addNewLabelTab);
-          const selectNewLabelSelect = page.locator('[role="tooltip"]');
+          // TabPopoverScene: popover is role="tooltip" with an input placeholder "Search labels"
+          const addLabelPopover = page.getByRole('tooltip').filter({
+            has: page.getByPlaceholder('Search labels'),
+          });
           const newNamespaceTabLoc = page.getByTestId('data-testid Tab namespace');
           const newLevelTabLoc = page.getByTestId('data-testid Tab level');
           const serviceTabLoc = page.getByTestId('data-testid Tab service');
@@ -478,7 +491,7 @@ test.describe('explore services page', () => {
           await addNewTab.click();
 
           // Dropdown should be open
-          await expect(selectNewLabelSelect).toContainText('Search labels');
+          await expect(addLabelPopover).toBeVisible();
 
           // Add "namespace" as a new tab
           await page.getByText('namespace', { exact: true }).click();
@@ -488,7 +501,7 @@ test.describe('explore services page', () => {
           await addNewTab.click();
 
           // Dropdown should be open
-          await expect(selectNewLabelSelect).toContainText('Search labels');
+          await expect(addLabelPopover).toBeVisible();
           await page.getByRole('option', { name: 'level' }).click();
           // await page.getByText(/level/, { exact: true }).click();
 
@@ -652,9 +665,11 @@ test.describe('explore services page', () => {
         await expect(addNewTab).toHaveCount(1);
         await addNewTab.click();
 
-        // Dropdown should be open
-        const selectNewLabelSelect = page.locator('[role="tooltip"]');
-        await expect(selectNewLabelSelect).toContainText('Search labels');
+        // Dropdown should be open (TabPopoverScene: tooltip + Search labels placeholder)
+        const addLabelPopover = page.getByRole('tooltip').filter({
+          has: page.getByPlaceholder('Search labels'),
+        });
+        await expect(addLabelPopover).toBeVisible();
 
         // Add "namespace" as a new tab
         await page.getByText('namespace', { exact: true }).click();

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -462,10 +462,7 @@ test.describe('explore services page', () => {
       test.describe('navigation', () => {
         test('user can use browser history to navigate through tabs', async ({ page }) => {
           const addNewTab = page.getByTestId(testIds.index.addNewLabelTab);
-          // TabPopoverScene: Grafana Popover content uses role="tooltip"; Combobox input has placeholder "Search labels"
-          const addLabelPopover = page.getByRole('tooltip').filter({
-            has: page.getByPlaceholder('Search labels'),
-          });
+          const selectNewLabelSelect = page.locator('[role="tooltip"]');
           const newNamespaceTabLoc = page.getByTestId('data-testid Tab namespace');
           const newLevelTabLoc = page.getByTestId('data-testid Tab level');
           const serviceTabLoc = page.getByTestId('data-testid Tab service');
@@ -480,17 +477,17 @@ test.describe('explore services page', () => {
           await addNewTab.click();
 
           // Dropdown should be open
-          await expect(addLabelPopover).toBeVisible();
+          await expect(selectNewLabelSelect).toContainText('Search labels');
 
           // Add "namespace" as a new tab
-          await page.getByRole('option', { name: 'namespace', exact: true }).click();
+          await page.getByText('namespace', { exact: true }).click();
           await expect(newNamespaceTabLoc).toHaveCount(1);
 
           // Click "New" tab
           await addNewTab.click();
 
           // Dropdown should be open
-          await expect(addLabelPopover).toBeVisible();
+          await expect(selectNewLabelSelect).toContainText('Search labels');
           await page.getByRole('option', { name: 'level' }).click();
           // await page.getByText(/level/, { exact: true }).click();
 
@@ -654,14 +651,12 @@ test.describe('explore services page', () => {
         await expect(addNewTab).toHaveCount(1);
         await addNewTab.click();
 
-        // Dropdown should be open (TabPopoverScene: tooltip + Combobox placeholder "Search labels")
-        const addLabelPopover = page.getByRole('tooltip').filter({
-          has: page.getByPlaceholder('Search labels'),
-        });
-        await expect(addLabelPopover).toBeVisible();
+        // Dropdown should be open
+        const selectNewLabelSelect = page.locator('[role="tooltip"]');
+        await expect(selectNewLabelSelect).toContainText('Search labels');
 
         // Add "namespace" as a new tab
-        await page.getByRole('option', { name: 'namespace', exact: true }).click();
+        await page.getByText('namespace', { exact: true }).click();
         const newNamespaceTabLoc = page.getByTestId('data-testid Tab namespace');
         await expect(newNamespaceTabLoc).toHaveCount(1);
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -549,8 +549,8 @@ test.describe('explore services breakdown page', () => {
     });
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the tenant field might not be visible
-    await page.getByText('FieldAll').click();
+    // Use the dropdown since the tenant field might not be visible (label + value no longer one "FieldAll" text node)
+    await page.getByLabel('Field', { exact: true }).click();
     await page.keyboard.type('tenan');
     await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
@@ -1946,8 +1946,8 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the tenant field might not be visible
-    await page.getByText('FieldAll').click();
+    // Use the dropdown since the tenant field might not be visible (label + value no longer one "FieldAll" text node)
+    await page.getByLabel('Field', { exact: true }).click();
     await page.keyboard.type('caller');
     await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
@@ -1969,8 +1969,8 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.goToLabelsTab();
 
-    // Use the dropdown since the tenant field might not be visible
-    await page.getByText('LabelAll').click();
+    // Use the dropdown since the tenant field might not be visible (label + value no longer one "LabelAll" text node)
+    await page.getByLabel('Label', { exact: true }).click();
     await page.keyboard.type('detected');
     await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -538,10 +538,10 @@ test.describe('explore services breakdown page', () => {
     });
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the tenant field might not be visible
-    await page.getByText('FieldAll').click();
-    await page.keyboard.type('tenan');
-    await page.keyboard.press('Enter');
+    // Fields tab field search combobox search for tenant since it might not be visible
+    await page.getByTestId('input-wrapper').getByRole('combobox').click();
+    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).fill('tenan');
+    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).press('Enter');
     await explorePage.assertNotLoading();
 
     // Assert loading is done and panels are showing
@@ -1148,24 +1148,29 @@ test.describe('explore services breakdown page', () => {
 
     // Show the popover
     await bytesIncludeButton.click();
-    const popover = page.getByRole('tooltip');
-    await expect(popover).toHaveCount(1);
+    // Popover content is portaled; match the numeric filter tooltip by a unique child (not the first tooltip on the page).
+    const popover = page.getByRole('tooltip').filter({
+      has: page.getByTestId(testIds.breakdowns.common.filterNumericPopover.submitButton),
+    });
+    await expect(popover).toBeVisible();
 
-    // Popover copy assertions
+    // Popover copy assertions (Combobox selected label is the input value, not text content)
     await expect(
-      popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputGreaterThanInclusive)
-    ).toHaveText('Greater than');
-    await expect(popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive)).toHaveText(
-      'Less than'
-    );
+      popover
+        .getByTestId(testIds.breakdowns.common.filterNumericPopover.inputGreaterThanInclusive)
+        .getByRole('combobox')
+    ).toHaveValue('Greater than');
+    await expect(
+      popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive).getByRole('combobox')
+    ).toHaveValue('Less than');
 
-    // Bytes should be default unit
-    await expect(popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputGreaterThanUnit)).toHaveText(
-      'UnitB'
-    );
-    await expect(popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanUnit)).toHaveText(
-      'UnitB'
-    );
+    // Bytes should be default unit (B) on the unit Combobox inputs
+    await expect(
+      popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputGreaterThanUnit).getByRole('combobox')
+    ).toHaveValue('B');
+    await expect(
+      popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanUnit).getByRole('combobox')
+    ).toHaveValue('B');
 
     // Add button should be disabled
     await expect(popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.submitButton)).toBeDisabled();
@@ -1188,14 +1193,13 @@ test.describe('explore services breakdown page', () => {
     await popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThan).pressSequentially('2');
 
     // Open unit "select"
-    await popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanUnit).locator('svg').click();
-
-    // select kilobytes
     await popover
       .getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanUnit)
-      .getByRole('listbox')
-      .getByText('KB', { exact: true })
+      .getByRole('combobox')
       .click();
+
+    // select kilobytes (unit menu is portaled; not under the Field test id subtree)
+    await page.getByRole('option', { name: 'KB', exact: true }).click();
 
     // Make inclusive
     await popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive).click();
@@ -1257,16 +1261,21 @@ test.describe('explore services breakdown page', () => {
 
     // Show the popover
     await bytesIncludeButton.click();
-    const popover = page.getByRole('tooltip');
-    await expect(popover).toHaveCount(1);
+    // Popover content is portaled; match the numeric filter tooltip by a unique child (not the first tooltip on the page).
+    const popover = page.getByRole('tooltip').filter({
+      has: page.getByTestId(testIds.breakdowns.common.filterNumericPopover.submitButton),
+    });
+    await expect(popover).toBeVisible();
 
-    // Popover copy assertions
+    // Popover copy assertions (Combobox selected label is the input value, not text content)
     await expect(
-      popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputGreaterThanInclusive)
-    ).toHaveText('Greater than');
-    await expect(popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive)).toHaveText(
-      'Less than'
-    );
+      popover
+        .getByTestId(testIds.breakdowns.common.filterNumericPopover.inputGreaterThanInclusive)
+        .getByRole('combobox')
+    ).toHaveValue('Greater than');
+    await expect(
+      popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive).getByRole('combobox')
+    ).toHaveValue('Less than');
 
     // Add button should be disabled
     await expect(popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.submitButton)).toBeDisabled();
@@ -1920,10 +1929,10 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the tenant field might not be visible
-    await page.getByText('FieldAll').click();
-    await page.keyboard.type('caller');
-    await page.keyboard.press('Enter');
+    // Use the dropdown since the caller field might not be visible
+    await page.getByTestId('input-wrapper').getByRole('combobox').click();
+    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).fill('caller');
+    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).press('Enter');
     await explorePage.assertNotLoading();
 
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(9);
@@ -1944,9 +1953,9 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToLabelsTab();
 
     // Use the dropdown since the tenant field might not be visible
-    await page.getByText('LabelAll').click();
-    await page.keyboard.type('detected');
-    await page.keyboard.press('Enter');
+    await page.getByTestId('input-wrapper').getByRole('combobox').click();
+    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).fill('detected');
+    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).press('Enter');
     await explorePage.assertNotLoading();
 
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(5);

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -21,6 +21,12 @@ const fieldName = 'caller';
 const levelName = 'detected_level';
 const metadataName = 'pod';
 const labelName = 'cluster';
+
+/** Field breakdown panels use the detected field name as Loki query refId (see FieldsAggregatedBreakdownScene). */
+function getFieldBreakdownQuery(queries: LokiQuery[], field: string): LokiQuery | undefined {
+  return queries.find((q) => q.refId === field);
+}
+
 test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
 
@@ -1340,7 +1346,7 @@ test.describe('explore services breakdown page', () => {
       const post = route.request().postDataJSON();
       const queries = post.queries as LokiQuery[];
 
-      if (queries[0].refId === 'logsPanelQuery') {
+      if (queries.some((q) => q.refId === 'logsPanelQuery')) {
         await route.continue();
       } else {
         await route.fulfill({ json: [] });
@@ -1356,19 +1362,21 @@ test.describe('explore services breakdown page', () => {
     // Wait for all panels to finish loading, or we might intercept an ongoing query below
     await expect(page.getByLabel('Panel loading bar')).toHaveCount(0);
 
+    await expect(bytesIncludeButton.getByTestId(testIds.breakdowns.common.filterSelect)).toHaveCount(1);
+
     // Now we'll intercept any further queries, note that the intercept above is still-preventing the actual request so the panels will return with no-data instantly
     await page.route('**/ds/query*', async (route) => {
       const post = route.request().postDataJSON();
       const queries = post.queries as LokiQuery[];
-
-      await expect.poll(() => queries[0].expr).toContain('bytes!=""');
+      const bytesQuery = getFieldBreakdownQuery(queries, 'bytes');
+      if (!bytesQuery?.expr.includes('bytes!=""')) {
+        await route.fulfill({ json: [] });
+        return;
+      }
       numberOfQueries++;
 
       await route.fulfill({ json: [] });
     });
-
-    // assert the filter select is in the document
-    await expect(bytesIncludeButton.getByTestId(testIds.breakdowns.common.filterSelect)).toHaveCount(1);
 
     // Include
     await bytesIncludeButton.getByTestId(testIds.breakdowns.common.filterSelect).click();
@@ -1392,7 +1400,7 @@ test.describe('explore services breakdown page', () => {
       const post = route.request().postDataJSON();
       const queries = post.queries as LokiQuery[];
 
-      if (queries[0].refId === 'logsPanelQuery') {
+      if (queries.some((q) => q.refId === 'logsPanelQuery')) {
         await route.continue();
       } else {
         await route.fulfill({ json: [] });
@@ -1407,19 +1415,22 @@ test.describe('explore services breakdown page', () => {
 
     // Wait for all panels to finish loading, or we might intercept an ongoing query below
     await expect(page.getByLabel('Panel loading bar')).toHaveCount(0);
+
+    await expect(bytesIncludeButton.getByTestId(testIds.breakdowns.common.filterSelect)).toHaveCount(1);
+
     // Now we'll intercept any further queries, note that the intercept above is still-preventing the actual request so the panels will return with no-data instantly
     await page.route('**/ds/query*', async (route) => {
       const post = route.request().postDataJSON();
       const queries = post.queries as LokiQuery[];
-
-      await expect.poll(() => queries[0].expr).toContain('bytes=""');
+      const bytesQuery = getFieldBreakdownQuery(queries, 'bytes');
+      if (!bytesQuery?.expr.includes('bytes=""')) {
+        await route.fulfill({ json: [] });
+        return;
+      }
       numberOfQueries++;
 
       await route.fulfill({ json: [] });
     });
-
-    // assert the filter select is in the document
-    await expect(bytesIncludeButton.getByTestId(testIds.breakdowns.common.filterSelect)).toHaveCount(1);
 
     // Open the dropdown and change from include to exclude
     await expect

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -549,8 +549,8 @@ test.describe('explore services breakdown page', () => {
     });
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the tenant field might not be visible (label + value no longer one "FieldAll" text node)
-    await page.getByLabel('Field', { exact: true }).click();
+    // Use the dropdown since the tenant field might not be visible
+    await page.getByTestId(testIds.breakdowns.labelFieldSearch).click();
     await page.keyboard.type('tenan');
     await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
@@ -1946,8 +1946,8 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the tenant field might not be visible (label + value no longer one "FieldAll" text node)
-    await page.getByLabel('Field', { exact: true }).click();
+    // Use the dropdown since the tenant field might not be visible
+    await page.getByTestId(testIds.breakdowns.labelFieldSearch).click();
     await page.keyboard.type('caller');
     await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
@@ -1970,7 +1970,7 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToLabelsTab();
 
     // Use the dropdown since the tenant field might not be visible (label + value no longer one "LabelAll" text node)
-    await page.getByLabel('Label', { exact: true }).click();
+    await page.getByTestId(testIds.breakdowns.labelFieldSearch).click();
     await page.keyboard.type('detected');
     await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -552,7 +552,7 @@ test.describe('explore services breakdown page', () => {
     // Use the dropdown since the tenant field might not be visible
     await page.getByTestId(testIds.breakdowns.labelFieldSearch).click();
     await page.keyboard.type('tenan');
-    await page.keyboard.press('Enter');
+    await page.getByRole('option', { name: 'tenant', exact: true }).click();
     await explorePage.assertNotLoading();
 
     // Assert loading is done and panels are showing
@@ -1947,9 +1947,7 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToFieldsTab();
 
     // Use the dropdown since the tenant field might not be visible
-    await page.getByTestId(testIds.breakdowns.labelFieldSearch).click();
-    await page.keyboard.type('caller');
-    await page.keyboard.press('Enter');
+    await page.getByLabel(`Select ${fieldName}`).click();
     await explorePage.assertNotLoading();
 
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(9);
@@ -1970,9 +1968,7 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToLabelsTab();
 
     // Use the dropdown since the tenant field might not be visible (label + value no longer one "LabelAll" text node)
-    await page.getByTestId(testIds.breakdowns.labelFieldSearch).click();
-    await page.keyboard.type('detected');
-    await page.keyboard.press('Enter');
+    await page.getByLabel(`Select ${levelName}`).click();
     await explorePage.assertNotLoading();
 
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(5);

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -549,10 +549,10 @@ test.describe('explore services breakdown page', () => {
     });
     await explorePage.goToFieldsTab();
 
-    // Fields tab field search combobox search for tenant since it might not be visible
-    await page.getByTestId('input-wrapper').getByRole('combobox').click();
-    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).fill('tenan');
-    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).press('Enter');
+    // Use the dropdown since the tenant field might not be visible
+    await page.getByText('FieldAll').click();
+    await page.keyboard.type('tenan');
+    await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
 
     // Assert loading is done and panels are showing
@@ -1946,10 +1946,10 @@ test.describe('explore services breakdown page', () => {
 
     await explorePage.goToFieldsTab();
 
-    // Use the dropdown since the caller field might not be visible
-    await page.getByTestId('input-wrapper').getByRole('combobox').click();
-    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).fill('caller');
-    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).press('Enter');
+    // Use the dropdown since the tenant field might not be visible
+    await page.getByText('FieldAll').click();
+    await page.keyboard.type('caller');
+    await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
 
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(9);
@@ -1970,9 +1970,9 @@ test.describe('explore services breakdown page', () => {
     await explorePage.goToLabelsTab();
 
     // Use the dropdown since the tenant field might not be visible
-    await page.getByTestId('input-wrapper').getByRole('combobox').click();
-    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).fill('detected');
-    await page.getByTestId('input-wrapper').getByRole('combobox', { name: 'All' }).press('Enter');
+    await page.getByText('LabelAll').click();
+    await page.keyboard.type('detected');
+    await page.keyboard.press('Enter');
     await explorePage.assertNotLoading();
 
     await expect(explorePage.getAllPanelsLocator()).toHaveCount(5);

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -509,7 +509,7 @@ test.describe('explore services breakdown page', () => {
 
     expect(panelTitles.length).toBeGreaterThan(0);
 
-    await page.getByTestId('data-testid SortBy direction').click();
+    await page.getByTestId(testIds.breakdowns.common.sortByDirection).click();
     // Desc is the default option, this should be a noop
     await page.getByRole('option', { name: 'Desc' }).click();
 
@@ -519,7 +519,7 @@ test.describe('explore services breakdown page', () => {
       expect(await panels.nth(i).getByRole('heading').textContent()).toEqual(panelTitles[i]);
     }
 
-    await page.getByTestId('data-testid SortBy direction').click();
+    await page.getByTestId(testIds.breakdowns.common.sortByDirection).click();
     // Now change the sort order
     await page.getByRole('option', { name: 'Asc' }).click();
 
@@ -567,7 +567,7 @@ test.describe('explore services breakdown page', () => {
 
     expect(panelTitles.length).toBeGreaterThan(0);
 
-    await page.getByTestId('data-testid SortBy direction').click();
+    await page.getByTestId(testIds.breakdowns.common.sortByDirection).click();
     // Desc is the default option, this should be a noop
     await page.getByRole('option', { name: 'Desc' }).click();
 
@@ -577,7 +577,7 @@ test.describe('explore services breakdown page', () => {
       expect(await panels.nth(i).getByRole('heading').textContent()).toEqual(panelTitles[i]);
     }
 
-    await page.getByTestId('data-testid SortBy direction').click();
+    await page.getByTestId(testIds.breakdowns.common.sortByDirection).click();
     // Now change the sort order
     await page.getByRole('option', { name: 'Asc' }).click();
 

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -27,6 +27,11 @@ function getFieldBreakdownQuery(queries: LokiQuery[], field: string): LokiQuery 
   return queries.find((q) => q.refId === field);
 }
 
+/** Sparse empty-field filter rendered as `| bytes=""` (see ExpressionBuilder.test / renderLogQLFieldFilters). */
+function queriesContainBytesEqualEmptyFilter(queries: LokiQuery[]): boolean {
+  return queries.some((q) => q.expr.includes('bytes=""'));
+}
+
 test.describe('explore services breakdown page', () => {
   let explorePage: ExplorePage;
 
@@ -1422,8 +1427,9 @@ test.describe('explore services breakdown page', () => {
     await page.route('**/ds/query*', async (route) => {
       const post = route.request().postDataJSON();
       const queries = post.queries as LokiQuery[];
-      const bytesQuery = getFieldBreakdownQuery(queries, 'bytes');
-      if (!bytesQuery?.expr.includes('bytes=""')) {
+      // After Exclude, the bytes breakdown panel is removed — batches often no longer include refId `bytes`.
+      // The sparse filter still appears on other queries (e.g. logs) that share VAR_FIELDS_EXPR.
+      if (!queriesContainBytesEqualEmptyFilter(queries)) {
         await route.fulfill({ json: [] });
         return;
       }

--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -1213,8 +1213,12 @@ test.describe('explore services breakdown page', () => {
     await page.getByRole('option', { name: 'KB', exact: true }).click();
 
     // Make inclusive
-    await popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive).click();
-    await popover.getByText('Less than or equal').click();
+    await popover
+      .getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive)
+      .getByRole('combobox')
+      .click();
+    // Inclusive operator menu is portaled like the unit menu; options are not under the tooltip subtree.
+    await page.getByRole('option', { name: 'Less than or equal', exact: true }).click();
 
     // Wait for pod query to execute
     const expressionsAfterNumericFilter: string[] = [];
@@ -1309,8 +1313,12 @@ test.describe('explore services breakdown page', () => {
     await popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThan).pressSequentially('5');
 
     // Make inclusive
-    await popover.getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive).click();
-    await popover.getByText('Less than or equal').click();
+    await popover
+      .getByTestId(testIds.breakdowns.common.filterNumericPopover.inputLessThanInclusive)
+      .getByRole('combobox')
+      .click();
+    // Inclusive operator menu is portaled
+    await page.getByRole('option', { name: 'Less than or equal', exact: true }).click();
 
     // Wait for pod query to execute
     const expressionsAfterNumericFilter: string[] = [];

--- a/tests/exploreServicesJsonBreakDown.spec.ts
+++ b/tests/exploreServicesJsonBreakDown.spec.ts
@@ -295,13 +295,17 @@ test.describe('explore nginx-json breakdown pages ', () => {
       // Show metadata node
       await page.getByRole('button', { name: 'Show structured metadata' }).click();
       await expect(page.getByText('Metadata', { exact: true }).first()).toBeVisible();
-      await expect(page.getByText('All levels')).toHaveCount(1);
+      // "All levels" is the MultiCombobox placeholder (not text content); use placeholder, not getByText
+      const levelsFilterPlaceholder = page
+        .getByTestId(testIds.variables.levels.inputWrap)
+        .getByPlaceholder('All levels');
+      await expect(levelsFilterPlaceholder).toHaveCount(1);
       await page
         .getByLabel(/Include log lines containing detected_level=".+"/)
         .first()
         .click();
 
-      await expect(page.getByText('All levels')).toHaveCount(0);
+      await expect(levelsFilterPlaceholder).toHaveCount(0);
       await expect(
         page.getByTestId('data-testid detected_level filter variable').getByText(/debug|error|info|warn/)
       ).toHaveCount(1);
@@ -352,7 +356,7 @@ test.describe('explore nginx-json breakdown pages ', () => {
       await explorePage.goToLogsTab();
       await explorePage.getJsonToggleLocator().click();
       await expect(
-        page.getByTestId('data-testid detected_level filter variable').getByText('All levels')
+        page.getByTestId(testIds.variables.levels.inputWrap).getByPlaceholder('All levels')
       ).toBeVisible();
       await page
         .getByRole('treeitem')
@@ -360,9 +364,9 @@ test.describe('explore nginx-json breakdown pages ', () => {
         .getByRole('button', { name: /INFO|DEBUG|WARN|ERROR/ })
         .first()
         .click();
-      await expect(page.getByTestId('data-testid detected_level filter variable').getByText('All levels')).toHaveCount(
-        0
-      );
+      await expect(
+        page.getByTestId(testIds.variables.levels.inputWrap).getByPlaceholder('All levels')
+      ).toHaveCount(0);
       // Verify something has been added to detected_level variable
       await expect(
         page.getByTestId('data-testid detected_level filter variable').getByRole('button', { name: 'Remove' })

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -274,16 +274,6 @@ export class ExplorePage {
     await main.evaluate((main) => main.scrollTo(0, 0));
   }
 
-  async assertFieldsIndex() {
-    // Assert the fields tab is active
-    expect(await this.page.getByTestId(testIds.exploreServiceDetails.tabFields).getAttribute('aria-selected')).toEqual(
-      'true'
-    );
-    // Assert the field group-by combobox is present (see FieldSelector + testIds.breakdowns.labelFieldSearch)
-    await expect(this.page.getByTestId(testIds.breakdowns.labelFieldSearch)).toHaveCount(1);
-    await expect(this.page.getByTestId(testIds.breakdowns.labelFieldSearch)).toBeVisible();
-  }
-
   async gotoServicesBreakdownOldUrl(serviceName = 'tempo-distributor', from = 'now-1m') {
     await this.page.goto(
       `/a/${pluginJson.id}/explore/service/tempo-distributor/logs?mode=service_details&patterns=[]&var-filters=service_name|=|${serviceName}&var-logsFormat= | logfmt&from=${from}&to=now`
@@ -440,10 +430,12 @@ export class ExplorePage {
     await this.page.keyboard.type(text);
     // Wait for loading to go away
     await expect(this.page.getByText('Loading options...')).toHaveCount(0);
-    // Need to scroll to the bottom of the list
-    await this.page.keyboard.press('ArrowUp');
-    // Select custom value
-    await this.page.getByRole('option', { name: /Filter values by/ }).click();
+    // Custom row is prepended by Combobox; use visible text (default "Use custom value" or i18n "Filter values by")
+    const customValueRow = this.page
+      .getByRole('option')
+      .filter({ hasText: E2EComboboxStrings.customValueOptionHasText });
+    await expect(customValueRow.first()).toBeVisible();
+    await customValueRow.first().click();
     // Close the label name dropdown that opens after adding a value
     await this.page.keyboard.press('Escape');
   }
@@ -558,6 +550,8 @@ export class ExplorePage {
 }
 
 export const E2EComboboxStrings = {
+  /** Substring on the Combobox "create custom value" row (Grafana default vs FieldSelector i18n). */
+  customValueOptionHasText: /Use custom value|Filter values by/i,
   editByKey: (keyName: string) => `Edit filter with key ${keyName}`,
   labels: {
     removeServiceLabel: 'Remove filter with key service_name',

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -276,10 +276,12 @@ export class ExplorePage {
 
   async assertFieldsIndex() {
     // Assert the fields tab is active
-    expect(await this.page.getByTestId('data-testid tab-fields').getAttribute('aria-selected')).toEqual('true');
-    // Assert the field group-by combobox is present (label "Field"; value "All" is not a single "FieldAll" text node)
-    await expect(this.page.getByLabel('Field', { exact: true })).toHaveCount(1);
-    await expect(this.page.getByLabel('Field', { exact: true })).toBeVisible();
+    expect(await this.page.getByTestId(testIds.exploreServiceDetails.tabFields).getAttribute('aria-selected')).toEqual(
+      'true'
+    );
+    // Assert the field group-by combobox is present (see FieldSelector + testIds.breakdowns.labelFieldSearch)
+    await expect(this.page.getByTestId(testIds.breakdowns.labelFieldSearch)).toHaveCount(1);
+    await expect(this.page.getByTestId(testIds.breakdowns.labelFieldSearch)).toBeVisible();
   }
 
   async gotoServicesBreakdownOldUrl(serviceName = 'tempo-distributor', from = 'now-1m') {

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -277,9 +277,9 @@ export class ExplorePage {
   async assertFieldsIndex() {
     // Assert the fields tab is active
     expect(await this.page.getByTestId('data-testid tab-fields').getAttribute('aria-selected')).toEqual('true');
-    // Assert the all option is selected
-    await expect(this.page.getByText('FieldAll')).toHaveCount(1);
-    await expect(this.page.getByText('FieldAll')).toBeVisible();
+    // Assert the field group-by combobox is present (label "Field"; value "All" is not a single "FieldAll" text node)
+    await expect(this.page.getByLabel('Field', { exact: true })).toHaveCount(1);
+    await expect(this.page.getByLabel('Field', { exact: true })).toBeVisible();
   }
 
   async gotoServicesBreakdownOldUrl(serviceName = 'tempo-distributor', from = 'now-1m') {

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -443,7 +443,7 @@ export class ExplorePage {
     // Need to scroll to the bottom of the list
     await this.page.keyboard.press('ArrowUp');
     // Select custom value
-    await this.page.getByRole('option', { name: /Use custom value/ }).click();
+    await this.page.getByRole('option', { name: /Filter values by/ }).click();
     // Close the label name dropdown that opens after adding a value
     await this.page.keyboard.press('Escape');
   }


### PR DESCRIPTION
## Summary 📝

- Resolves ESLint / TypeScript noise across the app: migrates several `Select` usages to `@grafana/ui` `Combobox`, tightens types and test typings, and applies small fixes in `Mousetrap`, `KeybindingSet`, `combineResponses`, `shardQuerySplitting`, and `text.ts` (including replacing an invalid `deprecation` disable with `@typescript-eslint/no-deprecated` for the `execCommand` fallback).
- TabPopoverScene could not be updated at this time and requires changes to grafana/ui https://github.com/grafana/logs-drilldown/issues/1855
- Minor config/test harness updates (`eslint.config.mjs`, `jest-setup.js`) and a locale string touch-up where needed.
- Add spellcheck to lint-staged


## Test 🧪

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] Check select udpate to combobox manually
<img width="374" height="274" alt="Screenshot 2026-04-09 at 1 12 49 PM" src="https://github.com/user-attachments/assets/c6643656-20df-43ae-a9e5-97517821227b" />
<img width="397" height="78" alt="Screenshot 2026-04-09 at 1 12 38 PM" src="https://github.com/user-attachments/assets/91892a7c-5a26-40de-b420-98bf469e0f6b" />
<img width="184" height="119" alt="Screenshot 2026-04-09 at 1 12 17 PM" src="https://github.com/user-attachments/assets/743989bc-6adf-49bf-9b69-4b659d83b57d" />
<img width="508" height="431" alt="Screenshot 2026-04-14 at 7 19 29 PM" src="https://github.com/user-attachments/assets/87c835b3-5578-43cf-b28a-7834a16d6c88" />


