### PR TITLE
fix(deps): bump dompurify override to 3.4.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   react-router-dom: 7.17.0
   uuid: 14.0.0
   immutable: 5.1.5
-  dompurify: 3.4.9
+  dompurify: 3.4.11
   serialize-javascript: 7.0.5
   strip-ansi: 6.0.1
   js-yaml: 4.2.0
@@ -4295,9 +4295,9 @@ packages:
     resolution:
       { integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA== }
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     resolution:
-      { integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ== }
+      { integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw== }
 
   dot-prop@5.3.0:
     resolution:
@@ -9204,7 +9204,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       eventemitter3: 5.0.1
       fast_array_intersect: 1.1.0
       history: 4.10.1
@@ -12254,7 +12254,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ overrides:
   react-router-dom: 7.17.0
   uuid: 14.0.0
   immutable: 5.1.5
-  dompurify: 3.4.9
+  dompurify: 3.4.11
   serialize-javascript: 7.0.5
   strip-ansi: 6.0.1
   js-yaml: 4.2.0


### PR DESCRIPTION
## Summary
- Bumps `dompurify` override from 3.4.9 to 3.4.11 in `pnpm-workspace.yaml`
- Fixes GHSA-cmwh-pvxp-8882 (moderate: permanent ALLOWED_ATTR pollution via setConfig())

## Test plan
- [x] `pnpm audit` passes with 0 vulnerabilities