### PR TITLE
chore(version): update grafana versions

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -53,7 +53,7 @@
   ],
   "roles": [],
   "dependencies": {
-    "grafanaDependency": ">=11.6.11 <12 || >=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5",
+    "grafanaDependency": ">=11.6.11-0 <12 || >=12.0.10-0 <12.1 || >=12.1.7-0 <12.2 || >=12.2.5-0",
     "plugins": [],
     "extensions": {
       "exposedComponents": [


### PR DESCRIPTION
## Summary 📝

- Follow Metrics Drilldown https://github.com/grafana/metrics-drilldown/pull/1313
- Update `grafanaDependency` in `src/plugin.json` to use prerelease-inclusive semver lower bounds (`>=X.Y.Z-0`), matching [metrics-drilldown#1313](https://github.com/grafana/metrics-drilldown/pull/1313).
- Unblocks the plugin catalog publish check that requires Grafana-owned plugins to include prerelease Grafana versions (e.g. `12.2.5-beta.1`) in their dependency ranges.

