### PR TITLE
chore(ci/cd): update to 10.1.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,13 +28,11 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      attestations: write
       pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      attestation: true
       run-playwright: false
 
       # Use argo workflows, auto merge to dev,ops in deployment tools

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,6 +34,8 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       run-playwright: false
+      # Publish the github release automatically, turn draft off
+      github-draft-release: false
 
       # Use argo workflows, auto merge to dev,ops in deployment tools
       grafana-cloud-deployment-type: provisioned

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
       pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      attestations: write
       pull-requests: read
     with:
       # Checkout/build PR or main branch, depending on event

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
       pull-requests: read
     with:
       # Checkout/build PR or main branch, depending on event


### PR DESCRIPTION
## Summary 📝

- Bump reusable plugin CI/CD workflows from [`plugin-ci-workflows@ci-cd-workflows/v9.0.0`](https://github.com/grafana/plugin-ci-workflows/releases/tag/ci-cd-workflows%2Fv9.0.0) to [`v10.1.0`](https://github.com/grafana/plugin-ci-workflows/releases/tag/ci-cd-workflows%2Fv10.1.0) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and [`.github/workflows/cd.yml`](.github/workflows/cd.yml).
- Picks up v10 fixes (including the v10.0.0 Playwright regression fix) and v10.1.0 docs publishing behavior: prod docs now open a PR on `grafana/website` instead of pushing directly.
- Remove Attestation it is no longer supported.
- Add github-draft-release: false

