### PR TITLE
feat(logs): new options for service selection (show context, go to log line, show similar log lines, add line filter) and updated permalinks

### DIFF
--- a/src/Components/ServiceScene/JSONPanel/JSONLogLineActionButtons.tsx
+++ b/src/Components/ServiceScene/JSONPanel/JSONLogLineActionButtons.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { isNumber } from 'lodash';
 
-import { DataFrame, Field, TimeRange } from '@grafana/data';
+import { DataFrame, Field } from '@grafana/data';
 import { SceneDataProvider, sceneGraph } from '@grafana/scenes';
 
 import { isLogLineField, isLogsIdField } from '../../../services/fields';
 import { logger } from '../../../services/logger';
-import { copyText, generateLogShortlink } from '../../../services/text';
+import { copyText, generateLogRowShortlink, getPermalinkLogRowFromDataFrame } from '../../../services/text';
 import CopyToClipboardButton from '../../Buttons/CopyToClipboardButton';
 import { JSONLogsScene } from '../JSONLogsScene';
 import { getLogsPanelFrame } from '../ServiceScene';
@@ -18,14 +18,10 @@ interface Props {
   model: JSONLogsScene;
 }
 export function JSONLogLineActionButtons({ model, keyPath }: Props) {
-  const timeRange = sceneGraph.getTimeRange(model).state.value;
   return (
     <>
       <CopyToClipboardButton onClick={() => copyLogLine(keyPath, sceneGraph.getData(model))} />
-      <CopyToClipboardButton
-        type={'share-alt'}
-        onClick={() => getLinkToLog(keyPath, timeRange, model.state.rawFrame)}
-      />
+      <CopyToClipboardButton type={'share-alt'} onClick={() => getLinkToLog(keyPath, model.state.rawFrame)} />
     </>
   );
 }
@@ -40,15 +36,25 @@ const copyLogLine = (keyPath: KeyPath, $data: SceneDataProvider) => {
   }
 };
 
