### PR TITLE
chore(ci): update bundle-types node version

### DIFF
--- a/.github/workflows/bundle-types.yml
+++ b/.github/workflows/bundle-types.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           entry-point: ./src/Components/ExposedComponents/types.ts
           ts-config: ./tsconfig-for-bundle-types.json
+          node-version: '24'


### PR DESCRIPTION
## Summary 📝

- Set `node-version: '24'` in the Bundle Types workflow so `grafana/plugin-actions/bundle-types` runs on Node 24 instead of the action default (Node 20).
- Fixes the [v2.1.2 tag Bundle Types failure](https://github.com/grafana/logs-drilldown/actions/runs/27376967207/job/80903612096), where `pnpm@11.3.0` failed on Node 20 with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`.
- Aligns the workflow with `package.json` (`engines.node: >=24`) and the CD workflow (`node-version: '24'`).
