### PR TITLE
chore(i18n): expose all supported languages in plugin.json

### DIFF
--- a/src/i18n/loadResources.ts
+++ b/src/i18n/loadResources.ts
@@ -1,6 +1,26 @@
 import { type ResourceLoader } from '@grafana/i18n';
 
-const SUPPORTED_LANGUAGES = new Set(['en-US']);
+const SUPPORTED_LANGUAGES = new Set([
+  'en-US',
+  'cs-CZ',
+  'de-DE',
+  'es-ES',
+  'fr-FR',
+  'hu-HU',
+  'id-ID',
+  'it-IT',
+  'ja-JP',
+  'ko-KR',
+  'nl-NL',
+  'pl-PL',
+  'pt-BR',
+  'pt-PT',
+  'ru-RU',
+  'sv-SE',
+  'tr-TR',
+  'zh-Hans',
+  'zh-Hant',
+]);
 const FALLBACK_LANGUAGE = 'en-US';
 
 export const loadResources: ResourceLoader = async (language: string) => {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -66,7 +66,27 @@
     }
   },
   "preload": true,
-  "languages": ["en-US"],
+  "languages": [
+    "en-US",
+    "cs-CZ",
+    "de-DE",
+    "es-ES",
+    "fr-FR",
+    "hu-HU",
+    "id-ID",
+    "it-IT",
+    "ja-JP",
+    "ko-KR",
+    "nl-NL",
+    "pl-PL",
+    "pt-BR",
+    "pt-PT",
+    "ru-RU",
+    "sv-SE",
+    "tr-TR",
+    "zh-Hans",
+    "zh-Hant"
+  ],
   "extensions": {
     "addedComponents": [],
     "addedFunctions": [


### PR DESCRIPTION
## Summary

- Expand `languages` in `src/plugin.json` from `["en-US"]` to the 19-locale Grafana canonical set, so Grafana knows which locales this plugin supports and requests the matching bundles at runtime.
- Expand `SUPPORTED_LANGUAGES` in `src/i18n/loadResources.ts` to match. Without this, Grafana would request e.g. `de-DE` but the loader's guard would resolve it back to `en-US` and short-circuit — no translations would ever load.
- No changes needed to `i18next.config.ts` (extraction config for the source language only) or to `crowdin.yml` / Crowdin workflows.

Closes #1824.

Prior art: grafana/metrics-drilldown#1096 made the equivalent change for the sister plugin.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx jest src/i18n/__tests__/loadResources.test.ts` — all 3 tests pass (en-US short-circuit, empty-string short-circuit, unsupported `xx-XX` falls back to `{}`)
- [ ] Manual smoke: set Grafana user language to e.g. `es-ES`, open Logs Drilldown — app loads without console errors; UI remains English until Crowdin lands `src/locales/es-ES/grafana-lokiexplore-app.json`, at which point Spanish strings render.