### PR TITLE
fix(BreadownView): remove hardcoded min height

### DIFF
--- a/src/Components/ServiceScene/BreakdownViews.ts
+++ b/src/Components/ServiceScene/BreakdownViews.ts
@@ -109,16 +109,12 @@ function buildLabelValuesBreakdownActionScene(value: string) {
 
 function buildLogsListScene() {
   return new SceneFlexLayout({
-    height: 'auto',
-    maxHeight: 'auto',
-    minHeight: 'auto',
     children: [
       new SceneFlexItem({
         body: new LogsVolumeContainerScene({}),
       }),
       new SceneFlexItem({
         body: new LogsListScene({}),
-        minHeight: '470px',
       }),
     ],
     direction: 'column',


### PR DESCRIPTION
Follow up to https://github.com/grafana/logs-drilldown/pull/1895, removing a hardcoded height.

Before:

<img width="1511" height="837" alt="Before" src="https://github.com/user-attachments/assets/ac2f496e-fbd0-4a4d-8b7c-fcee56a88ade" />

After:

<img width="1512" height="834" alt="After" src="https://github.com/user-attachments/assets/421cb275-68c5-4156-a20b-5e73ed858a0c" />
