### PR TITLE
chore(version-pr): try creating a pr for version-bump-changelog

### DIFF
--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -1,0 +1,39 @@
+name: Version PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver type of new version (major / minor / patch)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      generate-changelog:
+        description: 'Generate changelog'
+        required: false
+        type: boolean
+        default: true
+      create-pr:
+        description: 'Create a pull request'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Version bump
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@l2d2/version-bump-changelog-open-pr
+        with:
+          generate-changelog: ${{ inputs.generate-changelog }}
+          version: ${{ inputs.version }}
+          create-pr: ${{ inputs.create-pr }}

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -23,7 +23,8 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Description ✨
Back to experimenting with releases!

## Summary 📝

- Adds a new `workflow_dispatch` workflow [`.github/workflows/version-pr.yml`](.github/workflows/version-pr.yml) that runs the version bump/changelog action with **`create-pr: true`**, so semver bumps can open a PR instead of pushing directly to the branch.
- Mirrors the existing [`version-bump-changelog.yml`](.github/workflows/version-bump-changelog.yml) inputs (`version`, `generate-changelog`) and temporarily pins the action to `@l2d2/version-bump-changelog-open-pr` while that PR-creation support is validated upstream.

## Test 🧪

- [x] Need to test this one LIVE