### PR TITLE
fix(LevelsVariableScene): fix negative values in queries and the displayed value in the combobox

### DIFF
--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -72,12 +72,19 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
         return [];
       }
 
-      const newOptions = response.values.map((value) => ({
-        selected: levelsVar.state.filters.some((filter) => filter.value === value.text),
-        text: value.text,
-        value: value.value ?? value.text,
-        operator: FilterOp.Equal,
-      }));
+      const newOptions = response.values.map((value) => {
+        const existingFilter = levelsVar.state.filters.find((filter) => filter.value === value.text);
+        const operator = levelsVar.state.filters[0]?.operator ?? FilterOp.Equal;
+        return {
+          selected: Boolean(existingFilter),
+          text:
+            existingFilter?.valueLabels?.[0] ??
+            existingFilter?.value ??
+            (operator === FilterOp.Equal ? value.text : `!${value.text}`),
+          value: value.text,
+          operator,
+        };
+      });
       const existingSelectedOptions = this.state.options?.filter(
         (existingOption) =>
           existingOption.selected && !newOptions.some((newOption) => newOption.value === existingOption.value)
@@ -85,7 +92,7 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
       const options = existingSelectedOptions ? [...newOptions, ...existingSelectedOptions] : [...newOptions];
       this.setState({ options });
       return options
-        .map((option) => ({ label: option.text, value: String(option.value ?? option.text) }))
+        .map((option) => ({ label: option.text, value: String(option.value) }))
         .filter((option) => option.label?.includes(typeAhead));
     } catch (err) {
       return [];

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -186,7 +186,9 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
           options={model.getTagValues}
           createCustomValue={true}
           loading={isLoading}
-          value={options?.filter((v) => v.selected).map((v) => String(v.text))}
+          value={options
+            ?.filter((v) => v.selected)
+            .map((option) => ({ label: option.text, value: String(option.value) }))}
           width="auto"
           minWidth={20}
         />

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { AdHocVariableFilter, MetricFindValue } from '@grafana/data';
+import { MetricFindValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   AdHocFilterWithLabels,

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/css';
 import { AdHocVariableFilter, MetricFindValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
+  AdHocFilterWithLabels,
   ControlsLabel,
   SceneComponentProps,
   sceneGraph,
@@ -97,14 +98,14 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
     const levelsVar = getLevelsVariable(this);
     const filterOptions = this.state.options?.filter((opt) => opt.selected);
 
-    const filters: AdHocVariableFilter[] =
+    const filters =
       filterOptions?.map((filterOpt) => {
         const operator = filterOpt.operator ?? FilterOp.Equal;
         const value =
           filterOpt.value !== undefined && filterOpt.value !== ''
             ? String(filterOpt.value)
             : String(filterOpt.text ?? '');
-        const filter: AdHocVariableFilter = {
+        const filter: AdHocFilterWithLabels = {
           key: LEVEL_VARIABLE_VALUE,
           operator,
           value,
@@ -185,7 +186,7 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
           options={model.getTagValues}
           createCustomValue={true}
           loading={isLoading}
-          value={options?.filter((v) => v.selected).map((v) => String(v.value))}
+          value={options?.filter((v) => v.selected).map((v) => String(v.text))}
           width="auto"
           minWidth={20}
         />

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { MetricFindValue } from '@grafana/data';
+import { AdHocVariableFilter, MetricFindValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   ControlsLabel,
@@ -21,7 +21,7 @@ import { testIds } from '../../services/testIds';
 import { getLevelsVariable } from '../../services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from '../../services/variables';
 
-type ChipOption = MetricFindValue & { selected?: boolean };
+type ChipOption = MetricFindValue & { operator?: string; selected?: boolean };
 export interface LevelsVariableSceneState extends SceneObjectState {
   isLoading: boolean;
   options?: ChipOption[];
@@ -52,6 +52,7 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
         selected: true,
         text: filter.valueLabels?.[0] ?? filter.value,
         value: filter.value,
+        operator: filter.operator,
       })),
     });
   }
@@ -74,6 +75,7 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
         selected: levelsVar.state.filters.some((filter) => filter.value === value.text),
         text: value.text,
         value: value.value ?? value.text,
+        operator: FilterOp.Equal,
       }));
       const existingSelectedOptions = this.state.options?.filter(
         (existingOption) =>
@@ -95,14 +97,28 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
     const levelsVar = getLevelsVariable(this);
     const filterOptions = this.state.options?.filter((opt) => opt.selected);
 
-    levelsVar.updateFilters(
-      filterOptions?.map((filterOpt) => ({
-        key: LEVEL_VARIABLE_VALUE,
-        operator: FilterOp.Equal,
-        value: filterOpt.text,
-      })) ?? [],
-      { forcePublish, skipPublish }
-    );
+    const filters: AdHocVariableFilter[] =
+      filterOptions?.map((filterOpt) => {
+        const operator = filterOpt.operator ?? FilterOp.Equal;
+        const value =
+          filterOpt.value !== undefined && filterOpt.value !== ''
+            ? String(filterOpt.value)
+            : String(filterOpt.text ?? '');
+        const filter: AdHocVariableFilter = {
+          key: LEVEL_VARIABLE_VALUE,
+          operator,
+          value,
+        };
+        const displayLabel = filterOpt.text ?? value;
+        if (operator === FilterOp.NotEqual) {
+          filter.valueLabels = [displayLabel.startsWith('!') ? displayLabel : `!${value}`];
+        } else if (displayLabel !== value) {
+          filter.valueLabels = [displayLabel];
+        }
+        return filter;
+      }) ?? [];
+
+    levelsVar.updateFilters(filters, { forcePublish, skipPublish });
   };
 
   onChangeOptions = (options: Array<ComboboxOption<string>>) => {
@@ -116,6 +132,7 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
         selected: true,
         text: option.label ?? option.value,
         value: option.value,
+        operator: FilterOp.Equal,
       }));
 
     this.setState({

--- a/src/Components/IndexScene/LevelsVariableScene.tsx
+++ b/src/Components/IndexScene/LevelsVariableScene.tsx
@@ -74,13 +74,10 @@ export class LevelsVariableScene extends SceneObjectBase<LevelsVariableSceneStat
 
       const newOptions = response.values.map((value) => {
         const existingFilter = levelsVar.state.filters.find((filter) => filter.value === value.text);
-        const operator = levelsVar.state.filters[0]?.operator ?? FilterOp.Equal;
+        const operator = existingFilter?.operator ?? FilterOp.Equal;
         return {
           selected: Boolean(existingFilter),
-          text:
-            existingFilter?.valueLabels?.[0] ??
-            existingFilter?.value ??
-            (operator === FilterOp.Equal ? value.text : `!${value.text}`),
+          text: existingFilter?.valueLabels?.[0] ?? existingFilter?.value ?? value.text,
           value: value.text,
           operator,
         };


### PR DESCRIPTION
Fixed:
- Produced queries: negative level queries were being sent as `level = "!level"` instead of `level != "level"`
- Fixed visible value for negative filters, including the ! symbol
  <img width="177" height="68" alt="imagen" src="https://github.com/user-attachments/assets/64b7ca40-f189-40c2-ab40-d00c8c1636c1" />

Fixes https://github.com/grafana/logs-drilldown/pull/1752#pullrequestreview-4266778713