### PR TITLE
fix(combobox): open numeric popover react19, run against react19 dev image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
 
       # Same settings as publish
       run-playwright: ${{ github.event_name == 'pull_request' }} # Run playwright tests for PRs only
-      run-playwright-with-grafana-dependency: '>=11.6 <13.0.0 || >13.0.0'
-      # v7 added the React 19 preview image to the matrix; v4 doesn't have it
-      run-playwright-with-skip-grafana-react-19-preview-image: true
+      run-playwright-with-grafana-dependency: '>=11.6'
       upload-playwright-artifacts: true
       playwright-docker-compose-file: docker-compose.dev.yaml
       playwright-grafana-url: http://localhost:3001/grafana

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,6 +3,6 @@ const PRETTIER_WRITE = 'prettier --write --ignore-path .prettierignore';
 module.exports = {
   'src/**/*.{js,jsx,ts,tsx}': 'pnpm run lint',
   '**/*': ['eslint --fix', 'bash -c tsc-files --noEmit', PRETTIER_WRITE],
-  '!(tests/**/*|src/locales/**/*).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
+  '!(tests/**/*|src/locales/**/*|.github/**/*).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
     'cspell -c cspell.config.json --no-progress --no-summary',
 };

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -257,8 +257,7 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
     // Combobox menus render in a Portal
     const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
 
-    // Close the parent popover on document clicks (replaces ClickOutsideWrapper after Combobox portal change in PR #1845).
-    // Defer registration so the same user gesture that opened the popover cannot immediately toggle it closed.
+    // Close the parent popover on document clicks replaces ClickOutsideWrapper
     useEffect(() => {
       if (!comboboxMenuContainer) {
         return;
@@ -275,6 +274,7 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
             return;
           }
         }
+        // Skip close when the click is on Grafana Combobox
         if (isEventTargetInsideGrafanaComboboxMenu(event.target)) {
           return;
         }

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -262,15 +262,13 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
       if (!comboboxMenuContainer) {
         return;
       }
-      let onDocumentClick: ((event: MouseEvent) => void) | undefined;
-
-      onDocumentClick = (event: MouseEvent) => {
+      const onDocumentClick = (event: MouseEvent) => {
         if (!(event.target instanceof Node)) {
           return;
         }
         // Skip close when the click is on the filter button group
         if (event.target instanceof Element) {
-          if (event.target.closest(`[data-testid*="${'filter-button-group'}"]`)) {
+          if (event.target.closest(`[data-testid="${testIds.breakdowns.common.filterButtonGroup}"]`)) {
             return;
           }
         }
@@ -285,9 +283,7 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
       document.addEventListener('click', onDocumentClick, false);
 
       return () => {
-        if (onDocumentClick) {
-          document.removeEventListener('click', onDocumentClick, false);
-        }
+        document.removeEventListener('click', onDocumentClick, false);
       };
     }, [comboboxMenuContainer, selectLabelActionScene]);
 

--- a/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/NumericFilterPopoverScene.tsx
@@ -257,16 +257,24 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
     // Combobox menus render in a Portal
     const [comboboxMenuContainer, setComboboxMenuContainer] = useState<HTMLDivElement | null>(null);
 
-    // Close the parent popover on document clicks
+    // Close the parent popover on document clicks (replaces ClickOutsideWrapper after Combobox portal change in PR #1845).
+    // Defer registration so the same user gesture that opened the popover cannot immediately toggle it closed.
     useEffect(() => {
       if (!comboboxMenuContainer) {
         return;
       }
-      const onDocumentClick = (event: MouseEvent) => {
+      let onDocumentClick: ((event: MouseEvent) => void) | undefined;
+
+      onDocumentClick = (event: MouseEvent) => {
         if (!(event.target instanceof Node)) {
           return;
         }
-        // Skip close when the click is on Grafana Combobox
+        // Skip close when the click is on the filter button group
+        if (event.target instanceof Element) {
+          if (event.target.closest(`[data-testid*="${'filter-button-group'}"]`)) {
+            return;
+          }
+        }
         if (isEventTargetInsideGrafanaComboboxMenu(event.target)) {
           return;
         }
@@ -275,7 +283,12 @@ export class NumericFilterPopoverScene extends SceneObjectBase<NumericFilterPopo
         }
       };
       document.addEventListener('click', onDocumentClick, false);
-      return () => document.removeEventListener('click', onDocumentClick, false);
+
+      return () => {
+        if (onDocumentClick) {
+          document.removeEventListener('click', onDocumentClick, false);
+        }
+      };
     }, [comboboxMenuContainer, selectLabelActionScene]);
 
     const comboboxPortalProps = { portalContainer: comboboxMenuContainer ?? undefined };


### PR DESCRIPTION
## Summary 📝

- **`NumericFilterPopoverScene`:** Tighten the document `click` listener that closes the parent popover so clicks on the breakdown **filter button group** (`data-testid` …`filter-button-group`) are ignored—avoids the popover closing as soon as you use the **Add to filter** trigger after the Combobox portal work. Cleanup now removes the same handler reference reliably.
- **`lint-staged`:** Extend the cspell glob negation with **`.github/**/*`** so workflow YAML under `.github` is not spellchecked on pre-commit (fewer false positives on pins, comments, etc.).
- **`.github/workflows/ci.yml`:** Simplify shared CI inputs for the Playwright job—**`run-playwright-with-grafana-dependency: '>=11.6'`** and drop the prior skip / narrow range / React 19 preview image flags so the matrix matches the intended **React 19 dev** coverage from the branch commits.

## Test 🧪

- [x] Manually on a PR build: **Fields breakdown** → **Add to filter** → numeric popover stays open when using the header controls and Comboboxes; dismiss still works via outside click / Cancel as before
- [x] Confirm **CI workflow** reflects the new `run-playwright-with-grafana-dependency` value and Playwright still runs for PRs as expected