### PR TITLE
chore: lowercase drilldownbot github app slug

### DIFF
--- a/.github/workflows/format-gh-issues.yml
+++ b/.github/workflows/format-gh-issues.yml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
-          github_app: DrilldownBot
+          github_app: drilldownbot
 
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/update-deployment-tools.yml
+++ b/.github/workflows/update-deployment-tools.yml
@@ -49,7 +49,7 @@ jobs:
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
-          github_app: DrilldownBot
+          github_app: drilldownbot
 
       - name: Check out deployment_tools repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
We've renamed the vault engine from `github-app-DrilldownBot` to `github-app-drilldownbot` to match the actual GitHub App slug.