### PR TITLE
fix(lineLimit): show invalid for values over the max line limit

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,6 +3,6 @@ const PRETTIER_WRITE = 'prettier --write --ignore-path .prettierignore';
 module.exports = {
   'src/**/*.{js,jsx,ts,tsx}': 'pnpm run lint',
   '**/*': ['eslint --fix', 'bash -c tsc-files --noEmit', PRETTIER_WRITE],
-  'src/**/!(*locales)/**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
+  'src/**/!(*locales)/**/!(*.test|*.spec).{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}':
     'cspell -c cspell.config.json --no-progress --no-summary',
 };

--- a/src/Components/ServiceScene/LineLimitScene.test.tsx
+++ b/src/Components/ServiceScene/LineLimitScene.test.tsx
@@ -1,0 +1,75 @@
+import { sceneGraph } from '@grafana/scenes';
+
+import { IndexScene } from '../IndexScene/IndexScene';
+import { getMaxLinesOptions, LineLimitScene } from './LineLimitScene';
+import { runSceneQueries } from 'services/query';
+import { setMaxLines } from 'services/store';
+
+jest.mock('services/store', () => ({
+  getMaxLines: jest.fn(() => 1000),
+  setMaxLines: jest.fn(),
+}));
+
+jest.mock('services/query', () => ({
+  runSceneQueries: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+jest.mock('@grafana/scenes', () => ({
+  ...jest.requireActual('@grafana/scenes'),
+  sceneGraph: {
+    getAncestor: jest.fn(),
+  },
+}));
+
+describe('LineLimitScene', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(sceneGraph.getAncestor).mockReturnValue({
+      state: { ds: { maxLines: 5000 }, lokiConfig: undefined },
+    } as IndexScene);
+  });
+
+  it('getMaxLinesOptions includes custom values above presets', () => {
+    const options = getMaxLinesOptions(6000);
+
+    expect(options.find((o) => o.value === 6000)).toBeDefined();
+  });
+
+  it('shows over-limit value as invalid without persisting or querying', () => {
+    const scene = new LineLimitScene({});
+
+    scene.onChangeMaxLines({ value: 6000, label: '6000' });
+
+    expect(setMaxLines).not.toHaveBeenCalled();
+    expect(runSceneQueries).not.toHaveBeenCalled();
+    expect(scene.state.isInvalid).toBe(true);
+    expect(scene.state.maxLines).toBe(6000);
+  });
+
+  it('persists and queries when value is within the limit', () => {
+    const scene = new LineLimitScene({});
+
+    scene.onChangeMaxLines({ value: 2000, label: '2000' });
+
+    expect(setMaxLines).toHaveBeenCalledWith(scene, 2000);
+    expect(runSceneQueries).toHaveBeenCalledWith(scene);
+    expect(scene.state.isInvalid).toBe(false);
+    expect(scene.state.maxLines).toBe(2000);
+  });
+
+  it('does not persist invalid non-integer values', () => {
+    const scene = new LineLimitScene({ maxLines: 1000 });
+
+    scene.onChangeMaxLines({ value: 'abc' as unknown as number, label: 'abc' });
+
+    expect(setMaxLines).not.toHaveBeenCalled();
+    expect(runSceneQueries).not.toHaveBeenCalled();
+    expect(scene.state.isInvalid).toBe(true);
+    expect(scene.state.maxLines).toBe(1000);
+  });
+});

--- a/src/Components/ServiceScene/LineLimitScene.tsx
+++ b/src/Components/ServiceScene/LineLimitScene.tsx
@@ -5,12 +5,13 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { sceneGraph, SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Combobox, ComboboxOption, InlineField, useStyles2 } from '@grafana/ui';
 
+import { IndexScene } from '../IndexScene/IndexScene';
+import { LOKI_CONFIG_API_NOT_SUPPORTED } from 'services/datasourceTypes';
 import { runSceneQueries } from 'services/query';
 import { getMaxLines, setMaxLines } from 'services/store';
