### PR TITLE
fix(lineFilters): cancel debounced requests when onToggleExclusive changes

### DIFF
--- a/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.test.ts
+++ b/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.test.ts
@@ -1,11 +1,20 @@
+import { ChangeEvent } from 'react';
+
 import { AdHocFilterWithLabels } from '@grafana/scenes';
 
 import {
   applyLogSelectionToLineFilters,
   lineFilterRowIsEmpty,
+  LineFilterVariablesScene,
   nextLineFilterKeyLabel,
 } from './LineFilterVariablesScene';
-import { LineFilterCaseSensitive, LineFilterOp } from 'services/filterTypes';
+import { LINE_FILTER_INPUT_DEBOUNCE_MS, LineFilterCaseSensitive, LineFilterOp } from 'services/filterTypes';
+
+const mockGetLineFiltersVariable = jest.fn();
+
+jest.mock('services/variableGetters', () => ({
+  getLineFiltersVariable: (...args: unknown[]) => mockGetLineFiltersVariable(...args),
+}));
 
 describe('lineFilterRowIsEmpty', () => {
   it('treats undefined, empty, and whitespace-only as empty', () => {
@@ -81,5 +90,43 @@ describe('applyLogSelectionToLineFilters', () => {
     expect(next[0].value).toBe('x');
     expect(next[0].key).toBe(LineFilterCaseSensitive.caseSensitive);
     expect(next[0].keyLabel).toBe('0');
+  });
+});
+
+describe('onToggleExclusive', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not revert operator when exclude is toggled before debounced text update fires', () => {
+    const filter: AdHocFilterWithLabels = {
+      key: LineFilterCaseSensitive.caseInsensitive,
+      keyLabel: '0',
+      operator: LineFilterOp.match,
+      value: '',
+    };
+    let filters: AdHocFilterWithLabels[] = [{ ...filter }];
+    const updateFilters = jest.fn((newFilters: AdHocFilterWithLabels[]) => {
+      filters = newFilters;
+    });
+    mockGetLineFiltersVariable.mockReturnValue({
+      state: { filters },
+      updateFilters,
+    });
+
+    const scene = new LineFilterVariablesScene({});
+    scene.onInputChange({ target: { value: 'error' } } as ChangeEvent<HTMLInputElement>, filter);
+    scene.onToggleExclusive({ ...filter, value: 'error' });
+
+    expect(filters[0]?.operator).toBe(LineFilterOp.negativeMatch);
+
+    jest.advanceTimersByTime(LINE_FILTER_INPUT_DEBOUNCE_MS);
+
+    expect(updateFilters.mock.calls.at(-1)?.[0][0]?.operator).toBe(LineFilterOp.negativeMatch);
   });
 });

--- a/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.test.ts
+++ b/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.test.ts
@@ -93,7 +93,7 @@ describe('applyLogSelectionToLineFilters', () => {
   });
 });
 
