### PR TITLE
chore(e2e): combobox selecter getByRole

### DIFF
--- a/tests/exploreServicesBreakDown.spec.ts
+++ b/tests/exploreServicesBreakDown.spec.ts
@@ -715,8 +715,8 @@ test.describe('explore services breakdown page', () => {
     // Go to caller values breakdown
     await page.getByLabel(`Select ${levelName}`).click();
 
-    // Open fields combobox
-    const comboboxLocator = page.getByTestId(testIds.variables.levels.inputWrap);
+    // Open levels combobox
+    const comboboxLocator = page.getByTestId(testIds.variables.levels.inputWrap).getByRole('combobox');
     await comboboxLocator.click();
 
     // Select debug|error


### PR DESCRIPTION
## Summary 📝

- Fixes the E2E test for detected log level selection by targeting the actual nested `combobox` inside the levels filter wrapper.

## Test 🧪

- [x] e2e passes ci