### PR TITLE
fix(generateLinkFromFilters): fix potentially duplicated filters

### DIFF
--- a/src/services/text.test.ts
+++ b/src/services/text.test.ts
@@ -335,4 +335,62 @@ describe('generateLinkFromFilters', () => {
     expect(url.searchParams.get('var-fields')).toContain('region');
     expect(url.searchParams.get('var-lineFilters')).toContain('error');
   });
+
+  test('replaces existing label params instead of duplicating them', () => {
+    const pathWithLabel = `/a/${PLUGIN_ID}/explore?var-ds=DSID&var-filters=service_name|=|old`;
+
+    const url = new URL(
+      generateLinkFromFilters(pathWithLabel, {
+        labels: [{ key: 'pod', operator: FilterOp.Equal, type: LabelType.Indexed, value: 'mypod' }],
+      })
+    );
+
+    const labelParams = url.searchParams.getAll('var-filters');
+    expect(labelParams).toHaveLength(1);
+    expect(labelParams[0]).toContain('pod');
+    expect(labelParams[0]).not.toContain('service_name');
+  });
+
+  test('replaces existing line filter params instead of duplicating them', () => {
+    const pathWithLineFilter = `/a/${PLUGIN_ID}/explore?var-ds=DSID&var-lineFilters=caseSensitive|=|old`;
+
+    const url = new URL(
+      generateLinkFromFilters(pathWithLineFilter, {
+        labels: [],
+        lineFilters: [{ key: 'caseSensitive', operator: LineFilterOp.match, value: 'error' }],
+      })
+    );
+
+    const lineFilterParams = url.searchParams.getAll('var-lineFilters');
+    expect(lineFilterParams).toHaveLength(1);
+    expect(lineFilterParams[0]).toContain('error');
+    expect(lineFilterParams[0]).not.toContain('old');
+  });
+
+  test('replaces existing field and level params instead of duplicating them', () => {
+    const pathWithFields = `/a/${PLUGIN_ID}/explore?var-ds=DSID&var-fields=region|=|old&var-levels=detected_level|=|warn`;
+
+    const url = new URL(
+      generateLinkFromFilters(pathWithFields, {
+        fields: [{ key: 'region', operator: FilterOp.Equal, parser: 'mixed', type: LabelType.Parsed, value: 'us' }],
+        labels: [],
+      })
+    );
+
+    const fieldParams = url.searchParams.getAll('var-fields');
+    expect(fieldParams).toHaveLength(1);
+    expect(fieldParams[0]).toContain('us');
+    expect(fieldParams[0]).not.toContain('old');
+    // Levels are cleared alongside fields and not re-added when no level field is provided.
+    expect(url.searchParams.getAll('var-levels')).toHaveLength(0);
+  });
+
+  test('preserves existing filter params when no matching filters are provided', () => {
+    const pathWithFilters = `/a/${PLUGIN_ID}/explore?var-ds=DSID&var-filters=service_name|=|keep&var-lineFilters=caseSensitive|=|keep`;
+
+    const url = new URL(generateLinkFromFilters(pathWithFilters, { labels: [] }));
+
+    expect(url.searchParams.getAll('var-filters')).toEqual(['service_name|=|keep']);
+    expect(url.searchParams.getAll('var-lineFilters')).toEqual(['caseSensitive|=|keep']);
+  });
 });

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -143,6 +143,7 @@ export const generateLinkFromFilters = (path: string, filters: LinkFilters, time
   if (fields.length) {
     searchParams.delete(UrlParameters.Fields);
     searchParams.delete(UrlParameters.Levels);
+    searchParams.delete(UrlParameters.Metadata);
     searchParams = setUrlParamsFromFieldFilters(fields, searchParams);
   }
 

--- a/src/services/text.ts
+++ b/src/services/text.ts
@@ -1,7 +1,12 @@
 import { DataFrame, dateTime, LogRowModel, LogsSortOrder, TimeRange, urlUtil } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 
-import { setLineFilterUrlParams, setUrlParamsFromFieldFilters, setUrlParamsFromLabelFilters } from './extensions/links';
+import {
+  setLineFilterUrlParams,
+  setUrlParamsFromFieldFilters,
+  setUrlParamsFromLabelFilters,
+  UrlParameters,
+} from './extensions/links';
 import { LabelType } from './fieldsTypes';
 import { FieldFilter, FilterOp, IndexedLabelFilter, LineFilterType } from './filterTypes';
 import { logger } from './logger';
@@ -126,14 +131,18 @@ export const generateLinkFromFilters = (path: string, filters: LinkFilters, time
   const { fields = [], labels, lineFilters = [] } = filters;
 
   if (labels.length) {
+    searchParams.delete(UrlParameters.Labels);
     searchParams = setUrlParamsFromLabelFilters(labels, searchParams);
   }
 
   if (lineFilters.length) {
+    searchParams.delete(UrlParameters.LineFilters);
     searchParams = setLineFilterUrlParams(lineFilters, searchParams);
   }
 
   if (fields.length) {
+    searchParams.delete(UrlParameters.Fields);
+    searchParams.delete(UrlParameters.Levels);
     searchParams = setUrlParamsFromFieldFilters(fields, searchParams);
   }
 


### PR DESCRIPTION
Before these changes, filters (specially level) could hold duplicated values because we were building urlParams from the current URL params. Example of the bug:


https://github.com/user-attachments/assets/7c2b766d-49dc-48bc-b236-090187ac864b

