### PR TITLE
chore: upgrade pnpm from v10 to v11

### DIFF
--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/package.json
+++ b/package.json
@@ -151,16 +151,5 @@
     "tslib": "2.5.3",
     "uuid": "^14.0.0"
   },
-  "pnpm": {
-    "overrides": {
-      "react-router-dom": "^7.12.0",
-      "uuid": "^14.0.0",
-      "immutable": "~5.1.5",
-      "dompurify": "~3.4.0",
-      "serialize-javascript": "~7.0.5",
-      "strip-ansi": "~6.0.1",
-      "js-yaml": "~4.1.1"
-    }
-  },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
+  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,18 @@
 packages:
   - '.'
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - esbuild
-  - protobufjs
-  - unrs-resolver
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true
+
+overrides:
+  react-router-dom: ^7.12.0
+  uuid: ^14.0.0
+  immutable: ~5.1.5
+  dompurify: ~3.4.0
+  serialize-javascript: ~7.0.5
+  strip-ansi: ~6.0.1
+  js-yaml: ~4.1.1


### PR DESCRIPTION
### ✨ Description

Upgrade pnpm from v10.33.2 to v11.3.0.

pnpm 11 is a major version with a redesigned configuration system. The `pnpm` key in `package.json` is silently ignored in v11, so overrides must be migrated to `pnpm-workspace.yaml`. The `pnpm/action-setup` GitHub Action also needs v6 for pnpm 11 support.

### 📖 Summary of the changes

* **`package.json`**: Removed the `pnpm` key (overrides block), bumped `packageManager` to `pnpm@11.3.0`
* **`pnpm-workspace.yaml`**: Added `overrides` block (moved from `package.json`), replaced `onlyBuiltDependencies` with the new `allowBuilds` map
* **`.github/workflows/is-compatible.yml`**: Bumped `pnpm/action-setup` from v4 to v6.0.8 (v4 does not support pnpm 11)

Notable new pnpm 11 defaults to be aware of:

* `minimumReleaseAge: 1440` — newly-published packages are quarantined for 24h before resolution
* `strictDepBuilds: true` — build scripts blocked unless explicitly allowed via `allowBuilds`
* `verifyDepsBeforeRun: install` — auto-runs install if deps are stale before script execution

### 🧪 How to test?

* `pnpm install`
* `pnpm run typecheck`
* `pnpm run lint`
* `pnpm run test`
* `pnpm run build`
* Verify security overrides are applied: `pnpm why dompurify`, `pnpm why serialize-javascript` — all resolve to at least the override floor versions
* **Note:** The shared CI workflow (`grafana/plugin-ci-workflows`) uses `pnpm/action-setup` internally and may need updating to v6 for pnpm 11 support.

Mirrors https://github.com/grafana/metrics-drilldown/pull/1272 for logs-drilldown.