### PR TITLE
fix(LogsPanelScene): set timestamp resolution from viz options

### DIFF
--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -346,6 +346,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
     } else {
       panel
         .setOption('showTime', getBooleanLogOption('showTime', true))
+        .setOption('timestampResolution', getLogOption('timestampResolution', 'ms'))
         .setOption('showControls', true)
         .setOption('controlsStorageKey', LOG_OPTIONS_LOCALSTORAGE_KEY)
         .setOption('onLogOptionsChange', this.handleLogOptionsChange)


### PR DESCRIPTION
Setting a missing option.

### How to test

Set the timestamp resolution to ns, or ms. After refreshing, your selection must be respected.