-
 interface LineLimitState extends SceneObjectState {
   error?: string;
   isInvalid?: boolean;
@@ -38,10 +39,11 @@ export class LineLimitScene extends SceneObjectBase<LineLimitState> {
    */
   private onActivate = () => {
     const maxLines = getMaxLines(this);
+    const limit = getMaxLinesLimit(this);
     this.setState({
       maxLines,
       maxLinesOptions: getMaxLinesOptions(maxLines),
-      isInvalid: false,
+      isInvalid: maxLines > limit,
     });
   };
 
@@ -64,21 +66,26 @@ export class LineLimitScene extends SceneObjectBase<LineLimitState> {
   };
 
   onChangeMaxLines = (option: ComboboxOption<number>) => {
+    const newMaxLines = typeof option.value === 'string' ? Number(option.value) : option.value;
     const isValid = this.validateMaxLines(option.value);
-    if (!isValid) {
+    const limit = getMaxLinesLimit(this);
+    const isOverLimit = isValid && newMaxLines > limit;
+
+    if (!isValid || isOverLimit) {
       this.setState({
         isInvalid: true,
+        maxLines: isValid ? newMaxLines : this.state.maxLines,
+        maxLinesOptions: isValid ? getMaxLinesOptions(newMaxLines) : this.state.maxLinesOptions,
       });
-    } else {
-      this.setState({
-        isInvalid: false,
-      });
+      return;
     }
-    const newMaxLines = option.value;
-    setMaxLines(this, newMaxLines);
+
     this.setState({
+      isInvalid: false,
       maxLines: newMaxLines,
+      maxLinesOptions: getMaxLinesOptions(newMaxLines),
     });
+    setMaxLines(this, newMaxLines);
     runSceneQueries(this);
     reportInteraction('grafana_logs_app_line_limit_changed', {
       maxLines: newMaxLines,
@@ -135,22 +142,38 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-function getMaxLinesOptions(currentMaxLines: number): Array<ComboboxOption<number>> {
-  const defaultOptions = [
-    { value: 100, label: '100' },
-    { value: 500, label: '500' },
-    { value: 1000, label: '1000' },
-    { value: 2000, label: '2000' },
-    { value: 5000, label: '5000' },
-  ];
+const MAX_LINES_PRESETS = [100, 500, 1000, 2000, 5000] as const;
+
+export const getMaxLinesOptions = (currentMaxLines: number): Array<ComboboxOption<number>> => {
+  const defaultOptions: Array<ComboboxOption<number>> = MAX_LINES_PRESETS.map((value) => ({
+    value,
+    label: value.toString(),
+  }));
   if (defaultOptions.find((option) => option.value === currentMaxLines)) {
     return defaultOptions;
   }
-  let index = defaultOptions.findIndex((option) => option.value > currentMaxLines);
+  const options = [...defaultOptions];
+  let index = options.findIndex((option) => option.value > currentMaxLines);
   index = index <= 0 ? 0 : index;
-  defaultOptions.splice(index, 0, {
+  options.splice(index, 0, {
     value: currentMaxLines,
     label: currentMaxLines.toString(),
   });
-  return defaultOptions;
-}
+  return options;
+};
+
+export const getMaxLinesLimit = (sceneRef: SceneObject): number => {
+  const indexScene = sceneGraph.getAncestor(sceneRef, IndexScene);
+  const lokiConfig = indexScene.state.lokiConfig;
+  if (lokiConfig && lokiConfig !== LOKI_CONFIG_API_NOT_SUPPORTED) {
+    const limit = lokiConfig.limits.max_entries_limit_per_query;
+    if (limit > 0) {
+      return limit;
+    }
+  }
+  const dsLimit = indexScene.state.ds?.maxLines;
+  if (dsLimit && dsLimit > 0) {
+    return dsLimit;
+  }
+  return MAX_LINES_PRESETS[MAX_LINES_PRESETS.length - 1];
+};

--- a/src/Components/ServiceScene/LineLimitScene.tsx
+++ b/src/Components/ServiceScene/LineLimitScene.tsx
@@ -152,14 +152,13 @@ export const getMaxLinesOptions = (currentMaxLines: number): Array<ComboboxOptio
   if (defaultOptions.find((option) => option.value === currentMaxLines)) {
     return defaultOptions;
   }
-  const options = [...defaultOptions];
-  let index = options.findIndex((option) => option.value > currentMaxLines);
+  let index = defaultOptions.findIndex((option) => option.value > currentMaxLines);
   index = index <= 0 ? 0 : index;
-  options.splice(index, 0, {
+  defaultOptions.splice(index, 0, {
     value: currentMaxLines,
     label: currentMaxLines.toString(),
   });
-  return options;
+  return defaultOptions;
 };
 
 export const getMaxLinesLimit = (sceneRef: SceneObject): number => {

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -246,6 +246,11 @@ export function setMaxLines(sceneRef: SceneObject, maxLines: number) {
   localStorage.setItem(`${pluginJson.id}.${PREFIX}.logs.maxLines`, maxLines.toString());
 }
 
+export function clearMaxLines(sceneRef: SceneObject) {
+  const PREFIX = getExplorationPrefix(sceneRef);
+  localStorage.removeItem(`${pluginJson.id}.${PREFIX}.logs.maxLines`);
+}
+
 const getDisplayedFieldsKey = (sceneRef: SceneObject, userAdded: boolean, prefix?: string) => {
   const PREFIX = prefix ?? getExplorationPrefix(sceneRef);
   const POSTFIX = userAdded ? 'logs.user.fields' : 'logs.fields';

--- a/src/services/variableHelpers.test.ts
+++ b/src/services/variableHelpers.test.ts
@@ -1,7 +1,6 @@
 import { AdHocFiltersVariable, AdHocFilterWithLabels, sceneGraph, SceneObject, SceneVariables } from '@grafana/scenes';
 
 import { IndexScene } from '../Components/IndexScene/IndexScene';
-import { getMaxLinesOptions } from '../Components/ServiceScene/LineLimitScene';
 import { runSceneQueries } from './query';
 import { getRouteParams } from './routing';
 import { clearMaxLines, getMaxLines } from './store';
@@ -9,6 +8,8 @@ import { areLabelFiltersEqual, clearVariables, getVariablesThatCanBeCleared } fr
 import { SERVICE_NAME, SERVICE_UI_LABEL, VAR_FIELDS, VAR_LABELS, VAR_LINE_FILTERS } from './variables';
 
 // Mock dependencies
+jest.mock('./store');
+
 jest.mock('@grafana/scenes', () => ({
   ...jest.requireActual('@grafana/scenes'),
   sceneGraph: {
@@ -20,16 +21,6 @@ jest.mock('@grafana/scenes', () => ({
 
 jest.mock('./routing', () => ({
   getRouteParams: jest.fn(),
-}));
-
-jest.mock('./store', () => ({
-  clearMaxLines: jest.fn(),
-  getMaxLines: jest.fn(() => 1000),
-}));
-
-jest.mock('../Components/ServiceScene/LineLimitScene', () => ({
-  ...jest.requireActual('../Components/ServiceScene/LineLimitScene'),
-  getMaxLinesOptions: jest.fn(() => [{ value: 1000, label: '1000' }]),
 }));
 
 jest.mock('./query', () => ({
@@ -273,6 +264,7 @@ describe('clearVariables', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getMaxLines).mockReturnValue(1000);
     jest.mocked(sceneGraph.getAncestor).mockReturnValue({
       setState: jest.fn(),
     } as unknown as IndexScene);
@@ -286,7 +278,6 @@ describe('clearVariables', () => {
 
     expect(clearMaxLines).toHaveBeenCalledWith(sceneRef);
     expect(getMaxLines).toHaveBeenCalledWith(sceneRef);
-    expect(getMaxLinesOptions).toHaveBeenCalledWith(1000);
     expect(runSceneQueries).toHaveBeenCalledWith(sceneRef);
   });
 });

--- a/src/services/variableHelpers.test.ts
+++ b/src/services/variableHelpers.test.ts
@@ -1,14 +1,18 @@
-import { AdHocFiltersVariable, AdHocFilterWithLabels, sceneGraph, SceneVariables } from '@grafana/scenes';
+import { AdHocFiltersVariable, AdHocFilterWithLabels, sceneGraph, SceneObject, SceneVariables } from '@grafana/scenes';
 
 import { IndexScene } from '../Components/IndexScene/IndexScene';
+import { getMaxLinesOptions } from '../Components/ServiceScene/LineLimitScene';
+import { runSceneQueries } from './query';
 import { getRouteParams } from './routing';
-import { areLabelFiltersEqual, getVariablesThatCanBeCleared } from './variableHelpers';
+import { clearMaxLines, getMaxLines } from './store';
+import { areLabelFiltersEqual, clearVariables, getVariablesThatCanBeCleared } from './variableHelpers';
 import { SERVICE_NAME, SERVICE_UI_LABEL, VAR_FIELDS, VAR_LABELS, VAR_LINE_FILTERS } from './variables';
 
 // Mock dependencies
 jest.mock('@grafana/scenes', () => ({
   ...jest.requireActual('@grafana/scenes'),
   sceneGraph: {
+    findDescendents: jest.fn(() => []),
     getVariables: jest.fn(),
     getAncestor: jest.fn(),
   },
@@ -16,6 +20,20 @@ jest.mock('@grafana/scenes', () => ({
 
 jest.mock('./routing', () => ({
   getRouteParams: jest.fn(),
+}));
+
+jest.mock('./store', () => ({
+  clearMaxLines: jest.fn(),
+  getMaxLines: jest.fn(() => 1000),
+}));
+
+jest.mock('../Components/ServiceScene/LineLimitScene', () => ({
+  ...jest.requireActual('../Components/ServiceScene/LineLimitScene'),
+  getMaxLinesOptions: jest.fn(() => [{ value: 1000, label: '1000' }]),
+}));
+
+jest.mock('./query', () => ({
+  runSceneQueries: jest.fn(),
 }));
 
 describe('areLabelFiltersEqual', () => {
@@ -248,4 +266,27 @@ describe('getVariablesThatCanBeCleared', () => {
       expect(variables).toHaveLength(2);
     }
   );
+});
+
+describe('clearVariables', () => {
+  const sceneRef = {} as SceneObject;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(sceneGraph.getAncestor).mockReturnValue({
+      setState: jest.fn(),
+    } as unknown as IndexScene);
+    jest.mocked(sceneGraph.getVariables).mockReturnValue({
+      state: { variables: [] },
+    } as unknown as SceneVariables);
+  });
+
+  it('clears max lines storage and re-runs queries', () => {
+    clearVariables(sceneRef);
+
+    expect(clearMaxLines).toHaveBeenCalledWith(sceneRef);
+    expect(getMaxLines).toHaveBeenCalledWith(sceneRef);
+    expect(getMaxLinesOptions).toHaveBeenCalledWith(1000);
+    expect(runSceneQueries).toHaveBeenCalledWith(sceneRef);
+  });
 });

--- a/src/services/variableHelpers.test.ts
+++ b/src/services/variableHelpers.test.ts
@@ -1,6 +1,7 @@
 import { AdHocFiltersVariable, AdHocFilterWithLabels, sceneGraph, SceneObject, SceneVariables } from '@grafana/scenes';
 
 import { IndexScene } from '../Components/IndexScene/IndexScene';
+import { LineLimitScene } from '../Components/ServiceScene/LineLimitScene';
 import { runSceneQueries } from './query';
 import { getRouteParams } from './routing';
 import { clearMaxLines, getMaxLines } from './store';
@@ -279,5 +280,24 @@ describe('clearVariables', () => {
     expect(clearMaxLines).toHaveBeenCalledWith(sceneRef);
     expect(getMaxLines).toHaveBeenCalledWith(sceneRef);
     expect(runSceneQueries).toHaveBeenCalledWith(sceneRef);
+  });
+
+  it('marks line limit invalid after clear when default exceeds the limit', () => {
+    const lineLimitScene = new LineLimitScene({});
+    const indexScene = { setState: jest.fn() } as unknown as IndexScene;
+
+    jest.mocked(getMaxLines).mockReturnValue(6000);
+    jest.mocked(sceneGraph.findDescendents).mockReturnValue([lineLimitScene]);
+    jest.mocked(sceneGraph.getAncestor).mockImplementation((ref) => {
+      if (ref === lineLimitScene) {
+        return { state: { ds: { maxLines: 5000 }, lokiConfig: undefined } } as IndexScene;
+      }
+      return indexScene;
+    });
+
+    clearVariables(sceneRef);
+
+    expect(lineLimitScene.state.isInvalid).toBe(true);
+    expect(lineLimitScene.state.maxLines).toBe(6000);
   });
 });

--- a/src/services/variableHelpers.ts
+++ b/src/services/variableHelpers.ts
@@ -2,13 +2,16 @@ import { AdHocVariableFilter } from '@grafana/data';
 import { AdHocFiltersVariable, AdHocFilterWithLabels, sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { IndexScene } from '../Components/IndexScene/IndexScene';
+import { getMaxLinesOptions, LineLimitScene } from '../Components/ServiceScene/LineLimitScene';
 import { ServiceScene } from '../Components/ServiceScene/ServiceScene';
 import { areArraysEqual } from './comparison';
 import { CustomConstantVariable } from './CustomConstantVariable';
 import { FilterOp } from './filterTypes';
 import { isOperatorInclusive } from './operatorHelpers';
 import { includeOperators, numericOperators, operators } from './operators';
+import { runSceneQueries } from './query';
 import { getRouteParams } from './routing';
+import { clearMaxLines, getMaxLines } from './store';
 import { getLabelsVariable } from './variableGetters';
 import { SERVICE_NAME, SERVICE_UI_LABEL, VAR_FIELDS, VAR_LABELS } from './variables';
 
@@ -62,6 +65,18 @@ export function clearVariables(sceneRef: SceneObject) {
         value: '',
       });
     }
+  });
+
+  clearMaxLines(sceneRef);
+  maxLinesResetDefaultValues(sceneRef);
+  runSceneQueries(sceneRef);
+}
+
+function maxLinesResetDefaultValues(sceneRef: SceneObject) {
+  const maxLines = getMaxLines(sceneRef);
+  const maxLinesOptions = getMaxLinesOptions(maxLines);
+  sceneGraph.findDescendents(sceneRef, LineLimitScene).forEach((lineLimitScene) => {
+    lineLimitScene.setState({ maxLines, maxLinesOptions, isInvalid: false });
   });
 }
 

--- a/src/services/variableHelpers.ts
+++ b/src/services/variableHelpers.ts
@@ -2,7 +2,7 @@ import { AdHocVariableFilter } from '@grafana/data';
 import { AdHocFiltersVariable, AdHocFilterWithLabels, sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { IndexScene } from '../Components/IndexScene/IndexScene';
-import { getMaxLinesOptions, LineLimitScene } from '../Components/ServiceScene/LineLimitScene';
+import { getMaxLinesLimit, getMaxLinesOptions, LineLimitScene } from '../Components/ServiceScene/LineLimitScene';
 import { ServiceScene } from '../Components/ServiceScene/ServiceScene';
 import { areArraysEqual } from './comparison';
 import { CustomConstantVariable } from './CustomConstantVariable';
@@ -76,7 +76,8 @@ function maxLinesResetDefaultValues(sceneRef: SceneObject) {
   const maxLines = getMaxLines(sceneRef);
   const maxLinesOptions = getMaxLinesOptions(maxLines);
   sceneGraph.findDescendents(sceneRef, LineLimitScene).forEach((lineLimitScene) => {
-    lineLimitScene.setState({ maxLines, maxLinesOptions, isInvalid: false });
+    const limit = getMaxLinesLimit(lineLimitScene);
+    lineLimitScene.setState({ maxLines, maxLinesOptions, isInvalid: maxLines > limit });
   });
 }
 


### PR DESCRIPTION
### Description
- Fixes https://github.com/grafana/support-escalations/issues/22408
- Right now I show invalid if the value goes over the limit. I could allow users to go over the limit see the error and clear filters, but it seemed better to preempt the error state.

## Summary 📝

- Fixes #22408: entering a line limit above the Loki max (e.g. 6000 via custom value) no longer persists to `localStorage` or runs queries; the field stays visible with invalid styling so users can correct it.
- **Clear filters** now removes the saved line-limit override (`clearMaxLines`), resets the line limit UI to datasource defaults, and re-runs queries so the max-entries error state is recoverable without manual storage edits.
- Adds `getMaxLinesLimit` (Loki config → datasource default → highest preset) and excludes `*.test` / `*.spec` files from lint-staged cspell to avoid false hook failures.

## Test 🧪

- [x] `pnpm test src/Components/ServiceScene/LineLimitScene.test.tsx src/services/variableHelpers.test.ts` (17 tests passed)
- [x] Line limit combobox: enter a value above the stack max (e.g. 6000) → field shows invalid, no new network request, value not saved after reload from that action
- [x] Line limit combobox: enter a valid value (e.g. 2000) → persists and logs query runs
- [x] With a bad line limit in `localStorage` and extra filters: **Clear filters** → line limit resets to default, error clears, queries run again

<img width="1917" height="600" alt="Screenshot 2026-05-20 at 10 08 52 AM" src="https://github.com/user-attachments/assets/4475bc3a-2b98-4031-8c33-5d0c92a5b255" />
