### PR TITLE
chore(ci): update version-pr trigger

### DIFF
--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: boolean
         default: true
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary 📝

- Add a `pull_request` trigger (`types: [closed]`, `branches: [main]`) to the Version PR workflow so it runs when pull requests targeting `main` are closed.
- Keeps the existing `workflow_dispatch` trigger unchanged for manual version bumps.
