### PR TITLE
fix(ci): use JSON output for Crowdin token from get-vault-secrets

### DIFF
--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -16,12 +16,12 @@ jobs:
         id: vault-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
-            # Vault secret paths:
-            # - ci/repo/grafana/logs-drilldown/grafana-frontend-crowdin-token
-            repo_secrets: |
-                CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
+          # Vault secret paths:
+          # - ci/repo/grafana/logs-drilldown/grafana-frontend-crowdin-token
+          repo_secrets: |
+            CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
       - name: Create tasks in Crowdin
         uses: grafana/grafana-github-actions/crowdin-create-tasks@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 40

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -25,14 +25,14 @@ jobs:
         id: vault-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
-            # Vault secret paths:
-            # - ci/repo/grafana/logs-drilldown/grafana-frontend-crowdin-token
-            repo_secrets: |
-                CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
+          # Vault secret paths:
+          # - ci/repo/grafana/logs-drilldown/grafana-frontend-crowdin-token
+          repo_secrets: |
+            CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
       - name: Download from Crowdin
         uses: grafana/grafana-github-actions/crowdin-download@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 40
           pr_labels: 'i18n'
           github_board_id: 702

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -23,12 +23,12 @@ jobs:
         id: vault-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
-            # Vault secret paths:
-            # - ci/repo/grafana/logs-drilldown/grafana-frontend-crowdin-token
-            repo_secrets: |
-                CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
+          # Vault secret paths:
+          # - ci/repo/grafana/logs-drilldown/grafana-frontend-crowdin-token
+          repo_secrets: |
+            CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
       - name: Upload to Crowdin
         uses: grafana/grafana-github-actions/crowdin-upload@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 40


### PR DESCRIPTION
## Summary

Fixes #1934

[`grafana/shared-workflows` PR #1957](https://github.com/grafana/shared-workflows/pull/1957) (merged 2026-06-04) removed the environment variable export from the `get-vault-secrets` action. Secrets are now only available via JSON output, so the old `${{ env.CROWDIN_TOKEN }}` reference resolves to an empty string, causing the Crowdin CLI to fail with:

```
❌ Configuration file is invalid. Check the following parameters in your configuration file:
    - Required option 'api_token' is missing
```

## Changes

Updated all three Crowdin workflow files to use the new pattern:

```
crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
```

### Files updated
- `.github/workflows/i18n-crowdin-upload.yml`
- `.github/workflows/i18n-crowdin-download.yml`
- `.github/workflows/i18n-crowdin-create-tasks.yml`
