### PR TITLE
feat(LogsListScene): Allow logs panel to fit the screen height with an option to use full screen size

### DIFF
--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -8,6 +8,7 @@ import { reportInteraction, useChromeHeaderHeight } from '@grafana/runtime';
 import { SceneComponentProps, SceneFlexLayout, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
+import { syncLogsListPanelHeightFromScene } from '../../services/scenes';
 import {
   getCollapsibleFiltersState,
   getJsonParserVariableVisibility,
@@ -69,6 +70,11 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
     reportInteraction('grafana_logs_app_filters_collapse_toggled', {
       collapsed,
     });
+    const indexScene = sceneGraph.getAncestor(this, IndexScene);
+    const contentScene = indexScene.state.contentScene;
+    if (contentScene) {
+      syncLogsListPanelHeightFromScene(contentScene);
+    }
   };
 
   static Component = ({ model }: SceneComponentProps<VariableLayoutScene>) => {

--- a/src/Components/ServiceScene/BreakdownViews.ts
+++ b/src/Components/ServiceScene/BreakdownViews.ts
@@ -118,7 +118,6 @@ function buildLogsListScene() {
       }),
       new SceneFlexItem({
         body: new LogsListScene({}),
-        height: 'calc(100vh - 500px)',
         minHeight: '470px',
       }),
     ],

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 
 import { css } from '@emotion/css';
+import { useResizeObserver } from '@react-aria/utils';
 
 import { LoadingState, PanelData, shallowCompare } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
@@ -101,13 +102,26 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 
   public static Component = ({ model }: SceneComponentProps<LogsListScene>) => {
     const { panel } = model.useState();
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    useResizeObserver({
+      onResize: () => {
+        if (!panel || !wrapperRef.current) {
+          return;
+        }
+        console.log(wrapperRef.current.getBoundingClientRect().y);
+        panel.state.children?.[0].setState({
+          height: `calc(100vh - ${wrapperRef.current.getBoundingClientRect().y + 16}px)`,
+        });
+      },
+      ref: wrapperRef,
+    });
 
     if (!panel) {
       return;
     }
 
     return (
-      <div className={styles.panelWrapper}>
+      <div className={styles.panelWrapper} ref={wrapperRef}>
         <panel.Component model={panel} />
       </div>
     );
@@ -475,7 +489,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     this.logsPanelScene = new LogsPanelScene({ error, errorType, canClearFilters });
     const logsTablePanelNG = getFeatureFlag('logsTablePanelNG');
 
-    const panelHeight = 'calc(100vh - 180px)';
+    const panelHeight = 'calc(100vh - 48px)';
     const children =
       this.state.visualizationType === 'logs'
         ? [
@@ -496,7 +510,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
                 body: logsTablePanelNG
                   ? new LogsTablePanelScene({ error, canClearFilters })
                   : new LogsTableScene({ error, canClearFilters }),
-                height: 'calc(100vh - 220px)',
+                height: panelHeight,
               }),
             ];
 

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -86,6 +86,8 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
 
   private logsPanelScene?: LogsPanelScene = undefined;
 