-describe('onToggleExclusive', () => {
+describe('line filter debounce vs toggles', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
@@ -103,13 +103,7 @@ describe('onToggleExclusive', () => {
     jest.useRealTimers();
   });
 
-  it('does not revert operator when exclude is toggled before debounced text update fires', () => {
-    const filter: AdHocFilterWithLabels = {
-      key: LineFilterCaseSensitive.caseInsensitive,
-      keyLabel: '0',
-      operator: LineFilterOp.match,
-      value: '',
-    };
+  function setupScene(filter: AdHocFilterWithLabels) {
     let filters: AdHocFilterWithLabels[] = [{ ...filter }];
     const updateFilters = jest.fn((newFilters: AdHocFilterWithLabels[]) => {
       filters = newFilters;
@@ -118,15 +112,68 @@ describe('onToggleExclusive', () => {
       state: { filters },
       updateFilters,
     });
-
     const scene = new LineFilterVariablesScene({});
-    scene.onInputChange({ target: { value: 'error' } } as ChangeEvent<HTMLInputElement>, filter);
-    scene.onToggleExclusive({ ...filter, value: 'error' });
+    return {
+      scene,
+      filter,
+      get filters() {
+        return filters;
+      },
+      updateFilters,
+    };
+  }
 
-    expect(filters[0]?.operator).toBe(LineFilterOp.negativeMatch);
+  it('does not revert operator when exclude is toggled before debounced text update fires', () => {
+    const filter: AdHocFilterWithLabels = {
+      key: LineFilterCaseSensitive.caseInsensitive,
+      keyLabel: '0',
+      operator: LineFilterOp.match,
+      value: '',
+    };
+    const ctx = setupScene(filter);
+    ctx.scene.onInputChange({ target: { value: 'error' } } as ChangeEvent<HTMLInputElement>, filter);
+    ctx.scene.onToggleExclusive({ ...filter, value: 'error' });
+
+    expect(ctx.filters[0]?.operator).toBe(LineFilterOp.negativeMatch);
 
     jest.advanceTimersByTime(LINE_FILTER_INPUT_DEBOUNCE_MS);
 
-    expect(updateFilters.mock.calls.at(-1)?.[0][0]?.operator).toBe(LineFilterOp.negativeMatch);
+    expect(ctx.updateFilters.mock.calls.at(-1)?.[0][0]?.operator).toBe(LineFilterOp.negativeMatch);
+  });
+
+  it('does not revert operator when regex is toggled before debounced text update fires', () => {
+    const filter: AdHocFilterWithLabels = {
+      key: LineFilterCaseSensitive.caseInsensitive,
+      keyLabel: '0',
+      operator: LineFilterOp.match,
+      value: '',
+    };
+    const ctx = setupScene(filter);
+    ctx.scene.onInputChange({ target: { value: 'error' } } as ChangeEvent<HTMLInputElement>, filter);
+    ctx.scene.onRegexToggle({ ...filter, value: 'error' });
+
+    expect(ctx.filters[0]?.operator).toBe(LineFilterOp.regex);
+
+    jest.advanceTimersByTime(LINE_FILTER_INPUT_DEBOUNCE_MS);
+
+    expect(ctx.updateFilters.mock.calls.at(-1)?.[0][0]?.operator).toBe(LineFilterOp.regex);
+  });
+
+  it('does not revert case sensitivity when toggled before debounced text update fires', () => {
+    const filter: AdHocFilterWithLabels = {
+      key: LineFilterCaseSensitive.caseInsensitive,
+      keyLabel: '0',
+      operator: LineFilterOp.match,
+      value: '',
+    };
+    const ctx = setupScene(filter);
+    ctx.scene.onInputChange({ target: { value: 'error' } } as ChangeEvent<HTMLInputElement>, filter);
+    ctx.scene.onCaseSensitiveToggle({ ...filter, value: 'error' });
+
+    expect(ctx.filters[0]?.key).toBe(LineFilterCaseSensitive.caseSensitive);
+
+    jest.advanceTimersByTime(LINE_FILTER_INPUT_DEBOUNCE_MS);
+
+    expect(ctx.updateFilters.mock.calls.at(-1)?.[0][0]?.key).toBe(LineFilterCaseSensitive.caseSensitive);
   });
 });

--- a/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.tsx
+++ b/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.tsx
@@ -214,6 +214,8 @@ export class LineFilterVariablesScene extends SceneObjectBase<LineFilterRenderer
    * Updates filter operator when user toggles exclusion
    */
   onToggleExclusive = (filter: AdHocFilterWithLabels) => {
+    // Cancel the debounced update so that the operator matches the current api call
+    this.updateVariableDebounced.cancel();
     let newOperator: string;
     switch (filter.operator) {
       case LineFilterOp.match: {

--- a/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.tsx
+++ b/src/Components/IndexScene/LineFilter/LineFilterVariablesScene.tsx
@@ -183,6 +183,7 @@ export class LineFilterVariablesScene extends SceneObjectBase<LineFilterRenderer
    * Updates filter operator when user toggles regex
    */
   onRegexToggle = (filter: AdHocFilterWithLabels) => {
+    this.updateVariableDebounced.cancel();
     let newOperator: LineFilterOp;
     // Set value to scene state
     switch (filter.operator) {
@@ -214,7 +215,6 @@ export class LineFilterVariablesScene extends SceneObjectBase<LineFilterRenderer
    * Updates filter operator when user toggles exclusion
    */
   onToggleExclusive = (filter: AdHocFilterWithLabels) => {
-    // Cancel the debounced update so that the operator matches the current api call
     this.updateVariableDebounced.cancel();
     let newOperator: string;
     switch (filter.operator) {
@@ -246,6 +246,7 @@ export class LineFilterVariablesScene extends SceneObjectBase<LineFilterRenderer
    * Updates filter key when user toggles case sensitivity
    */
   onCaseSensitiveToggle = (filter: AdHocFilterWithLabels) => {
+    this.updateVariableDebounced.cancel();
     const caseSensitive =
       filter.key === LineFilterCaseSensitive.caseSensitive
         ? LineFilterCaseSensitive.caseInsensitive


### PR DESCRIPTION
### Description ✨
Fixes https://github.com/grafana/support-escalations/issues/22394

## Summary 📝

- Fixes #22394: switching line filter **Include** / **Exclude** immediately after typing no longer resets the filter when the 2s text debounce is still pending.
- Cancels the pending debounced line-filter update in `onToggleExclusive` so the include/exclude operator change is not overwritten by a stale callback.
- Adds a unit regression test covering type → toggle exclude → advance debounce timer.

## Test 🧪

- [x] `npx jest src/Components/IndexScene/LineFilter/LineFilterVariablesScene.test.ts` (7 tests passed)
- [x] Manual: open Logs Drilldown → Logs tab → type in line filter → switch Include/Exclude before ~2s elapses → filter text and exclude/include mode stay in sync; query reflects exclude (`!>`) without reverting to include
- [x] Manual: blur line filter or wait for debounce, then toggle Include/Exclude — behavior unchanged (still works as before)