### PR TITLE
chore(deps): downgrade data and i18n for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "@emotion/css": "11.10.6",
     "@grafana/api-clients": "^13.0.0-22766927077",
     "@grafana/assistant": "0.1.13",
-    "@grafana/data": "^13.0.0",
-    "@grafana/i18n": "^13.0.0",
+    "@grafana/data": "12.4.2",
+    "@grafana/i18n": "12.4.2",
     "@grafana/lezer-logql": "^0.3.0",
     "@grafana/runtime": "12.4.2",
     "@grafana/scenes": "^6.57.0",
@@ -158,9 +158,7 @@
     "qs": "6.14.2",
     "strip-ansi": "6.0.1",
     "tar": "7.5.11",
-    "js-yaml": "4.1.1",
-    "@grafana/data": "13.0.0",
-    "@grafana/schema": "12.4.2"
+    "js-yaml": "4.1.1"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,13 +1735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/data@npm:13.0.0":
-  version: 13.0.0
-  resolution: "@grafana/data@npm:13.0.0"
+"@grafana/data@npm:12.4.2":
+  version: 12.4.2
+  resolution: "@grafana/data@npm:12.4.2"
   dependencies:
     "@braintree/sanitize-url": "npm:7.0.1"
-    "@grafana/i18n": "npm:13.0.0"
-    "@grafana/schema": "npm:13.0.0"
+    "@grafana/i18n": "npm:12.4.2"
+    "@grafana/schema": "npm:12.4.2"
     "@leeoniya/ufuzzy": "npm:1.0.19"
     "@types/d3-interpolate": "npm:^3.0.0"
     "@types/string-hash": "npm:1.1.3"
@@ -1749,7 +1749,7 @@ __metadata:
     d3-interpolate: "npm:3.0.1"
     d3-scale-chromatic: "npm:3.1.0"
     date-fns: "npm:4.1.0"
-    dompurify: "npm:3.3.2"
+    dompurify: "npm:3.3.0"
     eventemitter3: "npm:5.0.1"
     fast_array_intersect: "npm:1.1.0"
     history: "npm:4.10.1"
@@ -1771,7 +1771,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10c0/00275abe72b7ad7d1d742a63075d9f84cd75c2875f24f75d4c8b0f612ea8368ce106289be1044455f2d39c737957737d486ef5da4413ad835cbd3bb4ceda54de
+  checksum: 10c0/783961bd253df95caca7ac53e0b11376e410bbda82c7be412cb3e700574769b4a170de2bf25f3d7ddf3d4fa819f9951199614795a94830de7f79f206ef5e202a
   languageName: node
   linkType: hard
 
@@ -1850,24 +1850,6 @@ __metadata:
   peerDependencies:
     react: ">=18"
   checksum: 10c0/1485c25fded7356f4051b70b74a5b39bb6261a998907ca765dd1e37902d381e204332604f64461b17dbd2bb8acde1cce0263a7ebbc90d68f0494698f12f7fe4f
-  languageName: node
-  linkType: hard
-
-"@grafana/i18n@npm:13.0.0, @grafana/i18n@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "@grafana/i18n@npm:13.0.0"
-  dependencies:
-    "@formatjs/intl-durationformat": "npm:^0.7.0"
-    "@typescript-eslint/utils": "npm:^8.33.1"
-    fast-deep-equal: "npm:^3.1.3"
-    i18next: "npm:^25.0.0"
-    i18next-browser-languagedetector: "npm:^8.0.0"
-    i18next-pseudo: "npm:^2.2.1"
-    micro-memoize: "npm:^4.1.2"
-    react-i18next: "npm:^15.0.0"
-  peerDependencies:
-    react: ">=18"
-  checksum: 10c0/e682b9b46b74261889886cd7bc96152ecc90ff8a03a8057fcd76c93b02ffc821f76ad6349b5a4fc586081c5e1315f357caf36680fa2e573d41894de1daa998cf
   languageName: node
   linkType: hard
 
@@ -9437,9 +9419,9 @@ __metadata:
     "@emotion/css": "npm:11.10.6"
     "@grafana/api-clients": "npm:^13.0.0-22766927077"
     "@grafana/assistant": "npm:0.1.13"
-    "@grafana/data": "npm:^13.0.0"
+    "@grafana/data": "npm:12.4.2"
     "@grafana/eslint-config": "npm:9.0.0"
-    "@grafana/i18n": "npm:^13.0.0"
+    "@grafana/i18n": "npm:12.4.2"
     "@grafana/lezer-logql": "npm:^0.3.0"
     "@grafana/plugin-e2e": "npm:3.3.3"
     "@grafana/plugin-types-bundler": "npm:0.5.0"


### PR DESCRIPTION
The compatibility check is failing a lot as the grafana dependencies get republished this week. This is to unblock ci, but I expect it will switch back to requiring 13.0.1. very soon.