+  private panelWrapperEl: HTMLDivElement | null = null;
+
   constructor(state: Partial<LogsListSceneState>) {
     super({
       ...state,
@@ -100,18 +102,41 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
+  public setPanelWrapperEl(el: HTMLDivElement | null) {
+    if (el === this.panelWrapperEl) {
+      return;
+    }
+    this.panelWrapperEl = el;
+  }
+
+  public getPanelWrapperEl(): HTMLDivElement | null {
+    return this.panelWrapperEl;
+  }
+
+  public syncPanelHeightFromWrapper = () => {
+    if (!this.state.panel || !this.panelWrapperEl) {
+      return;
+    }
+    this.state.panel.state.children?.[0].setState({
+      height: `calc(100vh - ${this.panelWrapperEl.getBoundingClientRect().y + 16}px)`,
+    });
+  };
+
   public static Component = ({ model }: SceneComponentProps<LogsListScene>) => {
     const { panel } = model.useState();
     const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+    useLayoutEffect(() => {
+      model.setPanelWrapperEl(wrapperRef.current);
+      return () => model.setPanelWrapperEl(null);
+    }, [model, panel]);
+
     useResizeObserver({
       onResize: () => {
-        if (!panel || !wrapperRef.current) {
+        if (!panel) {
           return;
         }
-        console.log(wrapperRef.current.getBoundingClientRect().y);
-        panel.state.children?.[0].setState({
-          height: `calc(100vh - ${wrapperRef.current.getBoundingClientRect().y + 16}px)`,
-        });
+        model.syncPanelHeightFromWrapper();
       },
       ref: wrapperRef,
     });

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -43,6 +43,7 @@ import { isEmptyLogsResult } from 'services/logsFrame';
 import {
   getBooleanLogOption,
   getDisplayedFieldsInStorage,
+  getExpandedLogsView,
   getExplorationPrefixForLabelValue,
   getLogsVisualizationType,
   getLogsVolumeOption,
@@ -117,8 +118,21 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     if (!this.state.panel || !this.panelWrapperEl) {
       return;
     }
+    if (getExpandedLogsView(this)) {
+      this.extendPanelHeight();
+      return;
+    }
     this.state.panel.state.children?.[0].setState({
       height: `calc(100vh - ${this.panelWrapperEl.getBoundingClientRect().y + 16}px)`,
+    });
+  };
+
+  public extendPanelHeight = () => {
+    if (!this.state.panel || !this.panelWrapperEl) {
+      return;
+    }
+    this.state.panel.state.children?.[0].setState({
+      height: `calc(100vh - ${56}px)`,
     });
   };
 

--- a/src/Components/ServiceScene/LogsListScene.tsx
+++ b/src/Components/ServiceScene/LogsListScene.tsx
@@ -1,10 +1,10 @@
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 
 import { css } from '@emotion/css';
 import { useResizeObserver } from '@react-aria/utils';
 
 import { LoadingState, PanelData, shallowCompare } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { locationService, useChromeHeaderHeight } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   SceneComponentProps,
@@ -60,6 +60,7 @@ export interface LogsListSceneState extends SceneObjectState {
   displayedFields: string[];
   error?: string;
   errorType?: ErrorType;
+  headerHeight: number;
   loading?: boolean;
   logsVolumeCollapsedByError?: boolean;
   // Displayed fields set by the otelLogsFormatting feature
@@ -93,6 +94,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
     super({
       ...state,
       displayedFields: [],
+      headerHeight: 48,
       userDisplayedFields: false,
       otelDisplayedFields: [],
       visualizationType: getLogsVisualizationType(),
@@ -122,23 +124,33 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       this.extendPanelHeight();
       return;
     }
+    const offset = this.panelWrapperEl.getBoundingClientRect().y + window.scrollY;
     this.state.panel.state.children?.[0].setState({
-      height: `calc(100vh - ${this.panelWrapperEl.getBoundingClientRect().y + 16}px)`,
+      height: `calc(100vh - ${offset + 16}px)`,
     });
   };
 
   public extendPanelHeight = () => {
-    if (!this.state.panel || !this.panelWrapperEl) {
+    if (!this.state.panel) {
       return;
     }
     this.state.panel.state.children?.[0].setState({
-      height: `calc(100vh - ${56}px)`,
+      height: `calc(100vh - ${this.state.headerHeight + 16}px)`,
     });
   };
 
   public static Component = ({ model }: SceneComponentProps<LogsListScene>) => {
     const { panel } = model.useState();
     const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const height = useChromeHeaderHeight();
+
+    useEffect(() => {
+      if (height) {
+        model.setState({
+          headerHeight: height,
+        });
+      }
+    }, [height, model]);
 
     useLayoutEffect(() => {
       model.setPanelWrapperEl(wrapperRef.current);

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -32,6 +32,7 @@ import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
 import { buildDataQuery, LINE_LIMIT } from 'services/query';
+import { syncLogsListPanelHeightFromScene } from 'services/scenes';
 import { getLogsVolumeOption, setLogsVolumeOption } from 'services/store';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
@@ -134,6 +135,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     }
     this.updateContainerHeight(panel);
     setLogsVolumeOption('collapsed', collapsed ? 'true' : undefined);
+    syncLogsListPanelHeightFromScene(sceneGraph.getAncestor(this, ServiceScene));
   }
 
   private getVizPanel() {

--- a/src/Components/ServiceScene/__mocks__/LogsListScene.tsx
+++ b/src/Components/ServiceScene/__mocks__/LogsListScene.tsx
@@ -15,6 +15,7 @@ export class LogsListScene extends SceneObjectBase<LogsListSceneState> {
       otelDisplayedFields: state.otelDisplayedFields ?? [],
       userDisplayedFields: state.userDisplayedFields ?? false,
       controlsExpanded: false,
+      headerHeight: 48,
       panel: new SceneFlexLayout({
         children: [
           new LogOptionsScene({

--- a/src/Components/Table/LogsHeaderActions.test.tsx
+++ b/src/Components/Table/LogsHeaderActions.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 
 import { LogsPanelHeaderActions } from './LogsHeaderActions';
+import { LineLimitScene } from 'Components/ServiceScene/LineLimitScene';
 import { toggleLogsListPanelSize } from 'services/scenes';
 import { getExpandedLogsView, setExpandedLogsView } from 'services/store';
 
@@ -44,7 +45,13 @@ describe('LogsPanelHeaderActions', () => {
     const lineLimitScene = new MockLineLimitScene({});
     const onChange = jest.fn();
 
-    render(<LogsPanelHeaderActions lineLimitScene={lineLimitScene} onChange={onChange} vizType="logs" />);
+    render(
+      <LogsPanelHeaderActions
+        lineLimitScene={lineLimitScene as unknown as LineLimitScene}
+        onChange={onChange}
+        vizType="logs"
+      />
+    );
 
     expect(screen.getByRole('radio', { name: 'Logs' })).toBeChecked();
     expect(screen.getByRole('radio', { name: 'Table' })).not.toBeChecked();
@@ -58,7 +65,13 @@ describe('LogsPanelHeaderActions', () => {
     const lineLimitScene = new MockLineLimitScene({});
     const onChange = jest.fn();
 
-    render(<LogsPanelHeaderActions lineLimitScene={lineLimitScene} onChange={onChange} vizType="logs" />);
+    render(
+      <LogsPanelHeaderActions
+        lineLimitScene={lineLimitScene as unknown as LineLimitScene}
+        onChange={onChange}
+        vizType="logs"
+      />
+    );
 
     await user.click(screen.getByRole('radio', { name: 'Table' }));
 
@@ -70,7 +83,13 @@ describe('LogsPanelHeaderActions', () => {
     const user = userEvent.setup();
     const lineLimitScene = new MockLineLimitScene({});
 
-    render(<LogsPanelHeaderActions lineLimitScene={lineLimitScene} onChange={jest.fn()} vizType="logs" />);
+    render(
+      <LogsPanelHeaderActions
+        lineLimitScene={lineLimitScene as unknown as LineLimitScene}
+        onChange={jest.fn()}
+        vizType="logs"
+      />
+    );
 
     const expandButton = screen.getAllByRole('button')[0];
     await user.click(expandButton);

--- a/src/Components/Table/LogsHeaderActions.test.tsx
+++ b/src/Components/Table/LogsHeaderActions.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+
+import { LogsPanelHeaderActions } from './LogsHeaderActions';
+import { toggleLogsListPanelSize } from 'services/scenes';
+import { getExpandedLogsView, setExpandedLogsView } from 'services/store';
+
+jest.mock('services/store', () => {
+  const actual = jest.requireActual<typeof import('services/store')>('services/store');
+  return {
+    ...actual,
+    getExpandedLogsView: jest.fn(),
+    setExpandedLogsView: jest.fn(),
+  };
+});
+
+jest.mock('services/scenes', () => {
+  const actual = jest.requireActual<typeof import('services/scenes')>('services/scenes');
+  return {
+    ...actual,
+    toggleLogsListPanelSize: jest.fn(),
+  };
+});
+
+class MockLineLimitScene extends SceneObjectBase<SceneObjectState> {
+  public static Component = () => <div data-testid="line-limit-mock">Line limit</div>;
+}
+
+describe('LogsPanelHeaderActions', () => {
+  const getExpandedLogsViewMock = getExpandedLogsView as jest.MockedFunction<typeof getExpandedLogsView>;
+  const setExpandedLogsViewMock = setExpandedLogsView as jest.MockedFunction<typeof setExpandedLogsView>;
+  const toggleLogsListPanelSizeMock = toggleLogsListPanelSize as jest.MockedFunction<typeof toggleLogsListPanelSize>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getExpandedLogsViewMock.mockReturnValue(false);
+  });
+
+  test('renders expand control, visualization radios, and line limit scene', () => {
+    const lineLimitScene = new MockLineLimitScene({});
+    const onChange = jest.fn();
+
+    render(<LogsPanelHeaderActions lineLimitScene={lineLimitScene} onChange={onChange} vizType="logs" />);
+
+    expect(screen.getByRole('radio', { name: 'Logs' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Table' })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: 'JSON' })).not.toBeChecked();
+    expect(screen.getByTestId('line-limit-mock')).toBeInTheDocument();
+    expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('calls onChange when a different visualization is selected', async () => {
+    const user = userEvent.setup();
+    const lineLimitScene = new MockLineLimitScene({});
+    const onChange = jest.fn();
+
+    render(<LogsPanelHeaderActions lineLimitScene={lineLimitScene} onChange={onChange} vizType="logs" />);
+
+    await user.click(screen.getByRole('radio', { name: 'Table' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('table');
+  });
+
+  test('expand control updates stored expanded state and resizes the logs panel', async () => {
+    const user = userEvent.setup();
+    const lineLimitScene = new MockLineLimitScene({});
+
+    render(<LogsPanelHeaderActions lineLimitScene={lineLimitScene} onChange={jest.fn()} vizType="logs" />);
+
+    const expandButton = screen.getAllByRole('button')[0];
+    await user.click(expandButton);
+
+    expect(setExpandedLogsViewMock).toHaveBeenCalledWith(lineLimitScene, true);
+    expect(toggleLogsListPanelSizeMock).toHaveBeenCalledWith(lineLimitScene, true);
+  });
+});

--- a/src/Components/Table/LogsHeaderActions.tsx
+++ b/src/Components/Table/LogsHeaderActions.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, Icon, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 
 import { LineLimitScene } from '../ServiceScene/LineLimitScene';
@@ -28,6 +29,9 @@ export function LogsPanelHeaderActions({ lineLimitScene, onChange, vizType }: Lo
     setExpandedLogsView(lineLimitScene, newState);
     setLogsExpanded(newState);
     toggleLogsListPanelSize(lineLimitScene, newState);
+    reportInteraction('grafana_logs_app_toggle_logs_size_clicked', {
+      expanded: newState,
+    });
   }, [lineLimitScene]);
 
   return (

--- a/src/Components/Table/LogsHeaderActions.tsx
+++ b/src/Components/Table/LogsHeaderActions.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, Icon, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 
 import { LineLimitScene } from '../ServiceScene/LineLimitScene';
-import { LogsVisualizationType } from 'services/store';
+import { toggleLogsListPanelSize } from 'services/scenes';
+import { getExpandedLogsView, LogsVisualizationType, setExpandedLogsView } from 'services/store';
 
 export interface LogsPanelHeaderActionsProps {
   lineLimitScene: LineLimitScene;
@@ -19,10 +20,31 @@ export interface LogsPanelHeaderActionsProps {
  * Viz toggle and line limit for the logs panel header row.
  */
 export function LogsPanelHeaderActions({ lineLimitScene, onChange, vizType }: LogsPanelHeaderActionsProps) {
+  const [logsExpanded, setLogsExpanded] = useState(getExpandedLogsView(lineLimitScene));
   const styles = useStyles2(getStyles);
+
+  const toggleLogsSize = useCallback(() => {
+    const newState = !getExpandedLogsView(lineLimitScene);
+    toggleLogsListPanelSize(lineLimitScene, newState);
+    setExpandedLogsView(lineLimitScene, newState);
+    setLogsExpanded(newState);
+  }, [lineLimitScene]);
 
   return (
     <div className={styles.toolbar}>
+      <Button
+        size="sm"
+        variant="secondary"
+        fill="outline"
+        onClick={toggleLogsSize}
+        tooltip={
+          logsExpanded
+            ? t('components.service-scene.log-options-buttons-scene.tooltip.condense-logs', 'Condense logs view')
+            : t('components.service-scene.log-options-buttons-scene.tooltip.expand-logs', 'Expand logs view')
+        }
+      >
+        <Icon size="sm" name={logsExpanded ? 'compress-arrows' : 'expand-arrows'} />
+      </Button>
       <RadioButtonGroup
         options={[
           {

--- a/src/Components/Table/LogsHeaderActions.tsx
+++ b/src/Components/Table/LogsHeaderActions.tsx
@@ -25,9 +25,9 @@ export function LogsPanelHeaderActions({ lineLimitScene, onChange, vizType }: Lo
 
   const toggleLogsSize = useCallback(() => {
     const newState = !getExpandedLogsView(lineLimitScene);
-    toggleLogsListPanelSize(lineLimitScene, newState);
     setExpandedLogsView(lineLimitScene, newState);
     setLogsExpanded(newState);
+    toggleLogsListPanelSize(lineLimitScene, newState);
   }, [lineLimitScene]);
 
   return (

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -680,6 +680,8 @@
         "show-original-log-line": "Show original log line",
         "tooltip": {
           "clear-displayed-fields": "Clear displayed fields: {{fields}}",
+          "condense-logs": "Condense logs view",
+          "expand-logs": "Expand logs view",
           "show-default-fields": "Show default fields: {{fields}}"
         }
       },

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -78,6 +78,17 @@ export function findObjectOfType<T extends SceneObject>(
   return null;
 }
 
+/** Recompute logs list panel height from its wrapper after layout changes (e.g. volume or header filters). */
+export function syncLogsListPanelHeightFromScene(root: SceneObject) {
+  const logsListScene = findObjectOfType(root, (scene) => scene instanceof LogsListScene, LogsListScene);
+  if (!logsListScene) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    logsListScene.syncPanelHeightFromWrapper();
+  });
+}
+
 export function getTimePicker(scene: IndexScene) {
   return scene.state.controls?.find((s) => s instanceof SceneTimePicker) as SceneTimePicker;
 }

--- a/src/services/scenes.ts
+++ b/src/services/scenes.ts
@@ -89,6 +89,18 @@ export function syncLogsListPanelHeightFromScene(root: SceneObject) {
   });
 }
 
+export function toggleLogsListPanelSize(root: SceneObject, expanded: boolean) {
+  const logsListScene = findObjectOfType(root, (scene) => scene instanceof LogsListScene, LogsListScene);
+  if (!logsListScene) {
+    return;
+  }
+  if (expanded) {
+    logsListScene.extendPanelHeight();
+  } else {
+    logsListScene.syncPanelHeightFromWrapper();
+  }
+}
+
 export function getTimePicker(scene: IndexScene) {
   return scene.state.controls?.find((s) => s instanceof SceneTimePicker) as SceneTimePicker;
 }

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -549,3 +549,19 @@ export function getTableLogLine(): LogLineState {
 export function setTableLogLine(value: LogLineState) {
   localStorage.setItem(TABLE_LOG_LINE_LOCALSTORAGE_KEY, value);
 }
+
+// Logs view size
+export function getExpandedLogsView(sceneRef: SceneObject) {
+  const PREFIX = getExplorationPrefix(sceneRef);
+  try {
+    return Boolean(JSON.parse(String(localStorage.getItem(`${pluginJson.id}.${PREFIX}.logs.expanded`))));
+  } catch (e) {
+    logger.error(e);
+  }
+  return false;
+}
+
+export function setExpandedLogsView(sceneRef: SceneObject, expanded: boolean) {
+  const PREFIX = getExplorationPrefix(sceneRef);
+  localStorage.setItem(`${pluginJson.id}.${PREFIX}.logs.expanded`, JSON.stringify(expanded));
+}

--- a/tests/breakdowns/crossTabAndEmptyUi.spec.ts
+++ b/tests/breakdowns/crossTabAndEmptyUi.spec.ts
@@ -229,6 +229,7 @@ test.describe('Cross-tab and empty UI', () => {
       refIds: ['logsPanelQuery', 'A'],
     });
 
+    await explorePage.toggleLogsVolume();
     await expect(explorePage.getLogsDirectionNewestFirstLocator()).toBeVisible();
     await expect(explorePage.getLogsDirectionOldestFirstLocator()).not.toBeVisible();
 

--- a/tests/breakdowns/jsonView.spec.ts
+++ b/tests/breakdowns/jsonView.spec.ts
@@ -387,8 +387,11 @@ test.describe('JSON view breakdown (nginx-json)', () => {
       const clipboardContent = await handle.jsonValue();
       // Navigate to url from clipboard
       await page.goto(clipboardContent);
-      // Assert that the Line we copied is in the viewport, and all the k/v exactly match
-      await expect(page.getByText(selectedLogLineText ?? '')).toBeInViewport();
+      // Short default viewport (see setDefaultViewportSize) leaves the linked row below the fold;
+      // scroll before asserting visibility in the viewport.
+      const restoredLine = page.getByText(selectedLogLineText ?? '').first();
+      await restoredLine.scrollIntoViewIfNeeded();
+      await expect(restoredLine).toBeInViewport();
     });
 
     test('derived field links', async ({ page, context }) => {

--- a/tests/breakdowns/table.spec.ts
+++ b/tests/breakdowns/table.spec.ts
@@ -26,7 +26,7 @@ test.describe('Table', () => {
   test(`should show "Explore" on table panel menu`, async ({ page }) => {
     await explorePage.goToLogsTab();
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const panelMenu = page.getByTestId('data-testid Panel menu Logs');
     const panelMenuItem = page.getByTestId('data-testid Panel menu item Explore');
 
@@ -46,7 +46,7 @@ test.describe('Table', () => {
     await page.getByLabel('Show this field instead of').nth(1).click();
 
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
 
     // Wait for both URL params to settle after switching to table view.
     await expect
@@ -67,7 +67,7 @@ test.describe('Table', () => {
     await explorePage.goToLogsTab();
 
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const table = page.getByTestId(testIds.table.wrapper);
     await expect(table).toBeVisible();
 
@@ -80,7 +80,7 @@ test.describe('Table', () => {
     await explorePage.goToLogsTab();
 
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const table = page.getByTestId(testIds.table.wrapper);
     await expect(table).toBeVisible();
 
@@ -107,7 +107,7 @@ test.describe('Table', () => {
     await explorePage.goToLogsTab();
 
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const table = page.getByTestId(testIds.table.wrapper);
     await expect(table).toBeVisible();
 
@@ -120,7 +120,7 @@ test.describe('Table', () => {
     const table = page.getByTestId(testIds.table.wrapper);
     await explorePage.goToLogsTab();
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
 
     // Assert table column order
     await expect(table.getByRole('columnheader').nth(0)).toContainText('timestamp');
@@ -140,7 +140,7 @@ test.describe('Table', () => {
 
   test(`should add ${levelName} filter on table click`, async ({ page }) => {
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
 
     const table = page.getByTestId(testIds.table.wrapper);
     // switch table body to label view
@@ -163,7 +163,7 @@ test.describe('Table', () => {
     explorePage.blockAllQueriesExcept({
       refIds: ['logsPanelQuery'],
     });
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const table = page.getByTestId(testIds.table.wrapper);
 
     // assert the table shows the raw log line option by default
@@ -192,7 +192,7 @@ test.describe('Table', () => {
     await page.getByLabel('Show this field instead of').nth(1).click();
 
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const columnHeaders = await page.getByRole('columnheader');
     await expect(columnHeaders).toHaveCount(8);
 
@@ -203,13 +203,13 @@ test.describe('Table', () => {
     await page.getByRole('button', { name: 'Show original log line' }).click();
 
     // Switch to table view
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     const defaultColumnHeaders = await page.getByRole('columnheader');
     await expect(defaultColumnHeaders).toHaveCount(6);
   });
 
   test('should show inspect modal', async ({ page }) => {
-    await explorePage.getTableToggleLocator().click();
+    await explorePage.clickTableToggle();
     // Expect table to be rendered
     await expect(page.getByTestId(testIds.table.wrapper)).toBeVisible();
 

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -82,6 +82,16 @@ export class ExplorePage {
     return this.getLogsVisualizationToolbar().getByRole('radio', { name: 'Table', exact: true });
   }
 
+  /**
+   * Switch to table viz. The Table toolbar radio shows a Grafana tooltip that can stay
+   * under the cursor and intercept clicks on the table header; dismiss it before further UI steps.
+   */
+  async clickTableToggle(): Promise<void> {
+    await this.getTableToggleLocator().click();
+    await this.page.keyboard.press('Escape');
+    await this.page.mouse.move(0, 0);
+  }
+
   getJsonToggleLocator() {
     return this.getLogsVisualizationToolbar().getByRole('radio', { name: 'JSON', exact: true });
   }

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -279,6 +279,10 @@ export class ExplorePage {
     await this.page.getByTestId('data-testid Show logs header').click();
   }
 
+  async toggleLogsVolume() {
+    await this.page.getByText(/Log volume/).click();
+  }
+
   /**
    * Changes the datasource from gdev-loki to gdev-loki-copy
    */

--- a/tests/fixtures/explore.ts
+++ b/tests/fixtures/explore.ts
@@ -237,7 +237,10 @@ export class ExplorePage {
   }
 
   async clearLocalStorage() {
-    await this.page.evaluate(() => window.localStorage.clear());
+    await this.page.evaluate(() => {
+      window.localStorage.clear();
+      window.localStorage.setItem('grafana.explore.logs.logsVolume.collapsed', 'false');
+    });
   }
 
   async setDefaultViewportSize() {


### PR DESCRIPTION
After many complaints about scrolls, we're removing the need for scrolling to see the bottom of the logs panel, and the panel height will adapt to the available space. Demo:


https://github.com/user-attachments/assets/950cc3f7-d86f-4e72-8984-31c7fec76152

Additionally, it adds a new option to optionally use full screen height for logs:

https://github.com/user-attachments/assets/486342f2-030e-4a9b-b993-baecf663cd01


