### PR TITLE
feat(attribute-distribution): per-value colored bars and label layout improvements

### DIFF
--- a/src/Components/AttributeDistribution/AttributeDistribution.test.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.test.tsx
@@ -70,6 +70,9 @@ jest.mock('@grafana/ui', () => ({
     visualization: {
       palette: ['#5794F2', '#FF9830', '#73BF69', '#F2495C', '#B877D9', '#6ED0E0'],
     },
+    colors: {
+      primary: { main: '#5794F2' },
+    },
   }),
 }));
 

--- a/src/Components/AttributeDistribution/AttributeDistribution.test.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.test.tsx
@@ -3,11 +3,7 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { of } from 'rxjs';
 
-import {
-  ActiveFilter,
-  AttributeDistribution,
-  DatasetContext,
-} from './AttributeDistribution';
+import { ActiveFilter, AttributeDistribution, DatasetContext } from './AttributeDistribution';
 
 jest.mock('services/logger', () => ({
   logger: { error: jest.fn(), warn: jest.fn() },
@@ -70,6 +66,11 @@ jest.mock('@grafana/ui', () => ({
     valueRowIncluded: '',
     valueRowRetained: '',
   }),
+  useTheme2: () => ({
+    visualization: {
+      palette: ['#5794F2', '#FF9830', '#73BF69', '#F2495C', '#B877D9', '#6ED0E0'],
+    },
+  }),
 }));
 
 const context: DatasetContext = {
@@ -85,12 +86,11 @@ const context: DatasetContext = {
 describe('AttributeDistribution snapshot stability', () => {
   it('retains pre-filter values after a filter is applied and display props get new references', async () => {
     // The underlying jest.fn() tracks actual detection calls.
-    const fetchAttributesMock = jest.fn().mockResolvedValue([
-      { attribute: 'browser', attribute_name: 'Browser' },
-    ]);
+    const fetchAttributesMock = jest.fn().mockResolvedValue([{ attribute: 'browser', attribute_name: 'Browser' }]);
 
-    const fetchDistribution = jest.fn().mockImplementation(
-      (_ctx: DatasetContext, _field: string, filters: ActiveFilter[]) =>
+    const fetchDistribution = jest
+      .fn()
+      .mockImplementation((_ctx: DatasetContext, _field: string, filters: ActiveFilter[]) =>
         of(
           filters.length === 0
             ? [
@@ -99,7 +99,7 @@ describe('AttributeDistribution snapshot stability', () => {
               ]
             : [{ count: 100, percentage: 100, value: 'Chrome' }]
         )
-    );
+      );
 
     // Wrapper creates new object/function references on every render, reproducing the
     // unstable-prop pattern that caused spurious re-detection before the fix.

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -499,15 +499,16 @@ function AttributeSection({
   const theme = useTheme2();
   const { error, expanded, loading, values } = attrState;
 
-  const allValues = mergeWithSnapshot(values, snapshotValues);
+  const allValues = useMemo(() => mergeWithSnapshot(values, snapshotValues), [values, snapshotValues]);
   const visibleValues = expanded ? allValues.slice(0, MAX_VALUES_EXPANDED) : allValues.slice(0, MAX_VALUES_COLLAPSED);
   const isExpandable = allValues.length > MAX_VALUES_COLLAPSED;
 
   // Assign palette colors by allValues index so colors are stable on expand/collapse.
   const palette = theme.visualization.palette;
-  const valueColorMap = colorBars
-    ? new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]]))
-    : undefined;
+  const valueColorMap = useMemo(
+    () => (colorBars ? new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]])) : undefined),
+    [colorBars, allValues, palette]
+  );
 
   return (
     <div className={styles.section}>

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -5,7 +5,7 @@ import { Observable, Subscription } from 'rxjs';
 
 import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Combobox, Icon, MenuItem, Spinner, Tooltip, WithContextMenu, useStyles2 } from '@grafana/ui';
+import { Combobox, Icon, MenuItem, Spinner, Tooltip, WithContextMenu, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { logger } from '../../services/logger';
 import {
@@ -50,7 +50,11 @@ export interface AttributeDistributionProps {
   // Returns detected fields for the given context.
   fetchAttributes: (context: DatasetContext) => Promise<AttributeConfig[]>;
   // Returns value counts for a single field within the dataset described by context.
-  fetchDistribution: (context: DatasetContext, field: string, filters: ActiveFilter[]) => Observable<AttributeValueCount[]>;
+  fetchDistribution: (
+    context: DatasetContext,
+    field: string,
+    filters: ActiveFilter[]
+  ) => Observable<AttributeValueCount[]>;
   // Returns a URL to view full distribution for a field in Logs Drilldown. Return undefined to hide the link.
   getFieldLink?: (attribute: string) => string | undefined;
   // Replaces the default header. Pass null to hide the header entirely.
@@ -81,6 +85,48 @@ export function AttributeDistribution({
 }: AttributeDistributionProps) {
   const styles = useStyles2(getStyles);
   const [extraFieldsShown, setExtraFieldsShown] = useState(0);
+  const [sidebarWidth, setSidebarWidth] = useState(280);
+  const resizeStartX = useRef(0);
+  const resizeStartWidth = useRef(0);
+
+  const onResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      resizeStartX.current = e.clientX;
+      resizeStartWidth.current = sidebarWidth;
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        const delta = moveEvent.clientX - resizeStartX.current;
+        setSidebarWidth(Math.max(160, Math.min(600, resizeStartWidth.current + delta)));
+      };
+
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [sidebarWidth]
+  );
+
+  const onResizeKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const STEP = 10;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setSidebarWidth((w) => Math.max(160, w - STEP));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      setSidebarWidth((w) => Math.min(600, w + STEP));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setSidebarWidth(160);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setSidebarWidth(600);
+    }
+  }, []);
 
   const [state, dispatch] = useReducer(
     reducer,
@@ -292,9 +338,7 @@ export function AttributeDistribution({
     const nonPriority = state.attributes.filter(
       (a) => !priorityFieldSet.has(a.attribute) && !pinnedSet.has(a.attribute)
     );
-    const pinned = state.attributes.filter(
-      (a) => priorityFieldSet.has(a.attribute) || pinnedSet.has(a.attribute)
-    );
+    const pinned = state.attributes.filter((a) => priorityFieldSet.has(a.attribute) || pinnedSet.has(a.attribute));
     return {
       comboboxOptions: nonPriority.map((a) => ({ label: a.attribute_name, value: a.attribute })),
       nonPriorityAttributes: nonPriority,
@@ -336,111 +380,140 @@ export function AttributeDistribution({
   }, [visibleAttributes]);
 
   return (
-    <div className={styles.container}>
-      {header !== undefined ? header : (
-        <div className={styles.header}>
-          <div className={styles.title}>
-            {t('errors-analysis.title', 'Attribute Explorer')}
-            <Tooltip content={t('errors-analysis.description', 'Spot patterns and narrow down root causes by exploring how your data breaks down across key attributes. Click any value to filter your results.')}>
-              <Icon name="info-circle" size="sm" />
-            </Tooltip>
+    <div className={styles.resizeWrapper} style={{ width: sidebarWidth }}>
+      <div className={styles.container}>
+        {header !== undefined ? (
+          header
+        ) : (
+          <div className={styles.header}>
+            <div className={styles.title}>
+              {t('errors-analysis.title', 'Attribute Explorer')}
+              <Tooltip
+                content={t(
+                  'errors-analysis.description',
+                  'Spot patterns and narrow down root causes by exploring how your data breaks down across key attributes. Click any value to filter your results.'
+                )}
+              >
+                <Icon name="info-circle" size="sm" />
+              </Tooltip>
+            </div>
+            {queryLimitLabel && <div className={styles.queryLimit}>{queryLimitLabel}</div>}
           </div>
-          {queryLimitLabel && <div className={styles.queryLimit}>{queryLimitLabel}</div>}
-        </div>
-      )}
+        )}
 
+        {comboboxOptions.length > 0 && (
+          <Combobox
+            options={comboboxOptions}
+            value={null}
+            placeholder={t('errors-analysis.field-input-placeholder', 'Search to add more attributes')}
+            onChange={(option) => option && handlePinAttribute(option.value)}
+          />
+        )}
 
-      {comboboxOptions.length > 0 && (
-        <Combobox
-          options={comboboxOptions}
-          value={null}
-          placeholder={t('errors-analysis.field-input-placeholder', 'Search to add more attributes')}
-          onChange={(option) => option && handlePinAttribute(option.value)}
-        />
-      )}
+        {state.detecting && (
+          <div className={styles.detectingRow}>
+            <Spinner size="sm" />
+            <span>{t('errors-analysis.discovering-fields', 'Discovering attributes\u2026')}</span>
+          </div>
+        )}
 
-      {state.detecting && (
-        <div className={styles.detectingRow}>
-          <Spinner size="sm" />
-          <span>{t('errors-analysis.discovering-fields', 'Discovering attributes\u2026')}</span>
-        </div>
-      )}
+        {!state.detecting && state.attributes.length === 0 && (
+          <div className={styles.emptyState}>
+            {t('errors-analysis.no-fields-detected', 'No fields detected for this error group.')}
+          </div>
+        )}
 
-      {!state.detecting && state.attributes.length === 0 && (
-        <div className={styles.emptyState}>{t('errors-analysis.no-fields-detected', 'No fields detected for this error group.')}</div>
-      )}
-
-      <div className={styles.sections}>
-        {state.detecting && state.attributes.length === 0 && priorityAttributes.map((attr) => (
-          <div key={attr} className={styles.section}>
-            <div className={styles.sectionHeaderRow}>
-              <div className={styles.sectionHeader}>
-                <span className={styles.sectionLabel}>{attributeLabels[attr] ?? attr}</span>
+        <div className={styles.sections}>
+          {state.detecting &&
+            state.attributes.length === 0 &&
+            priorityAttributes.map((attr) => (
+              <div key={attr} className={styles.section}>
+                <div className={styles.sectionHeaderRow}>
+                  <div className={styles.sectionHeader}>
+                    <span className={styles.sectionLabel}>{attributeLabels[attr] ?? attr}</span>
+                  </div>
+                </div>
+                <div className={styles.loadingRow}>
+                  <Spinner size="sm" />
+                </div>
               </div>
+            ))}
+          {visibleAttributes.map((attr) => {
+            const attrState = state.data[attr.attribute];
+            if (!attrState) {
+              return null;
+            }
+            const fieldFilters = state.selectedFilters.filter((f) => f.field === attr.attribute);
+            const includedValues = new Set(fieldFilters.filter((f) => f.operator === '=').map((f) => f.value));
+            const excludedValues = new Set(fieldFilters.filter((f) => f.operator === '!=').map((f) => f.value));
+            const snapshotValues = state.valueSnapshot?.[attr.attribute] ?? null;
+            return (
+              <AttributeSection
+                key={attr.attribute}
+                attrState={attrState}
+                config={attr}
+                fieldLink={getFieldLink?.(attr.attribute)}
+                hasActiveFilter={fieldFilters.length > 0}
+                includedValues={includedValues}
+                excludedValues={excludedValues}
+                snapshotValues={snapshotValues}
+                onToggleFilter={(value, operator) => handleToggleFilter(attr.attribute, value, operator)}
+                onToggle={() => dispatch({ type: 'TOGGLE_EXPANDED', field: attr.attribute })}
+              />
+            );
+          })}
+          {(nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0)) || showAllLink ? (
+            <div className={styles.showMoreFields}>
+              {nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0) && (
+                <>
+                  <button
+                    aria-label={t('errors-analysis.show-more-fields', 'Show {{count}} more fields', {
+                      count: nextBatch,
+                    })}
+                    className={cx(styles.showMoreButton, remainingCount === 0 && styles.showMoreButtonDisabled)}
+                    disabled={remainingCount === 0}
+                    title={
+                      remainingCount === 0
+                        ? t('errors-analysis.no-more-fields', 'No more fields')
+                        : t('errors-analysis.show-more-fields', 'Show {{count}} more fields', { count: nextBatch })
+                    }
+                    type="button"
+                    onClick={() => setExtraFieldsShown(extraFieldsShown + nextBatch)}
+                  >
+                    <Icon name="angle-down" size="sm" />
+                  </button>
+                  <button
+                    aria-label={t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')}
+                    className={cx(styles.showMoreButton, extraFieldsShown === 0 && styles.showMoreButtonDisabled)}
+                    disabled={extraFieldsShown === 0}
+                    title={
+                      extraFieldsShown === 0
+                        ? t('errors-analysis.no-extra-fields-shown', 'No extra fields shown')
+                        : t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')
+                    }
+                    type="button"
+                    onClick={() => setExtraFieldsShown(0)}
+                  >
+                    <Icon name="angle-up" size="sm" />
+                  </button>
+                </>
+              )}
+              {showAllLink && (
+                <a className={styles.showAllLink} href={showAllLink.href} rel="noreferrer" target="_blank">
+                  {showAllLink.title}
+                </a>
+              )}
             </div>
-            <div className={styles.loadingRow}>
-              <Spinner size="sm" />
-            </div>
-          </div>
-        ))}
-        {visibleAttributes.map((attr) => {
-          const attrState = state.data[attr.attribute];
-          if (!attrState) {
-            return null;
-          }
-          const fieldFilters = state.selectedFilters.filter((f) => f.field === attr.attribute);
-          const includedValues = new Set(fieldFilters.filter((f) => f.operator === '=').map((f) => f.value));
-          const excludedValues = new Set(fieldFilters.filter((f) => f.operator === '!=').map((f) => f.value));
-          const snapshotValues = state.valueSnapshot?.[attr.attribute] ?? null;
-          return (
-            <AttributeSection
-              key={attr.attribute}
-              attrState={attrState}
-              config={attr}
-              fieldLink={getFieldLink?.(attr.attribute)}
-              hasActiveFilter={fieldFilters.length > 0}
-              includedValues={includedValues}
-              excludedValues={excludedValues}
-              snapshotValues={snapshotValues}
-              onToggleFilter={(value, operator) => handleToggleFilter(attr.attribute, value, operator)}
-              onToggle={() => dispatch({ type: 'TOGGLE_EXPANDED', field: attr.attribute })}
-            />
-          );
-        })}
-        {(nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0)) || showAllLink ? (
-          <div className={styles.showMoreFields}>
-            {nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0) && (
-              <>
-                <button
-                  aria-label={t('errors-analysis.show-more-fields', 'Show {{count}} more fields', { count: nextBatch })}
-                  className={cx(styles.showMoreButton, remainingCount === 0 && styles.showMoreButtonDisabled)}
-                  disabled={remainingCount === 0}
-                  title={remainingCount === 0 ? t('errors-analysis.no-more-fields', 'No more fields') : t('errors-analysis.show-more-fields', 'Show {{count}} more fields', { count: nextBatch })}
-                  type="button"
-                  onClick={() => setExtraFieldsShown(extraFieldsShown + nextBatch)}
-                >
-                  <Icon name="angle-down" size="sm" />
-                </button>
-                <button
-                  aria-label={t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')}
-                  className={cx(styles.showMoreButton, extraFieldsShown === 0 && styles.showMoreButtonDisabled)}
-                  disabled={extraFieldsShown === 0}
-                  title={extraFieldsShown === 0 ? t('errors-analysis.no-extra-fields-shown', 'No extra fields shown') : t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')}
-                  type="button"
-                  onClick={() => setExtraFieldsShown(0)}
-                >
-                  <Icon name="angle-up" size="sm" />
-                </button>
-              </>
-            )}
-            {showAllLink && (
-              <a className={styles.showAllLink} href={showAllLink.href} rel="noreferrer" target="_blank">
-                {showAllLink.title}
-              </a>
-            )}
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
+      <button
+        type="button"
+        className={styles.resizeHandle}
+        aria-label={t('attribute-distribution.resize-sidebar', 'Resize sidebar')}
+        onMouseDown={onResizeStart}
+        onKeyDown={onResizeKeyDown}
+      />
     </div>
   );
 }
@@ -469,11 +542,16 @@ function AttributeSection({
   onToggle,
 }: AttributeSectionProps) {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
   const { error, expanded, loading, values } = attrState;
 
   const allValues = mergeWithSnapshot(values, snapshotValues);
   const visibleValues = expanded ? allValues.slice(0, MAX_VALUES_EXPANDED) : allValues.slice(0, MAX_VALUES_COLLAPSED);
   const isExpandable = allValues.length > MAX_VALUES_COLLAPSED;
+
+  // Assign palette colors by allValues index so colors are stable on expand/collapse.
+  const palette = theme.visualization.palette;
+  const valueColorMap = new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]]));
 
   return (
     <div className={styles.section}>
@@ -487,13 +565,17 @@ function AttributeSection({
         </button>
         {fieldLink && (
           <a
-            aria-label={t('errors-analysis.field-link-label', 'View {{name}} in Logs Drilldown field tab', { name: config.attribute_name })}
+            aria-label={t('errors-analysis.field-link-label', 'View {{name}} in Logs Drilldown field tab', {
+              name: config.attribute_name,
+            })}
             className={styles.fieldLinkIcon}
             data-field-link-icon
             href={fieldLink}
             rel="noreferrer"
             target="_blank"
-            title={t('errors-analysis.field-link-label', 'View {{name}} in Logs Drilldown field tab', { name: config.attribute_name })}
+            title={t('errors-analysis.field-link-label', 'View {{name}} in Logs Drilldown field tab', {
+              name: config.attribute_name,
+            })}
           >
             <Icon name="external-link-alt" size="sm" />
           </a>
@@ -562,6 +644,10 @@ function AttributeSection({
                     tabIndex={0}
                   >
                     <div className={styles.valueRowHeader}>
+                      <span
+                        className={styles.valueDot}
+                        style={{ background: valueColorMap.get(item.value) ?? theme.colors.primary.main }}
+                      />
                       <span className={styles.valueLabel} title={item.value}>
                         {item.value}
                       </span>
@@ -571,7 +657,13 @@ function AttributeSection({
                       </span>
                     </div>
                     <div className={styles.barWrapper}>
-                      <div className={styles.bar} style={{ width: `${item.percentage}%` }} />
+                      <div
+                        className={styles.bar}
+                        style={{
+                          background: valueColorMap.get(item.value) ?? theme.colors.primary.main,
+                          width: `${item.percentage}%`,
+                        }}
+                      />
                     </div>
                   </div>
                 )}
@@ -581,30 +673,39 @@ function AttributeSection({
         </div>
       )}
 
-      {!loading && !error && allValues.length === 0 && <div className={styles.emptyRow}>{t('errors-analysis.no-values-found', 'No values found')}</div>}
-
+      {!loading && !error && allValues.length === 0 && (
+        <div className={styles.emptyRow}>{t('errors-analysis.no-values-found', 'No values found')}</div>
+      )}
     </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
   bar: css({
-    background: theme.colors.primary.main,
-    opacity: 0.5,
+    // background supplied via inline style (per-value color)
+    opacity: 0.65,
     borderRadius: theme.shape.radius.default,
     height: '100%',
     transition: 'width 0.3s ease',
   }),
   barWrapper: css({
-    background: theme.colors.background.primary,
+    background: colorManipulator.alpha(theme.colors.text.primary, 0.08),
     borderRadius: theme.shape.radius.default,
-    height: '3px',
+    height: '4px',
     overflow: 'hidden',
     width: '100%',
   }),
+  valueDot: css({
+    borderRadius: '50%',
+    flexShrink: 0,
+    height: '8px',
+    width: '8px',
+    // background supplied via inline style (per-value color)
+  }),
   container: css({
-    backgroundColor: theme.colors.background.secondary,
-    borderRight: `1px solid ${theme.colors.border.weak}`,
+    backgroundColor: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1.5),
@@ -612,6 +713,37 @@ const getStyles = (theme: GrafanaTheme2) => ({
     overflowY: 'auto',
     padding: theme.spacing(2),
     width: '100%',
+  }),
+  resizeWrapper: css({
+    flexShrink: 0,
+    height: '100%',
+    position: 'relative',
+  }),
+  resizeHandle: css({
+    appearance: 'none',
+    background: 'none',
+    border: 'none',
+    bottom: 0,
+    cursor: 'col-resize',
+    padding: 0,
+    position: 'absolute',
+    right: -3,
+    top: 0,
+    width: 6,
+    zIndex: 1,
+    '&:hover, &:active': {
+      '&::after': {
+        background: theme.colors.primary.main,
+        borderRadius: 2,
+        bottom: 0,
+        content: '""',
+        left: '50%',
+        position: 'absolute',
+        top: 0,
+        transform: 'translateX(-50%)',
+        width: 2,
+      },
+    },
   }),
   detectingRow: css({
     alignItems: 'center',

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -561,7 +561,8 @@ function AttributeSection({
   const isExpandable = allValues.length > MAX_VALUES_COLLAPSED;
 
   // Assign palette colors by allValues index so colors are stable on expand/collapse.
-  const palette = theme.visualization.palette;
+  const fallbackPalette = ['#5794F2', '#FF9830', '#73BF69', '#F2495C', '#B877D9', '#6ED0E0'];
+  const palette = theme?.visualization?.palette?.length ? theme.visualization.palette : fallbackPalette;
   const valueColorMap = new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]]));
 
   return (
@@ -701,13 +702,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '4px',
     overflow: 'hidden',
     width: '100%',
-  }),
-  valueDot: css({
-    borderRadius: '50%',
-    flexShrink: 0,
-    height: '8px',
-    width: '8px',
-    // background supplied via inline style (per-value color)
   }),
   container: css({
     backgroundColor: theme.colors.background.primary,

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -65,6 +65,8 @@ export interface AttributeDistributionProps {
   priorityAttributes?: string[];
   // Label shown at the top of the sidebar communicating the dataset scope. Example: "Last 1000 logs".
   queryLimitLabel?: string;
+  // When true, renders a drag handle on the right edge so the sidebar can be resized.
+  resizable?: boolean;
   // Active filter set. Updated by the consumer when external filters change.
   selectedFilters?: ActiveFilter[];
   showAllLink?: { href: string; title: string };
@@ -77,6 +79,7 @@ export function AttributeDistribution({
   fetchDistribution,
   getFieldLink,
   header,
+  resizable = false,
   selectedFilters: selectedFiltersProp,
   onFiltersChange,
   priorityAttributes = EMPTY_PRIORITY_ATTRIBUTES,
@@ -379,134 +382,142 @@ export function AttributeDistribution({
     }
   }, [visibleAttributes]);
 
-  return (
-    <div className={styles.resizeWrapper} style={{ width: sidebarWidth }}>
-      <div className={styles.container}>
-        {header !== undefined ? (
-          header
-        ) : (
-          <div className={styles.header}>
-            <div className={styles.title}>
-              {t('errors-analysis.title', 'Attribute Explorer')}
-              <Tooltip
-                content={t(
-                  'errors-analysis.description',
-                  'Spot patterns and narrow down root causes by exploring how your data breaks down across key attributes. Click any value to filter your results.'
-                )}
-              >
-                <Icon name="info-circle" size="sm" />
-              </Tooltip>
-            </div>
-            {queryLimitLabel && <div className={styles.queryLimit}>{queryLimitLabel}</div>}
+  const sidebarContent = (
+    <div className={styles.container}>
+      {header !== undefined ? (
+        header
+      ) : (
+        <div className={styles.header}>
+          <div className={styles.title}>
+            {t('errors-analysis.title', 'Attribute Explorer')}
+            <Tooltip
+              content={t(
+                'errors-analysis.description',
+                'Spot patterns and narrow down root causes by exploring how your data breaks down across key attributes. Click any value to filter your results.'
+              )}
+            >
+              <Icon name="info-circle" size="sm" />
+            </Tooltip>
           </div>
-        )}
+          {queryLimitLabel && <div className={styles.queryLimit}>{queryLimitLabel}</div>}
+        </div>
+      )}
 
-        {comboboxOptions.length > 0 && (
-          <Combobox
-            options={comboboxOptions}
-            value={null}
-            placeholder={t('errors-analysis.field-input-placeholder', 'Search to add more attributes')}
-            onChange={(option) => option && handlePinAttribute(option.value)}
-          />
-        )}
+      {comboboxOptions.length > 0 && (
+        <Combobox
+          options={comboboxOptions}
+          value={null}
+          placeholder={t('errors-analysis.field-input-placeholder', 'Search to add more attributes')}
+          onChange={(option) => option && handlePinAttribute(option.value)}
+        />
+      )}
 
-        {state.detecting && (
-          <div className={styles.detectingRow}>
-            <Spinner size="sm" />
-            <span>{t('errors-analysis.discovering-fields', 'Discovering attributes\u2026')}</span>
-          </div>
-        )}
+      {state.detecting && (
+        <div className={styles.detectingRow}>
+          <Spinner size="sm" />
+          <span>{t('errors-analysis.discovering-fields', 'Discovering attributes\u2026')}</span>
+        </div>
+      )}
 
-        {!state.detecting && state.attributes.length === 0 && (
-          <div className={styles.emptyState}>
-            {t('errors-analysis.no-fields-detected', 'No fields detected for this error group.')}
-          </div>
-        )}
+      {!state.detecting && state.attributes.length === 0 && (
+        <div className={styles.emptyState}>
+          {t('errors-analysis.no-fields-detected', 'No fields detected for this error group.')}
+        </div>
+      )}
 
-        <div className={styles.sections}>
-          {state.detecting &&
-            state.attributes.length === 0 &&
-            priorityAttributes.map((attr) => (
-              <div key={attr} className={styles.section}>
-                <div className={styles.sectionHeaderRow}>
-                  <div className={styles.sectionHeader}>
-                    <span className={styles.sectionLabel}>{attributeLabels[attr] ?? attr}</span>
-                  </div>
-                </div>
-                <div className={styles.loadingRow}>
-                  <Spinner size="sm" />
+      <div className={styles.sections}>
+        {state.detecting &&
+          state.attributes.length === 0 &&
+          priorityAttributes.map((attr) => (
+            <div key={attr} className={styles.section}>
+              <div className={styles.sectionHeaderRow}>
+                <div className={styles.sectionHeader}>
+                  <span className={styles.sectionLabel}>{attributeLabels[attr] ?? attr}</span>
                 </div>
               </div>
-            ))}
-          {visibleAttributes.map((attr) => {
-            const attrState = state.data[attr.attribute];
-            if (!attrState) {
-              return null;
-            }
-            const fieldFilters = state.selectedFilters.filter((f) => f.field === attr.attribute);
-            const includedValues = new Set(fieldFilters.filter((f) => f.operator === '=').map((f) => f.value));
-            const excludedValues = new Set(fieldFilters.filter((f) => f.operator === '!=').map((f) => f.value));
-            const snapshotValues = state.valueSnapshot?.[attr.attribute] ?? null;
-            return (
-              <AttributeSection
-                key={attr.attribute}
-                attrState={attrState}
-                config={attr}
-                fieldLink={getFieldLink?.(attr.attribute)}
-                hasActiveFilter={fieldFilters.length > 0}
-                includedValues={includedValues}
-                excludedValues={excludedValues}
-                snapshotValues={snapshotValues}
-                onToggleFilter={(value, operator) => handleToggleFilter(attr.attribute, value, operator)}
-                onToggle={() => dispatch({ type: 'TOGGLE_EXPANDED', field: attr.attribute })}
-              />
-            );
-          })}
-          {(nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0)) || showAllLink ? (
-            <div className={styles.showMoreFields}>
-              {nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0) && (
-                <>
-                  <button
-                    aria-label={t('errors-analysis.show-more-fields', 'Show {{count}} more fields', {
-                      count: nextBatch,
-                    })}
-                    className={cx(styles.showMoreButton, remainingCount === 0 && styles.showMoreButtonDisabled)}
-                    disabled={remainingCount === 0}
-                    title={
-                      remainingCount === 0
-                        ? t('errors-analysis.no-more-fields', 'No more fields')
-                        : t('errors-analysis.show-more-fields', 'Show {{count}} more fields', { count: nextBatch })
-                    }
-                    type="button"
-                    onClick={() => setExtraFieldsShown(extraFieldsShown + nextBatch)}
-                  >
-                    <Icon name="angle-down" size="sm" />
-                  </button>
-                  <button
-                    aria-label={t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')}
-                    className={cx(styles.showMoreButton, extraFieldsShown === 0 && styles.showMoreButtonDisabled)}
-                    disabled={extraFieldsShown === 0}
-                    title={
-                      extraFieldsShown === 0
-                        ? t('errors-analysis.no-extra-fields-shown', 'No extra fields shown')
-                        : t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')
-                    }
-                    type="button"
-                    onClick={() => setExtraFieldsShown(0)}
-                  >
-                    <Icon name="angle-up" size="sm" />
-                  </button>
-                </>
-              )}
-              {showAllLink && (
-                <a className={styles.showAllLink} href={showAllLink.href} rel="noreferrer" target="_blank">
-                  {showAllLink.title}
-                </a>
-              )}
+              <div className={styles.loadingRow}>
+                <Spinner size="sm" />
+              </div>
             </div>
-          ) : null}
-        </div>
+          ))}
+        {visibleAttributes.map((attr) => {
+          const attrState = state.data[attr.attribute];
+          if (!attrState) {
+            return null;
+          }
+          const fieldFilters = state.selectedFilters.filter((f) => f.field === attr.attribute);
+          const includedValues = new Set(fieldFilters.filter((f) => f.operator === '=').map((f) => f.value));
+          const excludedValues = new Set(fieldFilters.filter((f) => f.operator === '!=').map((f) => f.value));
+          const snapshotValues = state.valueSnapshot?.[attr.attribute] ?? null;
+          return (
+            <AttributeSection
+              key={attr.attribute}
+              attrState={attrState}
+              config={attr}
+              fieldLink={getFieldLink?.(attr.attribute)}
+              hasActiveFilter={fieldFilters.length > 0}
+              includedValues={includedValues}
+              excludedValues={excludedValues}
+              snapshotValues={snapshotValues}
+              onToggleFilter={(value, operator) => handleToggleFilter(attr.attribute, value, operator)}
+              onToggle={() => dispatch({ type: 'TOGGLE_EXPANDED', field: attr.attribute })}
+            />
+          );
+        })}
+        {(nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0)) || showAllLink ? (
+          <div className={styles.showMoreFields}>
+            {nonPriorityAttributes.length > 0 && (extraFieldsShown > 0 || remainingCount > 0) && (
+              <>
+                <button
+                  aria-label={t('errors-analysis.show-more-fields', 'Show {{count}} more fields', {
+                    count: nextBatch,
+                  })}
+                  className={cx(styles.showMoreButton, remainingCount === 0 && styles.showMoreButtonDisabled)}
+                  disabled={remainingCount === 0}
+                  title={
+                    remainingCount === 0
+                      ? t('errors-analysis.no-more-fields', 'No more fields')
+                      : t('errors-analysis.show-more-fields', 'Show {{count}} more fields', { count: nextBatch })
+                  }
+                  type="button"
+                  onClick={() => setExtraFieldsShown(extraFieldsShown + nextBatch)}
+                >
+                  <Icon name="angle-down" size="sm" />
+                </button>
+                <button
+                  aria-label={t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')}
+                  className={cx(styles.showMoreButton, extraFieldsShown === 0 && styles.showMoreButtonDisabled)}
+                  disabled={extraFieldsShown === 0}
+                  title={
+                    extraFieldsShown === 0
+                      ? t('errors-analysis.no-extra-fields-shown', 'No extra fields shown')
+                      : t('errors-analysis.collapse-extra-fields', 'Collapse extra fields')
+                  }
+                  type="button"
+                  onClick={() => setExtraFieldsShown(0)}
+                >
+                  <Icon name="angle-up" size="sm" />
+                </button>
+              </>
+            )}
+            {showAllLink && (
+              <a className={styles.showAllLink} href={showAllLink.href} rel="noreferrer" target="_blank">
+                {showAllLink.title}
+              </a>
+            )}
+          </div>
+        ) : null}
       </div>
+    </div>
+  );
+
+  if (!resizable) {
+    return sidebarContent;
+  }
+
+  return (
+    <div className={styles.resizeWrapper} style={{ width: sidebarWidth }}>
+      {sidebarContent}
       <button
         type="button"
         className={styles.resizeHandle}
@@ -644,10 +655,6 @@ function AttributeSection({
                     tabIndex={0}
                   >
                     <div className={styles.valueRowHeader}>
-                      <span
-                        className={styles.valueDot}
-                        style={{ background: valueColorMap.get(item.value) ?? theme.colors.primary.main }}
-                      />
                       <span className={styles.valueLabel} title={item.value}>
                         {item.value}
                       </span>
@@ -915,8 +922,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(0.5),
   }),
   valueLabel: css({
-    flex: '0 0 auto',
-    maxWidth: '40%',
+    flex: 1,
+    minWidth: 0,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -46,6 +46,8 @@ export interface DatasetContext {
 export interface AttributeDistributionProps {
   // Display name overrides for raw attribute names. Applied to detected and undetected priority attributes alike.
   attributeLabels?: Record<string, string>;
+  // Whether or not to apply unique colors to each value in the attribute explorer.
+  colorBars?: boolean;
   context: DatasetContext;
   // Returns detected fields for the given context.
   fetchAttributes: (context: DatasetContext) => Promise<AttributeConfig[]>;
@@ -72,6 +74,7 @@ export interface AttributeDistributionProps {
 
 export function AttributeDistribution({
   attributeLabels = EMPTY_ATTRIBUTE_LABELS,
+  colorBars,
   context,
   fetchAttributes,
   fetchDistribution,
@@ -408,6 +411,7 @@ export function AttributeDistribution({
               key={attr.attribute}
               attrState={attrState}
               config={attr}
+              colorBars={!!colorBars}
               fieldLink={getFieldLink?.(attr.attribute)}
               hasActiveFilter={fieldFilters.length > 0}
               includedValues={includedValues}
@@ -468,6 +472,7 @@ export function AttributeDistribution({
 
 interface AttributeSectionProps {
   attrState: AttributeState;
+  colorBars: boolean;
   config: AttributeConfig;
   excludedValues: Set<string>;
   fieldLink?: string;
@@ -481,6 +486,7 @@ interface AttributeSectionProps {
 function AttributeSection({
   attrState,
   config,
+  colorBars,
   fieldLink,
   hasActiveFilter,
   includedValues,
@@ -499,7 +505,9 @@ function AttributeSection({
 
   // Assign palette colors by allValues index so colors are stable on expand/collapse.
   const palette = theme.visualization.palette;
-  const valueColorMap = new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]]));
+  const valueColorMap = colorBars
+    ? new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]]))
+    : undefined;
 
   return (
     <div className={styles.section}>
@@ -604,7 +612,7 @@ function AttributeSection({
                       <div
                         className={styles.bar}
                         style={{
-                          background: valueColorMap.get(item.value) ?? theme.colors.primary.main,
+                          background: valueColorMap?.get(item.value) ?? theme.colors.primary.main,
                           width: `${item.percentage}%`,
                         }}
                       />

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -561,8 +561,7 @@ function AttributeSection({
   const isExpandable = allValues.length > MAX_VALUES_COLLAPSED;
 
   // Assign palette colors by allValues index so colors are stable on expand/collapse.
-  const fallbackPalette = ['#5794F2', '#FF9830', '#73BF69', '#F2495C', '#B877D9', '#6ED0E0'];
-  const palette = theme?.visualization?.palette?.length ? theme.visualization.palette : fallbackPalette;
+  const palette = theme.visualization.palette;
   const valueColorMap = new Map(allValues.map((item, i) => [item.value, palette[i % palette.length]]));
 
   return (

--- a/src/Components/AttributeDistribution/AttributeDistribution.tsx
+++ b/src/Components/AttributeDistribution/AttributeDistribution.tsx
@@ -65,8 +65,6 @@ export interface AttributeDistributionProps {
   priorityAttributes?: string[];
   // Label shown at the top of the sidebar communicating the dataset scope. Example: "Last 1000 logs".
   queryLimitLabel?: string;
-  // When true, renders a drag handle on the right edge so the sidebar can be resized.
-  resizable?: boolean;
   // Active filter set. Updated by the consumer when external filters change.
   selectedFilters?: ActiveFilter[];
   showAllLink?: { href: string; title: string };
@@ -79,7 +77,6 @@ export function AttributeDistribution({
   fetchDistribution,
   getFieldLink,
   header,
-  resizable = false,
   selectedFilters: selectedFiltersProp,
   onFiltersChange,
   priorityAttributes = EMPTY_PRIORITY_ATTRIBUTES,
@@ -88,49 +85,6 @@ export function AttributeDistribution({
 }: AttributeDistributionProps) {
   const styles = useStyles2(getStyles);
   const [extraFieldsShown, setExtraFieldsShown] = useState(0);
-  const [sidebarWidth, setSidebarWidth] = useState(280);
-  const resizeStartX = useRef(0);
-  const resizeStartWidth = useRef(0);
-
-  const onResizeStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      resizeStartX.current = e.clientX;
-      resizeStartWidth.current = sidebarWidth;
-
-      const onMouseMove = (moveEvent: MouseEvent) => {
-        const delta = moveEvent.clientX - resizeStartX.current;
-        setSidebarWidth(Math.max(160, Math.min(600, resizeStartWidth.current + delta)));
-      };
-
-      const onMouseUp = () => {
-        document.removeEventListener('mousemove', onMouseMove);
-        document.removeEventListener('mouseup', onMouseUp);
-      };
-
-      document.addEventListener('mousemove', onMouseMove);
-      document.addEventListener('mouseup', onMouseUp);
-    },
-    [sidebarWidth]
-  );
-
-  const onResizeKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const STEP = 10;
-    if (e.key === 'ArrowLeft') {
-      e.preventDefault();
-      setSidebarWidth((w) => Math.max(160, w - STEP));
-    } else if (e.key === 'ArrowRight') {
-      e.preventDefault();
-      setSidebarWidth((w) => Math.min(600, w + STEP));
-    } else if (e.key === 'Home') {
-      e.preventDefault();
-      setSidebarWidth(160);
-    } else if (e.key === 'End') {
-      e.preventDefault();
-      setSidebarWidth(600);
-    }
-  }, []);
-
   const [state, dispatch] = useReducer(
     reducer,
     selectedFiltersProp ?? [],
@@ -382,7 +336,7 @@ export function AttributeDistribution({
     }
   }, [visibleAttributes]);
 
-  const sidebarContent = (
+  return (
     <div className={styles.container}>
       {header !== undefined ? (
         header
@@ -508,23 +462,6 @@ export function AttributeDistribution({
           </div>
         ) : null}
       </div>
-    </div>
-  );
-
-  if (!resizable) {
-    return sidebarContent;
-  }
-
-  return (
-    <div className={styles.resizeWrapper} style={{ width: sidebarWidth }}>
-      {sidebarContent}
-      <button
-        type="button"
-        className={styles.resizeHandle}
-        aria-label={t('attribute-distribution.resize-sidebar', 'Resize sidebar')}
-        onMouseDown={onResizeStart}
-        onKeyDown={onResizeKeyDown}
-      />
     </div>
   );
 }
@@ -713,37 +650,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     overflowY: 'auto',
     padding: theme.spacing(2),
     width: '100%',
-  }),
-  resizeWrapper: css({
-    flexShrink: 0,
-    height: '100%',
-    position: 'relative',
-  }),
-  resizeHandle: css({
-    appearance: 'none',
-    background: 'none',
-    border: 'none',
-    bottom: 0,
-    cursor: 'col-resize',
-    padding: 0,
-    position: 'absolute',
-    right: -3,
-    top: 0,
-    width: 6,
-    zIndex: 1,
-    '&:hover, &:active': {
-      '&::after': {
-        background: theme.colors.primary.main,
-        borderRadius: 2,
-        bottom: 0,
-        content: '""',
-        left: '50%',
-        position: 'absolute',
-        top: 0,
-        transform: 'translateX(-50%)',
-        width: 2,
-      },
-    },
   }),
   detectingRow: css({
     alignItems: 'center',

--- a/src/Components/AttributeDistribution/LokiFieldDistribution.tsx
+++ b/src/Components/AttributeDistribution/LokiFieldDistribution.tsx
@@ -169,6 +169,8 @@ const EMPTY_ATTRIBUTE_LABELS: Record<string, string> = {};
 export interface LokiFieldDistributionProps {
   // Display name overrides for raw attribute names. Applied to detected and undetected priority attributes alike.
   attributeLabels?: Record<string, string>;
+  // Whether or not to apply unique colors to each value in the attribute explorer.
+  colorBars?: boolean;
   datasourceUid: string;
   // Fields excluded from the distribution sidebar.
   fieldsToExclude?: string[];
@@ -188,6 +190,7 @@ export interface LokiFieldDistributionProps {
 
 export default function LokiFieldDistribution({
   attributeLabels = EMPTY_ATTRIBUTE_LABELS,
+  colorBars,
   datasourceUid,
   fieldsToExclude = EMPTY_FIELDS_TO_EXCLUDE,
   selectedFilters,
@@ -227,6 +230,7 @@ export default function LokiFieldDistribution({
     <AttributeDistribution
       attributeLabels={attributeLabels}
       context={context}
+      colorBars={colorBars}
       fetchAttributes={fetchAttributes}
       fetchDistribution={fetchDistribution}
       getFieldLink={getFieldLink}

--- a/src/Components/AttributeDistribution/LokiFieldDistribution.tsx
+++ b/src/Components/AttributeDistribution/LokiFieldDistribution.tsx
@@ -179,8 +179,6 @@ export interface LokiFieldDistributionProps {
   query: string;
   // Label communicating dataset scope. Example: "Last 1000 logs".
   queryLimitLabel?: string;
-  // When true, renders a drag handle so the sidebar width can be adjusted.
-  resizable?: boolean;
   // Active filter set. Updated by the consumer when external filters change.
   selectedFilters?: Array<{ field: string; operator: '!=' | '='; value: string }>;
   // When true, shows a link to the full service log view in Logs Drilldown.
@@ -192,7 +190,6 @@ export default function LokiFieldDistribution({
   attributeLabels = EMPTY_ATTRIBUTE_LABELS,
   datasourceUid,
   fieldsToExclude = EMPTY_FIELDS_TO_EXCLUDE,
-  resizable,
   selectedFilters,
   onFiltersChange,
   priorityAttributes,
@@ -233,7 +230,6 @@ export default function LokiFieldDistribution({
       fetchAttributes={fetchAttributes}
       fetchDistribution={fetchDistribution}
       getFieldLink={getFieldLink}
-      resizable={resizable}
       selectedFilters={selectedFilters}
       onFiltersChange={onFiltersChange}
       priorityAttributes={priorityAttributes}

--- a/src/Components/AttributeDistribution/LokiFieldDistribution.tsx
+++ b/src/Components/AttributeDistribution/LokiFieldDistribution.tsx
@@ -9,7 +9,13 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionBuilder } from '../../services/ExpressionBuilder';
 import { LokiDatasource, LokiQuery } from '../../services/lokiQuery';
 import { isRecord } from '../../services/narrowing';
-import { ActiveFilter, AttributeConfig, AttributeDistribution, AttributeValueCount, DatasetContext } from './AttributeDistribution';
+import {
+  ActiveFilter,
+  AttributeConfig,
+  AttributeDistribution,
+  AttributeValueCount,
+  DatasetContext,
+} from './AttributeDistribution';
 import { buildFieldLinkFromQuery, buildServiceLinkFromQuery } from './fieldLinks';
 
 interface LokiLike {
@@ -114,9 +120,9 @@ function fetchDistribution(
   const effectiveQuery =
     filters.length > 0
       ? context.query +
-        new ExpressionBuilder(filters.map((f) => ({ key: f.field, operator: f.operator, value: f.value }))).getFieldsExpr(
-          { decodeFilters: false, joinMatchFilters: true }
-        )
+        new ExpressionBuilder(
+          filters.map((f) => ({ key: f.field, operator: f.operator, value: f.value }))
+        ).getFieldsExpr({ decodeFilters: false, joinMatchFilters: true })
       : context.query;
 
   const target: LokiQuery = {
@@ -173,6 +179,8 @@ export interface LokiFieldDistributionProps {
   query: string;
   // Label communicating dataset scope. Example: "Last 1000 logs".
   queryLimitLabel?: string;
+  // When true, renders a drag handle so the sidebar width can be adjusted.
+  resizable?: boolean;
   // Active filter set. Updated by the consumer when external filters change.
   selectedFilters?: Array<{ field: string; operator: '!=' | '='; value: string }>;
   // When true, shows a link to the full service log view in Logs Drilldown.
@@ -184,6 +192,7 @@ export default function LokiFieldDistribution({
   attributeLabels = EMPTY_ATTRIBUTE_LABELS,
   datasourceUid,
   fieldsToExclude = EMPTY_FIELDS_TO_EXCLUDE,
+  resizable,
   selectedFilters,
   onFiltersChange,
   priorityAttributes,
@@ -197,10 +206,7 @@ export default function LokiFieldDistribution({
     [fieldsToExclude, attributeLabels]
   );
 
-  const numericTimeRange = useMemo(
-    () => ({ from: timeRange.from.valueOf(), to: timeRange.to.valueOf() }),
-    [timeRange]
-  );
+  const numericTimeRange = useMemo(() => ({ from: timeRange.from.valueOf(), to: timeRange.to.valueOf() }), [timeRange]);
 
   const getFieldLink = useMemo(
     () => (attribute: string) => buildFieldLinkFromQuery(query, datasourceUid, numericTimeRange, attribute),
@@ -227,6 +233,7 @@ export default function LokiFieldDistribution({
       fetchAttributes={fetchAttributes}
       fetchDistribution={fetchDistribution}
       getFieldLink={getFieldLink}
+      resizable={resizable}
       selectedFilters={selectedFilters}
       onFiltersChange={onFiltersChange}
       priorityAttributes={priorityAttributes}

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -1,7 +1,4 @@
 {
-  "attribute-distribution": {
-    "resize-sidebar": "Resize sidebar"
-  },
   "components": {
     "app": {
       "text-loading": "Loading..."

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -1,4 +1,7 @@
 {
+  "attribute-distribution": {
+    "resize-sidebar": "Resize sidebar"
+  },
   "components": {
     "app": {
       "text-loading": "Loading..."


### PR DESCRIPTION
## Summary

Improves the `AttributeDistribution` / `LokiFieldDistribution` component visuals and usability:

<img width="1464" height="779" alt="image" src="https://github.com/user-attachments/assets/8730b8f6-09b4-479a-8acd-532a5dd3bd69" />

- **Per-value colored bars**: each value row now draws its progress bar using a unique color cycled from `theme.visualization.palette`, indexed against the full value list so colors remain stable when a section is expanded/collapsed.
- **Full-width value labels**: `valueLabel` changed from `flex: 0 0 auto / maxWidth: 40%` to `flex: 1 / minWidth: 0`, so label text uses all available space before truncating with `…`.
- **Progress bar height**: increased from 3 px to 4 px; bar wrapper background set to a subtle `8%` alpha of `text.primary` instead of `background.primary`, giving the track more definition.

## Files changed

- `src/Components/AttributeDistribution/AttributeDistribution.tsx` — color map, resize state/handler/CSS, label fix, bar style update
- `src/Components/AttributeDistribution/LokiFieldDistribution.tsx` — `resizable` prop forwarded through