-function getLinkToLog(keyPath: KeyPath, timeRange: TimeRange, rawFrame: DataFrame | undefined) {
-  const idField: Field<string> | undefined = rawFrame?.fields.find((f) => isLogsIdField(f.name));
+function getLinkToLog(keyPath: KeyPath, rawFrame: DataFrame | undefined) {
   const logLineIndex = keyPath[0];
   if (!isNumber(logLineIndex)) {
     const error = Error('Invalid line index');
     logger.error(error, { msg: 'Error getting log line index' });
     throw error;
   }
+  if (!rawFrame) {
+    return;
+  }
+
+  const row = getPermalinkLogRowFromDataFrame(rawFrame, logLineIndex);
+  if (!row) {
+    return;
+  }
+
+  const idField: Field<string> | undefined = rawFrame.fields.find((f) => isLogsIdField(f.name));
   const logId = idField?.values[logLineIndex];
-  const logLineLink = generateLogShortlink('selectedLine', { id: logId, row: logLineIndex }, timeRange);
+  // The JSON view scrolls to and highlights the line from the `selectedLine` url param.
+  const logLineLink = generateLogRowShortlink(row, { id: logId, row: logLineIndex }, 'selectedLine');
   copyText(logLineLink);
 }

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -50,7 +50,7 @@ import { LineFilterCaseSensitive, LineFilterOp } from 'services/filterTypes';
 import { isDedupStrategy, isLogsSortOrder } from 'services/guards';
 import { logsControlsSupported } from 'services/panel';
 import { runSceneQueries } from 'services/query';
-import { copyText, generateLogShortlink, resolveRowTimeRangeForSharing } from 'services/text';
+import { copyText, generateLogRowShortlink } from 'services/text';
 import { clearVariables } from 'services/variableHelpers';
 import { VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from 'services/variables';
 
@@ -412,19 +412,14 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
       return;
     }
     const parent = this.getParentScene();
-    const timeRange = resolveRowTimeRangeForSharing(row);
     copyText(
-      generateLogShortlink(
-        'panelState',
-        {
-          logs: {
-            displayedFields: parent.state.displayedFields,
-            id: row.uid,
-            sortOrder: this.state.sortOrder,
-          },
+      generateLogRowShortlink(row, {
+        logs: {
+          displayedFields: parent.state.displayedFields,
+          id: row.uid,
+          sortOrder: this.state.sortOrder,
         },
-        timeRange
-      )
+      })
     );
   };
 

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -28,11 +28,11 @@ import { NoMatchingLabelsScene } from './Breakdowns/NoMatchingLabelsScene';
 import { LogOptionsScene } from './LogOptionsScene';
 import { LogsListScene } from './LogsListScene';
 import { ErrorType, LogsPanelError } from './LogsPanelError';
-import { ServiceScene } from './ServiceScene';
+import { getLogsPanelFrame, ServiceScene } from './ServiceScene';
 import { PanelMenu } from 'Components/Panels/PanelMenu';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { areArraysEqual } from 'services/comparison';
-import { getVariableForLabel } from 'services/fields';
+import { getVariableForLabel, isLogsIdField } from 'services/fields';
 import { FilterOp } from 'services/filterTypes';
 import { logger } from 'services/logger';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
@@ -41,7 +41,12 @@ import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
 import { runSceneQueries } from 'services/query';
 import { setControlsExpandedStateFromLocalStorage } from 'services/scenes';
 import { getBooleanLogOption, getLogOption, setDisplayedFieldsInStorage, setLogOption } from 'services/store';
-import { copyText, generateLogShortlink } from 'services/text';
+import {
+  copyText,
+  generateLogRowShortlink,
+  generateLogShortlink,
+  getPermalinkLogRowFromDataFrame,
+} from 'services/text';
 import { clearVariables } from 'services/variableHelpers';
 
 interface LogsTablePanelSceneState extends SceneObjectState {
@@ -259,18 +264,25 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
 
   buildLinkToLogLine = (uid: string) => {
     const parent = this.getParentScene();
-    const timeRange = sceneGraph.getTimeRange(parent).state.value;
-    const link = generateLogShortlink(
-      'panelState',
-      {
-        logs: {
-          displayedFields: parent.state.displayedFields,
-          id: uid,
-          sortOrder: this.state.sortOrder,
-        },
+    const panelState = {
+      logs: {
+        displayedFields: parent.state.displayedFields,
+        id: uid,
+        sortOrder: this.state.sortOrder,
       },
-      timeRange
-    );
+    };
+
+    // The panel only gives us the log line's uid, so resolve its row in the logs frame to build a row-based
+    // shortlink (which adds field filters + a tight time range around the line). Fall back to the current panel
+    // time range if the row can't be resolved from its uid.
+    const dataFrame = getLogsPanelFrame(sceneGraph.getData(this).state.data);
+    const idField = dataFrame?.fields.find((field) => isLogsIdField(field.name));
+    const rowIndex = idField ? idField.values.findIndex((value) => value === uid) : -1;
+    const row = dataFrame && rowIndex >= 0 ? getPermalinkLogRowFromDataFrame(dataFrame, rowIndex) : null;
+
+    const link = row
+      ? generateLogRowShortlink(row, panelState)
+      : generateLogShortlink('panelState', panelState, sceneGraph.getTimeRange(parent).state.value);
 
     copyText(link);
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -645,7 +645,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
             divider: true,
           },
           {
-            label: t('components.service-selection-scene.logs-panel.go-to-log-line', 'Show similar logs'),
+            label: t('components.service-selection-scene.logs-panel.show-similar-logs', 'Show similar logs'),
             onClick: goToSimilarLogs,
           },
           {

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -41,7 +41,7 @@ import {
 import { areArraysEqual } from '../../services/comparison';
 import { CustomConstantVariable } from '../../services/CustomConstantVariable';
 import { escapeLabelValueInExactSelector } from '../../services/extensions/scenesMethods';
-import { pushUrlHandler } from '../../services/navigate';
+import { getDrillDownIndexLink, pushUrlHandler } from '../../services/navigate';
 import { getQueryRunnerFromChildren } from '../../services/scenes';
 import {
   clearServiceSelectionSearchVariable,
@@ -554,6 +554,15 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const levelFilter = this.getLevelFilterForService(labelValue);
 
     const backendDisplayedFields = this.getDefaultColumns(labelName, labelValue);
+
+    const onClickFilterString = (lineFilter: string) => {
+      const link = getDrillDownIndexLink(labelName, labelValue, {
+        'var-filters': [`${labelName}|=|${labelValue}`],
+        'var-lineFilters': [`caseInsensitive,0|__gfp__=|${lineFilter}`],
+      });
+      window.open(link, '_blank');
+    };
+
     const cssGridItem = new SceneCSSGridItem({
       $behaviors: [new behaviors.CursorSync({ sync: DashboardCursorSync.Off })],
       body: PanelBuilders.logs()
@@ -577,6 +586,8 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setOption('enableLogDetails', false)
         .setOption('fontSize', 'small')
         .setOption('displayedFields', backendDisplayedFields)
+        .setOption('onClickFilterString', onClickFilterString)
+        .setOption('showLogContextToggle', true)
         .build(),
     });
 
@@ -1153,6 +1164,13 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       flexDirection: 'column',
       flexGrow: 1,
+      // Hack to select internal div
+      'section > div[class$="panel-content"]': css({
+        // A components withing the Logs viz sets contain, which creates a new containing block that is not body which breaks the popover menu
+        contain: 'none',
+        // Prevent overflow from spilling out of parent container
+        overflow: 'auto',
+      }),
     }),
     bodyWrapper: css({
       display: 'flex',

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -574,9 +574,6 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         [UrlParameterType.From]: timeRange.from.toISOString(),
         [UrlParameterType.To]: timeRange.to.toISOString(),
       };
-      if (log.labels.detected_level) {
-        params['var-levels'] = [`detected_level|=|${log.labels.detected_level}`];
-      }
       const link = getDrillDownIndexLink(labelName, labelValue, params);
       window.open(link, '_blank');
     };

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -11,6 +11,7 @@ import {
   GrafanaTheme2,
   LoadingState,
   LogRowModel,
+  UrlQueryMap,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
@@ -568,12 +569,15 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
 
     const goToLogLine = (log: LogRowModel) => {
       const timeRange = resolveRowTimeRangeForSharing(log);
-      const link = getDrillDownIndexLink(labelName, labelValue, {
+      const params: UrlQueryMap = {
         'var-filters': [`${labelName}|=|${labelValue}`],
-        'var-levels': [`detected_level|=|${log.logLevel}`],
         [UrlParameterType.From]: timeRange.from.toISOString(),
         [UrlParameterType.To]: timeRange.to.toISOString(),
-      });
+      };
+      if (log.labels.detected_level) {
+        params['var-levels'] = [`detected_level|=|${log.labels.detected_level}`];
+      }
+      const link = getDrillDownIndexLink(labelName, labelValue, params);
       window.open(link, '_blank');
     };
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -84,12 +84,7 @@ import {
   wrapWildcardSearch,
 } from 'services/query';
 import { addTabToLocalStorage, getFavoriteLabelValuesFromStorage, getServiceSelectionPageCount } from 'services/store';
-import {
-  generateLinkFromFilters,
-  getLogLineFilterParams,
-  getLogLinePermalinkFilterParams,
-  resolveRowTimeRangeForSharing,
-} from 'services/text';
+import { generateLinkFromFilters, getLogLinePermalinkFilterParams, resolveRowTimeRangeForSharing } from 'services/text';
 import {
   DETECTED_FIELDS_MIXED_FORMAT_EXPR_NO_JSON_FIELDS,
   EXPLORATION_DS,
@@ -616,7 +611,7 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         USER_EVENTS_PAGES.service_selection,
         USER_EVENTS_ACTIONS.service_selection.show_similar_logs_clicked
       );
-      const { fields } = getLogLineFilterParams(log);
+      const { fields } = getLogLinePermalinkFilterParams(log);
       goToLog(fields);
     };
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -10,7 +10,9 @@ import {
   dateTime,
   GrafanaTheme2,
   LoadingState,
+  LogRowModel,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -79,6 +81,7 @@ import {
   wrapWildcardSearch,
 } from 'services/query';
 import { addTabToLocalStorage, getFavoriteLabelValuesFromStorage, getServiceSelectionPageCount } from 'services/store';
+import { resolveRowTimeRangeForSharing, UrlParameterType } from 'services/text';
 import {
   DETECTED_FIELDS_MIXED_FORMAT_EXPR_NO_JSON_FIELDS,
   EXPLORATION_DS,
@@ -563,6 +566,17 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       window.open(link, '_blank');
     };
 
+    const goToLogLine = (log: LogRowModel) => {
+      const timeRange = resolveRowTimeRangeForSharing(log);
+      const link = getDrillDownIndexLink(labelName, labelValue, {
+        'var-filters': [`${labelName}|=|${labelValue}`],
+        'var-levels': [`detected_level|=|${log.logLevel}`],
+        [UrlParameterType.From]: timeRange.from.toISOString(),
+        [UrlParameterType.To]: timeRange.to.toISOString(),
+      });
+      window.open(link, '_blank');
+    };
+
     const cssGridItem = new SceneCSSGridItem({
       $behaviors: [new behaviors.CursorSync({ sync: DashboardCursorSync.Off })],
       body: PanelBuilders.logs()
@@ -588,6 +602,15 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setOption('displayedFields', backendDisplayedFields)
         .setOption('onClickFilterString', onClickFilterString)
         .setOption('showLogContextToggle', true)
+        .setOption('logLineMenuCustomItems', [
+          {
+            divider: true,
+          },
+          {
+            label: t('components.service-selection-scene.logs-panel.go-to-log-line', 'Go to log line'),
+            onClick: goToLogLine,
+          },
+        ])
         .build(),
     });
 

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -11,7 +11,7 @@ import {
   GrafanaTheme2,
   LoadingState,
   LogRowModel,
-  UrlQueryMap,
+  TimeRange,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
@@ -71,6 +71,8 @@ import { ServiceSelectionTabsScene } from './ServiceSelectionTabsScene';
 import { LoadSearchScene } from 'Components/SavedSearches/LoadSearchScene';
 import { getFeatureFlag } from 'featureFlags/openFeature';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
+import { LabelType } from 'services/fieldsTypes';
+import { FieldFilter, FilterOp } from 'services/filterTypes';
 import { getLevelLabelsFromSeries, toggleLevelVisibility } from 'services/levels';
 import { getMetadataService } from 'services/metadata';
 import { getQueryRunner, getSceneQueryRunner, setLevelColorOverrides, UNKNOWN_LEVEL_LOGS } from 'services/panel';
@@ -82,7 +84,12 @@ import {
   wrapWildcardSearch,
 } from 'services/query';
 import { addTabToLocalStorage, getFavoriteLabelValuesFromStorage, getServiceSelectionPageCount } from 'services/store';
-import { resolveRowTimeRangeForSharing, UrlParameterType } from 'services/text';
+import {
+  generateLinkFromFilters,
+  getLogLineFilterParams,
+  getLogLinePermalinkFilterParams,
+  resolveRowTimeRangeForSharing,
+} from 'services/text';
 import {
   DETECTED_FIELDS_MIXED_FORMAT_EXPR_NO_JSON_FIELDS,
   EXPLORATION_DS,
@@ -567,15 +574,29 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
       window.open(link, '_blank');
     };
 
-    const goToLogLine = (log: LogRowModel) => {
-      const timeRange = resolveRowTimeRangeForSharing(log);
-      const params: UrlQueryMap = {
-        'var-filters': [`${labelName}|=|${labelValue}`],
-        [UrlParameterType.From]: timeRange.from.toISOString(),
-        [UrlParameterType.To]: timeRange.to.toISOString(),
-      };
-      const link = getDrillDownIndexLink(labelName, labelValue, params);
+    const goToLog = (fields: FieldFilter[], timeRange?: TimeRange) => {
+      const labels = [
+        {
+          key: labelName,
+          operator: FilterOp.Equal,
+          type: LabelType.Indexed,
+          value: labelValue,
+        },
+      ];
+
+      const link = generateLinkFromFilters(getDrillDownIndexLink(labelName, labelValue), { labels, fields }, timeRange);
       window.open(link, '_blank');
+    };
+
+    const goToLogLine = (log: LogRowModel) => {
+      const { fields } = getLogLinePermalinkFilterParams(log);
+      const timeRange = resolveRowTimeRangeForSharing(log);
+      goToLog(fields, timeRange);
+    };
+
+    const goToSimilarLogs = (log: LogRowModel) => {
+      const { fields } = getLogLineFilterParams(log);
+      goToLog(fields);
     };
 
     const cssGridItem = new SceneCSSGridItem({
@@ -606,6 +627,10 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         .setOption('logLineMenuCustomItems', [
           {
             divider: true,
+          },
+          {
+            label: t('components.service-selection-scene.logs-panel.go-to-log-line', 'Show similar logs'),
+            onClick: goToSimilarLogs,
           },
           {
             label: t('components.service-selection-scene.logs-panel.go-to-log-line', 'Go to log line'),

--- a/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionScene.tsx
@@ -72,7 +72,7 @@ import { LoadSearchScene } from 'Components/SavedSearches/LoadSearchScene';
 import { getFeatureFlag } from 'featureFlags/openFeature';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { LabelType } from 'services/fieldsTypes';
-import { FieldFilter, FilterOp } from 'services/filterTypes';
+import { FieldFilter, FilterOp, LineFilterCaseSensitive, LineFilterOp, LineFilterType } from 'services/filterTypes';
 import { getLevelLabelsFromSeries, toggleLevelVisibility } from 'services/levels';
 import { getMetadataService } from 'services/metadata';
 import { getQueryRunner, getSceneQueryRunner, setLevelColorOverrides, UNKNOWN_LEVEL_LOGS } from 'services/panel';
@@ -567,14 +567,23 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
     const backendDisplayedFields = this.getDefaultColumns(labelName, labelValue);
 
     const onClickFilterString = (lineFilter: string) => {
-      const link = getDrillDownIndexLink(labelName, labelValue, {
-        'var-filters': [`${labelName}|=|${labelValue}`],
-        'var-lineFilters': [`caseInsensitive,0|__gfp__=|${lineFilter}`],
-      });
-      window.open(link, '_blank');
+      reportAppInteraction(
+        USER_EVENTS_PAGES.service_selection,
+        USER_EVENTS_ACTIONS.service_selection.logs_popover_line_filter
+      );
+      goToLog(
+        [],
+        [
+          {
+            key: LineFilterCaseSensitive.caseInsensitive.toString(),
+            operator: LineFilterOp.match,
+            value: lineFilter,
+          },
+        ]
+      );
     };
 
-    const goToLog = (fields: FieldFilter[], timeRange?: TimeRange) => {
+    const goToLog = (fields: FieldFilter[], lineFilters: LineFilterType[] = [], timeRange?: TimeRange) => {
       const labels = [
         {
           key: labelName,
@@ -584,17 +593,29 @@ export class ServiceSelectionScene extends SceneObjectBase<ServiceSelectionScene
         },
       ];
 
-      const link = generateLinkFromFilters(getDrillDownIndexLink(labelName, labelValue), { labels, fields }, timeRange);
+      const link = generateLinkFromFilters(
+        getDrillDownIndexLink(labelName, labelValue),
+        { labels, fields, lineFilters },
+        timeRange
+      );
       window.open(link, '_blank');
     };
 
     const goToLogLine = (log: LogRowModel) => {
+      reportAppInteraction(
+        USER_EVENTS_PAGES.service_selection,
+        USER_EVENTS_ACTIONS.service_selection.go_to_log_line_clicked
+      );
       const { fields } = getLogLinePermalinkFilterParams(log);
       const timeRange = resolveRowTimeRangeForSharing(log);
-      goToLog(fields, timeRange);
+      goToLog(fields, [], timeRange);
     };
 
     const goToSimilarLogs = (log: LogRowModel) => {
+      reportAppInteraction(
+        USER_EVENTS_PAGES.service_selection,
+        USER_EVENTS_ACTIONS.service_selection.show_similar_logs_clicked
+      );
       const { fields } = getLogLineFilterParams(log);
       goToLog(fields);
     };

--- a/src/Components/Table/LineActionIcons.tsx
+++ b/src/Components/Table/LineActionIcons.tsx
@@ -8,7 +8,7 @@ import { ClipboardButton, IconButton, Modal, useTheme2 } from '@grafana/ui';
 
 import { testIds } from '../../services/testIds';
 import { useQueryContext } from 'Components/Table/Context/QueryContext';
-import { generateLogShortlink } from 'services/text';
+import { generateLogRowShortlink, getPermalinkLogRowFromDataFrame } from 'services/text';
 
 export const getStyles = (theme: GrafanaTheme2, isNumber?: boolean) => ({
   clipboardButton: css({
@@ -51,16 +51,21 @@ export function LineActionIcons(props: { rowIndex: number; value: unknown }) {
   const isNumber = typeof props.value === 'string' && !isNaN(Number(props.value));
   const theme = useTheme2();
   const styles = getStyles(theme, isNumber);
-  const { logsFrame, timeRange } = useQueryContext();
+  const { logsFrame } = useQueryContext();
   const logId = logsFrame?.idField?.values[props.rowIndex];
   const lineValue = logsFrame?.bodyField.values[props.rowIndex];
   const [isInspecting, setIsInspecting] = useState(false);
   const getText = useCallback(() => {
-    if (timeRange) {
-      return generateLogShortlink('selectedLine', { id: logId, row: props.rowIndex }, timeRange);
+    if (!logsFrame) {
+      return '';
     }
-    return '';
-  }, [logId, props.rowIndex, timeRange]);
+    const row = getPermalinkLogRowFromDataFrame(logsFrame.raw, props.rowIndex);
+    if (!row) {
+      return '';
+    }
+    // The Table view scrolls to and highlights the line from the `selectedLine` url param.
+    return generateLogRowShortlink(row, { id: logId, row: props.rowIndex }, 'selectedLine');
+  }, [logsFrame, logId, props.rowIndex]);
   return (
     <>
       <div className={styles.iconWrapper}>

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -727,6 +727,9 @@
         "docs-link": "Instructions to enable volume in the Loki config:",
         "title": "Log volume has not been configured."
       },
+      "logs-panel": {
+        "go-to-log-line": "Go to log line"
+      },
       "no-service-search-results": {
         "title": "No service matched your search."
       },

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -728,7 +728,8 @@
         "title": "Log volume has not been configured."
       },
       "logs-panel": {
-        "go-to-log-line": "Go to log line"
+        "go-to-log-line": "Go to log line",
+        "show-similar-logs": "Show similar logs"
       },
       "no-service-search-results": {
         "title": "No service matched your search."

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -51,6 +51,12 @@ export const USER_EVENTS_ACTIONS = {
     service_selected: 'service_selected',
     // Adding new tab
     add_new_tab: 'add_new_tab',
+    // Clicking "Go to log line" in the logs panel menu.
+    go_to_log_line_clicked: 'go_to_log_line_clicked',
+    // Clicking "Show similar logs" in the logs panel menu.
+    show_similar_logs_clicked: 'show_similar_logs_clicked',
+    // Clicking a line filter from the logs panel popover menu.
+    logs_popover_line_filter: 'logs_popover_line_filter',
   },
   [USER_EVENTS_PAGES.service_details]: {
     // Selecting action view tab (logs/labels/fields/patterns). Props: newActionView, previousActionView

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -97,7 +97,7 @@ export function stringifyAdHocValueLabels(value?: string): string {
   return escapeURLDelimiters(replaceEscapeChars(value));
 }
 
-function setUrlParamsFromFieldFilters(fields: FieldFilter[], params: URLSearchParams) {
+export function setUrlParamsFromFieldFilters(fields: FieldFilter[], params: URLSearchParams) {
   for (const field of fields) {
     if (field.type === LabelType.StructuredMetadata) {
       if (field.key === LEVEL_VARIABLE_VALUE) {
@@ -350,4 +350,3 @@ export function interpolateQueryExpr(value: string | unknown[], variable: QueryV
   const escapedValues = lodashMap(value, lokiSpecialRegexEscape);
   return escapedValues.join('|');
 }
-

--- a/src/services/extensions/links.ts
+++ b/src/services/extensions/links.ts
@@ -147,7 +147,7 @@ export function setUrlParamsFromLabelFilters(labelFilters: IndexedLabelFilter[],
   return params;
 }
 
-function setLineFilterUrlParams(lineFilters: LineFilterType[], params: URLSearchParams) {
+export function setLineFilterUrlParams(lineFilters: LineFilterType[], params: URLSearchParams) {
   for (const lineFilter of lineFilters) {
     params = appendUrlParameter(
       UrlParameters.LineFilters,

--- a/src/services/text.test.ts
+++ b/src/services/text.test.ts
@@ -1,7 +1,16 @@
-import { dateTime, LogsSortOrder, TimeRange } from '@grafana/data';
+import { dateTime, FieldType, LogsSortOrder, TimeRange, toDataFrame } from '@grafana/data';
 
 import { PLUGIN_ID } from './plugin';
-import { generateLogShortlink } from './text';
+import {
+  capitalizeFirstLetter,
+  ensureValidTimeRangeForLink,
+  generateLink,
+  generateLogRowShortlink,
+  generateLogShortlink,
+  PermalinkLogRow,
+  resolveRowTimeRangeForSharing,
+  truncateText,
+} from './text';
 
 // Var declaration is required to hoist subPath, so we can use it in both the jest.mock call below (which is also hoisted), and the test assertion
 // eslint-disable-next-line no-var
@@ -47,5 +56,155 @@ describe('generateLogShortlink', () => {
         JSON.stringify(panelState)
       )}`
     );
+  });
+});
+
+describe('generateLink', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', `/a/${PLUGIN_ID}/explore`);
+  });
+
+  test('prepends protocol, host, and configured sub-path to the relative url', () => {
+    expect(generateLink(`/a/${PLUGIN_ID}/explore?var-ds=DSID`)).toEqual(
+      `http://localhost:3000${mockSubPath}/a/${PLUGIN_ID}/explore?var-ds=DSID`
+    );
+  });
+
+  test('handles an empty relative url', () => {
+    expect(generateLink('')).toEqual(`http://localhost:3000${mockSubPath}`);
+  });
+});
+
+describe('capitalizeFirstLetter', () => {
+  test('capitalizes the first letter and keeps the rest unchanged', () => {
+    expect(capitalizeFirstLetter('hello')).toEqual('Hello');
+  });
+
+  test('leaves an already capitalized string unchanged', () => {
+    expect(capitalizeFirstLetter('Hello world')).toEqual('Hello world');
+  });
+});
+
+describe('truncateText', () => {
+  test('truncates and appends an ellipsis when the input is longer than the length', () => {
+    expect(truncateText('hello world', 5, true)).toEqual('hello…');
+  });
+
+  test('does not append an ellipsis when ellipsis is disabled', () => {
+    expect(truncateText('hello world', 5, false)).toEqual('hello');
+  });
+
+  test('does not append an ellipsis when the input fits within the length', () => {
+    expect(truncateText('hi', 5, true)).toEqual('hi');
+  });
+});
+
+describe('ensureValidTimeRangeForLink', () => {
+  test('returns the original range when end is after start', () => {
+    expect(ensureValidTimeRangeForLink(1000, 5000)).toEqual([1000, 5000]);
+  });
+
+  test('expands the range by 1000ms when end equals start', () => {
+    expect(ensureValidTimeRangeForLink(1000, 1000)).toEqual([1000, 2000]);
+  });
+
+  test('expands the range by 1000ms when end is before start', () => {
+    expect(ensureValidTimeRangeForLink(5000, 1000)).toEqual([5000, 6000]);
+  });
+});
+
+describe('resolveRowTimeRangeForSharing', () => {
+  test('builds a 1000ms range centered on the log timestamp', () => {
+    const timeEpochMs = 1_000_000;
+    const range = resolveRowTimeRangeForSharing({ timeEpochMs });
+
+    expect(range.from.valueOf()).toEqual(timeEpochMs - 500);
+    expect(range.to.valueOf()).toEqual(timeEpochMs + 500);
+    expect(range.raw.from.valueOf()).toEqual(timeEpochMs - 500);
+    expect(range.raw.to.valueOf()).toEqual(timeEpochMs + 500);
+    expect(range.to.valueOf() - range.from.valueOf()).toEqual(1000);
+  });
+});
+
+describe('generateLogRowShortlink', () => {
+  const timeEpochMs = 1_000_000;
+
+  beforeEach(() => {
+    window.history.pushState(
+      {},
+      '',
+      `/a/${PLUGIN_ID}/explore/service/test/logs?var-ds=DSID&var-filters=service_name|=|test&from=now-5m&to=now`
+    );
+  });
+
+  test('preserves existing params, injects the panel state, and derives the time range from the row', () => {
+    const log: PermalinkLogRow = {
+      dataFrame: toDataFrame({ fields: [] }),
+      labels: {},
+      rowIndex: 0,
+      timeEpochMs,
+      uniqueLabels: {},
+    };
+    const panelState = {
+      logs: { displayedFields: ['field1'], id: 'abc-123', sortOrder: LogsSortOrder.Descending },
+    };
+
+    const url = new URL(generateLogRowShortlink(log, panelState));
+
+    expect(url.origin).toEqual('http://localhost:3000');
+    expect(url.pathname).toEqual(`${mockSubPath}/a/${PLUGIN_ID}/explore/service/test/logs`);
+    expect(url.searchParams.get('var-ds')).toEqual('DSID');
+    expect(url.searchParams.get('panelState')).toEqual(JSON.stringify(panelState));
+    // The time range is centered on the log line, not the original now-5m/now picker range.
+    expect(url.searchParams.get('from')).toEqual(dateTime(timeEpochMs - 500).toISOString());
+    expect(url.searchParams.get('to')).toEqual(dateTime(timeEpochMs + 500).toISOString());
+    // No fields/labels filters were derived from this empty row.
+    expect(url.searchParams.get('var-fields')).toBeNull();
+    expect(url.searchParams.get('var-labels')).toBeNull();
+  });
+
+  test('derives level and structured-metadata field filters but drops indexed labels', () => {
+    const log: PermalinkLogRow = {
+      dataFrame: toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [timeEpochMs] },
+          { name: 'Line', type: FieldType.string, values: ['line'] },
+          {
+            name: 'labelTypes',
+            type: FieldType.other,
+            values: [{ detected_level: 'S', pod: 'I', service: 'S' }],
+          },
+        ],
+      }),
+      labels: { detected_level: 'info' },
+      rowIndex: 0,
+      timeEpochMs,
+      uniqueLabels: { detected_level: 'info', pod: 'mypod', service: 'mysvc' },
+    };
+
+    const url = new URL(generateLogRowShortlink(log));
+
+    // `detected_level` is structured metadata so it lands in the levels variable.
+    expect(url.searchParams.get('var-levels')).toContain('detected_level');
+    // `service` is structured metadata so it lands in the metadata variable.
+    expect(url.searchParams.get('var-metadata')).toContain('service');
+    // `pod` is an indexed label, which generateLogRowShortlink intentionally drops.
+    expect(url.searchParams.get('var-labels')).toBeNull();
+  });
+
+  test('uses the provided param name for the panel state', () => {
+    const log: PermalinkLogRow = {
+      dataFrame: toDataFrame({ fields: [] }),
+      labels: {},
+      rowIndex: 0,
+      timeEpochMs,
+      uniqueLabels: {},
+    };
+    const panelState = { id: 'row-1', row: 3 };
+
+    const url = new URL(generateLogRowShortlink(log, panelState, 'customState'));
+
+    expect(url.searchParams.get('customState')).toEqual(JSON.stringify(panelState));
+    expect(url.searchParams.get('panelState')).toBeNull();
   });
 });

--- a/src/services/text.test.ts
+++ b/src/services/text.test.ts
@@ -1,12 +1,16 @@
 import { dateTime, FieldType, LogsSortOrder, TimeRange, toDataFrame } from '@grafana/data';
 
+import { LabelType } from './fieldsTypes';
+import { FilterOp, LineFilterOp } from './filterTypes';
 import { PLUGIN_ID } from './plugin';
 import {
   capitalizeFirstLetter,
   ensureValidTimeRangeForLink,
   generateLink,
+  generateLinkFromFilters,
   generateLogRowShortlink,
   generateLogShortlink,
+  getLogLinePermalinkFilterParams,
   PermalinkLogRow,
   resolveRowTimeRangeForSharing,
   truncateText,
@@ -161,6 +165,7 @@ describe('generateLogRowShortlink', () => {
     // No fields/labels filters were derived from this empty row.
     expect(url.searchParams.get('var-fields')).toBeNull();
     expect(url.searchParams.get('var-labels')).toBeNull();
+    expect(url.searchParams.get('var-filters')).toBeDefined();
   });
 
   test('derives level and structured-metadata field filters but drops indexed labels', () => {
@@ -206,5 +211,128 @@ describe('generateLogRowShortlink', () => {
 
     expect(url.searchParams.get('customState')).toEqual(JSON.stringify(panelState));
     expect(url.searchParams.get('panelState')).toBeNull();
+  });
+});
+
+describe('getLogLinePermalinkFilterParams', () => {
+  const makeLog = (overrides: Partial<PermalinkLogRow>): PermalinkLogRow => ({
+    dataFrame: toDataFrame({ fields: [] }),
+    labels: {},
+    rowIndex: 0,
+    timeEpochMs: 0,
+    uniqueLabels: {},
+    ...overrides,
+  });
+
+  test('returns empty filters for a row with no labels', () => {
+    expect(getLogLinePermalinkFilterParams(makeLog({}))).toEqual({ fields: [], labels: [] });
+  });
+
+  test('derives a level field from the detected_level label', () => {
+    const log = makeLog({
+      dataFrame: toDataFrame({
+        fields: [{ name: 'labelTypes', type: FieldType.other, values: [{ detected_level: 'S' }] }],
+      }),
+      labels: { detected_level: 'info' },
+    });
+
+    expect(getLogLinePermalinkFilterParams(log).fields).toEqual([
+      { key: 'detected_level', operator: FilterOp.Equal, type: LabelType.StructuredMetadata, value: 'info' },
+    ]);
+  });
+
+  test('defaults the level field type to Parsed when the frame has no label types', () => {
+    const log = makeLog({ labels: { detected_level: 'warn' } });
+
+    expect(getLogLinePermalinkFilterParams(log).fields).toEqual([
+      { key: 'detected_level', operator: FilterOp.Equal, type: LabelType.Parsed, value: 'warn' },
+    ]);
+  });
+
+  test('routes indexed labels to labels and structured metadata to fields', () => {
+    const log = makeLog({
+      dataFrame: toDataFrame({
+        fields: [{ name: 'labelTypes', type: FieldType.other, values: [{ pod: 'I', region: 'S' }] }],
+      }),
+      uniqueLabels: { pod: 'mypod', region: 'us-east' },
+    });
+
+    const { fields, labels } = getLogLinePermalinkFilterParams(log);
+
+    expect(labels).toEqual([{ key: 'pod', operator: FilterOp.Equal, type: LabelType.Indexed, value: 'mypod' }]);
+    expect(fields).toEqual([
+      {
+        key: 'region',
+        operator: FilterOp.Equal,
+        parser: 'structuredMetadata',
+        type: LabelType.StructuredMetadata,
+        value: 'us-east',
+      },
+    ]);
+  });
+
+  test('skips reserved labels such as level and aggregated-metric markers', () => {
+    const log = makeLog({
+      uniqueLabels: { __aggregated_metric__: '1', detected_level: 'info', level: 'info', level_extracted: 'info' },
+    });
+
+    expect(getLogLinePermalinkFilterParams(log)).toEqual({ fields: [], labels: [] });
+  });
+
+  test('limits parsed fields to two to avoid overcrowding the filters', () => {
+    const log = makeLog({
+      dataFrame: toDataFrame({
+        fields: [{ name: 'labelTypes', type: FieldType.other, values: [{ p1: 'P', p2: 'P', p3: 'P' }] }],
+      }),
+      uniqueLabels: { p1: 'a', p2: 'b', p3: 'c' },
+    });
+
+    const { fields } = getLogLinePermalinkFilterParams(log);
+
+    expect(fields.map((field) => field.key)).toEqual(['p1', 'p2']);
+    expect(fields.every((field) => field.parser === 'mixed')).toBe(true);
+  });
+});
+
+describe('generateLinkFromFilters', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', `/a/${PLUGIN_ID}/explore`);
+  });
+
+  const path = `/a/${PLUGIN_ID}/explore?var-ds=DSID`;
+
+  test('prepends the sub-path and preserves the existing query when no filters are given', () => {
+    const url = new URL(generateLinkFromFilters(path, { labels: [] }));
+
+    expect(url.origin).toEqual('http://localhost:3000');
+    expect(url.pathname).toEqual(`${mockSubPath}/a/${PLUGIN_ID}/explore`);
+    expect(url.searchParams.get('var-ds')).toEqual('DSID');
+  });
+
+  test('writes the time range into from/to params', () => {
+    const timeRange: TimeRange = {
+      from: dateTime(0),
+      raw: { from: dateTime(0), to: dateTime(1000) },
+      to: dateTime(1000),
+    };
+
+    const url = new URL(generateLinkFromFilters(path, { labels: [] }, timeRange));
+
+    expect(url.searchParams.get('from')).toEqual(dateTime(0).toISOString());
+    expect(url.searchParams.get('to')).toEqual(dateTime(1000).toISOString());
+  });
+
+  test('adds indexed label, field, and line filter params', () => {
+    const url = new URL(
+      generateLinkFromFilters(path, {
+        fields: [{ key: 'region', operator: FilterOp.Equal, parser: 'mixed', type: LabelType.Parsed, value: 'us' }],
+        labels: [{ key: 'pod', operator: FilterOp.Equal, type: LabelType.Indexed, value: 'mypod' }],
+        lineFilters: [{ key: 'caseSensitive', operator: LineFilterOp.match, value: 'error' }],
+      })
+    );
+
+    expect(url.searchParams.get('var-filters')).toContain('pod');
+    expect(url.searchParams.get('var-fields')).toContain('region');
+    expect(url.searchParams.get('var-lineFilters')).toContain('error');
   });
 });

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,9 +1,9 @@
 import { dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 
-import { setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';
+import { setLineFilterUrlParams, setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';
 import { LabelType } from './fieldsTypes';
-import { FieldFilter, FilterOp, IndexedLabelFilter } from './filterTypes';
+import { FieldFilter, FilterOp, IndexedLabelFilter, LineFilterType } from './filterTypes';
 import { logger } from './logger';
 import { getLabelTypeFromFrame } from './lokiQuery';
 import { LEVEL_VARIABLE_VALUE } from './variables';
@@ -57,25 +57,44 @@ export const generateLogShortlink = (paramName: string, data: PermalinkDataType,
   return generateLink(urlUtil.renderUrl(location.pathname, searchParams));
 };
 
-export const generateLogRowShortlink = (log: LogRowModel, panelState: PermalinkDataType) => {
+export const generateLogRowShortlink = (log: LogRowModel, panelState?: PermalinkDataType) => {
   const location = locationService.getLocation();
   const timeRange = resolveRowTimeRangeForSharing(log);
   let searchParams = new URLSearchParams(location.search);
+  searchParams.set('panelState', JSON.stringify(panelState));
+  return generateLinkFromFilters(location.pathname, timeRange, searchParams, getLogLineFilterParams(log));
+};
+
+export type LinkFilters = {
+  fields?: FieldFilter[];
+  labels: IndexedLabelFilter[];
+  lineFilters?: LineFilterType[];
+};
+
+export const generateLinkFromFilters = (
+  path: string,
+  timeRange: TimeRange,
+  searchParams: URLSearchParams,
+  filters: LinkFilters
+) => {
   searchParams.set(UrlParameterType.From, timeRange.from.toISOString());
   searchParams.set(UrlParameterType.To, timeRange.to.toISOString());
-  searchParams.set('panelState', JSON.stringify(panelState));
 
-  const { fields, labels } = getLogLineFilterParams(log);
-
-  if (fields.length) {
-    searchParams = setUrlParamsFromFieldFilters(fields, searchParams);
-  }
+  const { fields = [], labels, lineFilters = [] } = filters;
 
   if (labels.length) {
     searchParams = setUrlParamsFromLabelFilters(labels, searchParams);
   }
 
-  return generateLink(`${location.pathname}?${searchParams.toString()}`);
+  if (lineFilters.length) {
+    searchParams = setLineFilterUrlParams(lineFilters, searchParams);
+  }
+
+  if (fields.length) {
+    searchParams = setUrlParamsFromFieldFilters(fields, searchParams);
+  }
+
+  return generateLink(`${path}?${searchParams.toString()}`);
 };
 
 /**

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,4 +1,4 @@
-import { DataFrame, dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
+import { DataFrame, dateTime, FieldType, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 
 import { setLineFilterUrlParams, setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';
@@ -170,6 +170,9 @@ export function getLogLinePermalinkFilterParams(log: PermalinkLogRow) {
     }
     const labelType = getLabelTypeFromFrame(label, log.dataFrame, log.rowIndex) ?? LabelType.Parsed;
 
+    // Limit parsed fields to not overcrowd the filters with superfluous entries.
+    const hasParsedFields = fields.filter((field) => field.type === LabelType.Parsed).length === 2;
+
     if (labelType === LabelType.Indexed) {
       labels.push({
         key: label,
@@ -177,7 +180,7 @@ export function getLogLinePermalinkFilterParams(log: PermalinkLogRow) {
         type: LabelType.Indexed,
         value: log.uniqueLabels[label],
       });
-    } else {
+    } else if (labelType === LabelType.StructuredMetadata || !hasParsedFields) {
       fields.push({
         key: label,
         operator: FilterOp.Equal,
@@ -191,24 +194,6 @@ export function getLogLinePermalinkFilterParams(log: PermalinkLogRow) {
   return {
     fields,
     labels,
-  };
-}
-
-/**
- * Given a particular log, return the minimum set of filters to browse this and similar log lines.
- */
-export function getLogLineFilterParams(log: PermalinkLogRow) {
-  const { fields, labels } = getLogLinePermalinkFilterParams(log);
-
-  // If structured metadata fields are available, filter parsed fields to reduce noise.
-  const hasStructuredMetadata = fields.some((field) => field.type === LabelType.StructuredMetadata);
-  const filteredFields = hasStructuredMetadata
-    ? fields.filter((field) => field.type === LabelType.StructuredMetadata)
-    : fields;
-
-  return {
-    labels,
-    fields: filteredFields,
   };
 }
 

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,4 +1,4 @@
-import { DataFrame, dateTime, FieldType, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
+import { DataFrame, dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 
 import { setLineFilterUrlParams, setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,10 +1,11 @@
-import { dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
+import { DataFrame, dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 
 import { setLineFilterUrlParams, setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';
 import { LabelType } from './fieldsTypes';
 import { FieldFilter, FilterOp, IndexedLabelFilter, LineFilterType } from './filterTypes';
 import { logger } from './logger';
+import { parseLogsFrame } from './logsFrame';
 import { getLabelTypeFromFrame } from './lokiQuery';
 import { LEVEL_VARIABLE_VALUE } from './variables';
 
@@ -44,6 +45,14 @@ type PermalinkDataType =
       };
     };
 
+/**
+ * The minimal subset of {@link LogRowModel} required to build a permalink to a log line.
+ * A full `LogRowModel` (as provided by the native logs panel) satisfies this type, but it can
+ * also be constructed from a raw data frame row via {@link getPermalinkLogRowFromDataFrame},
+ * which is what the Table and JSON visualizations use.
+ */
+export type PermalinkLogRow = Pick<LogRowModel, 'dataFrame' | 'labels' | 'rowIndex' | 'timeEpochMs' | 'uniqueLabels'>;
+
 export const generateLink = (relativeUrl: string): string => {
   return `${window.location.protocol}//${window.location.host}${config.appSubUrl}${relativeUrl}`;
 };
@@ -57,14 +66,47 @@ export const generateLogShortlink = (paramName: string, data: PermalinkDataType,
   return generateLink(urlUtil.renderUrl(location.pathname, searchParams));
 };
 
-export const generateLogRowShortlink = (log: LogRowModel, panelState?: PermalinkDataType) => {
+export const generateLogRowShortlink = (
+  log: PermalinkLogRow,
+  panelState?: PermalinkDataType,
+  paramName = 'panelState'
+) => {
   const location = locationService.getLocation();
   const timeRange = resolveRowTimeRangeForSharing(log);
   let searchParams = new URLSearchParams(location.search);
-  searchParams.set('panelState', JSON.stringify(panelState));
+  searchParams.set(paramName, JSON.stringify(panelState));
   const { fields } = getLogLinePermalinkFilterParams(log);
   return generateLinkFromFilters(`${location.pathname}?${searchParams.toString()}`, { fields, labels: [] }, timeRange);
 };
+
+/**
+ * Builds a {@link PermalinkLogRow} from a raw logs data frame and a row index. Used by the Table and
+ * JSON visualizations, which work with data frames rather than `LogRowModel`s, to produce permalinks
+ * via {@link generateLogRowShortlink}.
+ */
+export function getPermalinkLogRowFromDataFrame(dataFrame: DataFrame, rowIndex: number): PermalinkLogRow | null {
+  const logsFrame = parseLogsFrame(dataFrame);
+  if (!logsFrame) {
+    return null;
+  }
+
+  const timeEpochMs = Number(logsFrame.timeField.values[rowIndex]);
+  if (!Number.isFinite(timeEpochMs)) {
+    return null;
+  }
+
+  // Use the row's full label set for both `labels` and `uniqueLabels`: `getLogLinePermalinkFilterParams`
+  // reads the level from `labels` and derives field filters from `uniqueLabels`, skipping indexed labels.
+  const labels = logsFrame.getLogFrameLabelsAsLabels()?.[rowIndex] ?? {};
+
+  return {
+    dataFrame,
+    labels,
+    rowIndex,
+    timeEpochMs,
+    uniqueLabels: labels,
+  };
+}
 
 export type LinkFilters = {
   fields?: FieldFilter[];
@@ -109,7 +151,7 @@ const OMIT_UNIQUE_LABELS = [
 /**
  * Given a particular log, generate the necessary filters to narrow down the search as much as possible.
  */
-export function getLogLinePermalinkFilterParams(log: LogRowModel) {
+export function getLogLinePermalinkFilterParams(log: PermalinkLogRow) {
   const labels: IndexedLabelFilter[] = [];
   const fields: FieldFilter[] = [];
 
@@ -117,7 +159,7 @@ export function getLogLinePermalinkFilterParams(log: LogRowModel) {
     fields.push({
       key: LEVEL_VARIABLE_VALUE,
       operator: FilterOp.Equal,
-      type: getLabelTypeFromFrame(LEVEL_VARIABLE_VALUE, log.dataFrame) ?? LabelType.Parsed,
+      type: getLabelTypeFromFrame(LEVEL_VARIABLE_VALUE, log.dataFrame, log.rowIndex) ?? LabelType.Parsed,
       value: log.labels[LEVEL_VARIABLE_VALUE],
     });
   }
@@ -126,7 +168,7 @@ export function getLogLinePermalinkFilterParams(log: LogRowModel) {
     if (OMIT_UNIQUE_LABELS.includes(label)) {
       continue;
     }
-    const labelType = getLabelTypeFromFrame(label, log.dataFrame) ?? LabelType.Parsed;
+    const labelType = getLabelTypeFromFrame(label, log.dataFrame, log.rowIndex) ?? LabelType.Parsed;
 
     if (labelType === LabelType.Indexed) {
       labels.push({
@@ -155,7 +197,7 @@ export function getLogLinePermalinkFilterParams(log: LogRowModel) {
 /**
  * Given a particular log, return the minimum set of filters to browse this and similar log lines.
  */
-export function getLogLineFilterParams(log: LogRowModel) {
+export function getLogLineFilterParams(log: PermalinkLogRow) {
   const { fields, labels } = getLogLinePermalinkFilterParams(log);
 
   // If structured metadata fields are available, filter parsed fields to reduce noise.
@@ -195,7 +237,7 @@ export function truncateText(input: string, length: number, ellipsis: boolean) {
 /** Minimum duration in ms so trace lookups (e.g. from Loki derived field) always get start < end. */
 const MIN_SHARE_RANGE_MS = 1000;
 
-export function resolveRowTimeRangeForSharing(row: LogRowModel): TimeRange {
+export function resolveRowTimeRangeForSharing(row: Pick<LogRowModel, 'timeEpochMs'>): TimeRange {
   // With infinite scrolling, we cannot rely on the time picker range, so we use a time range around the shared log line.
   // Ensure end > start (Tempo returns "end timestamp must not be before or equal to start time" otherwise).
   const half = Math.max(MIN_SHARE_RANGE_MS / 2, 1);

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -59,10 +59,13 @@ export const generateLogShortlink = (paramName: string, data: PermalinkDataType,
 
 export const generateLogRowShortlink = (log: LogRowModel, panelState?: PermalinkDataType) => {
   const location = locationService.getLocation();
+  console.log(location);
+  return;
   const timeRange = resolveRowTimeRangeForSharing(log);
   let searchParams = new URLSearchParams(location.search);
   searchParams.set('panelState', JSON.stringify(panelState));
-  return generateLinkFromFilters(location.pathname, timeRange, searchParams, getLogLineFilterParams(log));
+  const { fields } = getLogLinePermalinkFilterParams(log);
+  return generateLinkFromFilters(location.pathname, timeRange, searchParams, { fields, labels: [] });
 };
 
 export type LinkFilters = {
@@ -71,14 +74,14 @@ export type LinkFilters = {
   lineFilters?: LineFilterType[];
 };
 
-export const generateLinkFromFilters = (
-  path: string,
-  timeRange: TimeRange,
-  searchParams: URLSearchParams,
-  filters: LinkFilters
-) => {
-  searchParams.set(UrlParameterType.From, timeRange.from.toISOString());
-  searchParams.set(UrlParameterType.To, timeRange.to.toISOString());
+export const generateLinkFromFilters = (path: string, filters: LinkFilters, timeRange?: TimeRange) => {
+  const url = new URL(generateLink(path));
+
+  let searchParams = url.searchParams;
+  if (timeRange) {
+    searchParams.set(UrlParameterType.From, timeRange.from.toISOString());
+    searchParams.set(UrlParameterType.To, timeRange.to.toISOString());
+  }
 
   const { fields = [], labels, lineFilters = [] } = filters;
 
@@ -94,12 +97,9 @@ export const generateLinkFromFilters = (
     searchParams = setUrlParamsFromFieldFilters(fields, searchParams);
   }
 
-  return generateLink(`${path}?${searchParams.toString()}`);
+  return `${url.origin}${url.pathname}?${searchParams.toString()}`;
 };
 
-/**
- * Given a particular log, generate the necessary filters to narrow down the search as much as possible.
- */
 const OMIT_UNIQUE_LABELS = [
   '__aggregated_metric__',
   '__stream_shard__',
@@ -108,7 +108,10 @@ const OMIT_UNIQUE_LABELS = [
   'level',
   'level_extracted',
 ];
-export function getLogLineFilterParams(log: LogRowModel) {
+/**
+ * Given a particular log, generate the necessary filters to narrow down the search as much as possible.
+ */
+export function getLogLinePermalinkFilterParams(log: LogRowModel) {
   const labels: IndexedLabelFilter[] = [];
   const fields: FieldFilter[] = [];
 
@@ -131,6 +134,7 @@ export function getLogLineFilterParams(log: LogRowModel) {
       labels.push({
         key: label,
         operator: FilterOp.Equal,
+        type: LabelType.Indexed,
         value: log.uniqueLabels[label],
       });
     } else {
@@ -143,9 +147,28 @@ export function getLogLineFilterParams(log: LogRowModel) {
       });
     }
   }
+
   return {
     fields,
     labels,
+  };
+}
+
+/**
+ * Given a particular log, return the minimum set of filters to browse this and similar log lines.
+ */
+export function getLogLineFilterParams(log: LogRowModel) {
+  const { fields, labels } = getLogLinePermalinkFilterParams(log);
+
+  // If structured metadata fields are available, filter parsed fields to reduce noise.
+  const hasStructuredMetadata = fields.some((field) => field.type === LabelType.StructuredMetadata);
+  const filteredFields = hasStructuredMetadata
+    ? fields.filter((field) => field.type === LabelType.StructuredMetadata)
+    : fields;
+
+  return {
+    labels,
+    fields: filteredFields,
   };
 }
 

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -59,13 +59,11 @@ export const generateLogShortlink = (paramName: string, data: PermalinkDataType,
 
 export const generateLogRowShortlink = (log: LogRowModel, panelState?: PermalinkDataType) => {
   const location = locationService.getLocation();
-  console.log(location);
-  return;
   const timeRange = resolveRowTimeRangeForSharing(log);
   let searchParams = new URLSearchParams(location.search);
   searchParams.set('panelState', JSON.stringify(panelState));
   const { fields } = getLogLinePermalinkFilterParams(log);
-  return generateLinkFromFilters(location.pathname, timeRange, searchParams, { fields, labels: [] });
+  return generateLinkFromFilters(`${location.pathname}?${searchParams.toString()}`, { fields, labels: [] }, timeRange);
 };
 
 export type LinkFilters = {

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,7 +1,12 @@
 import { dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 
+import { setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';
+import { LabelType } from './fieldsTypes';
+import { FieldFilter, FilterOp, IndexedLabelFilter } from './filterTypes';
 import { logger } from './logger';
+import { getLabelTypeFromFrame } from './lokiQuery';
+import { LEVEL_VARIABLE_VALUE } from './variables';
 
 /**
  * Copies text synchronously. If not executed in the same call stack as the user event this will fail in Safari!
@@ -51,6 +56,79 @@ export const generateLogShortlink = (paramName: string, data: PermalinkDataType,
   searchParams[paramName] = JSON.stringify(data);
   return generateLink(urlUtil.renderUrl(location.pathname, searchParams));
 };
+
+export const generateLogRowShortlink = (log: LogRowModel, panelState: PermalinkDataType) => {
+  const location = locationService.getLocation();
+  const timeRange = resolveRowTimeRangeForSharing(log);
+  let searchParams = new URLSearchParams(location.search);
+  searchParams.set(UrlParameterType.From, timeRange.from.toISOString());
+  searchParams.set(UrlParameterType.To, timeRange.to.toISOString());
+  searchParams.set('panelState', JSON.stringify(panelState));
+
+  const { fields, labels } = getLogLineFilterParams(log);
+
+  if (fields.length) {
+    searchParams = setUrlParamsFromFieldFilters(fields, searchParams);
+  }
+
+  if (labels.length) {
+    searchParams = setUrlParamsFromLabelFilters(labels, searchParams);
+  }
+
+  return generateLink(`${location.pathname}?${searchParams.toString()}`);
+};
+
+/**
+ * Given a particular log, generate the necessary filters to narrow down the search as much as possible.
+ */
+const OMIT_UNIQUE_LABELS = [
+  '__aggregated_metric__',
+  '__stream_shard__',
+  '__adaptive_logs_sampled__',
+  LEVEL_VARIABLE_VALUE,
+  'level',
+  'level_extracted',
+];
+export function getLogLineFilterParams(log: LogRowModel) {
+  const labels: IndexedLabelFilter[] = [];
+  const fields: FieldFilter[] = [];
+
+  if (log.labels[LEVEL_VARIABLE_VALUE]) {
+    fields.push({
+      key: LEVEL_VARIABLE_VALUE,
+      operator: FilterOp.Equal,
+      type: getLabelTypeFromFrame(LEVEL_VARIABLE_VALUE, log.dataFrame) ?? LabelType.Parsed,
+      value: log.labels[LEVEL_VARIABLE_VALUE],
+    });
+  }
+
+  for (const label in log.uniqueLabels) {
+    if (OMIT_UNIQUE_LABELS.includes(label)) {
+      continue;
+    }
+    const labelType = getLabelTypeFromFrame(label, log.dataFrame) ?? LabelType.Parsed;
+
+    if (labelType === LabelType.Indexed) {
+      labels.push({
+        key: label,
+        operator: FilterOp.Equal,
+        value: log.uniqueLabels[label],
+      });
+    } else {
+      fields.push({
+        key: label,
+        operator: FilterOp.Equal,
+        type: labelType,
+        parser: labelType === LabelType.StructuredMetadata ? 'structuredMetadata' : 'mixed',
+        value: log.uniqueLabels[label],
+      });
+    }
+  }
+  return {
+    fields,
+    labels,
+  };
+}
 
 /** Ensures end > start so downstream (e.g. Tempo trace lookup) never gets "end timestamp must not be before or equal to start time". */
 export function ensureValidTimeRangeForLink(fromMs: number, toMs: number): [number, number] {


### PR DESCRIPTION
Closes https://github.com/grafana/logs-drilldown/issues/1936
Closes https://github.com/grafana/logs-drilldown/issues/1951

### Service selection

<img width="275" height="278" alt="imagen" src="https://github.com/user-attachments/assets/d8a8bd4a-7a4d-4d1d-aeb8-8be272d0780b" />

This PR enables a few extra features in the service selection scene to:

- Go to log line: go to service details for a specific log line by adding a level filter and narrowing down the time range.
- Show similar log lines: go to service details with pre-applied filters based on the selected log line.
- Popover menu: go to the service selection page with a line filter by clicking on "add as line contains" filter.
- Enable Log Context in the service selection log panels.

Example:

https://github.com/user-attachments/assets/d6a848ad-8a40-45b3-bdf7-b3773911776d

### Permalinks

Updated the functions that generate links to log lines to more accurately point at particular log line to share. 
