### PR TITLE
feat(Fields): Add support for optional parsers

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -434,6 +434,7 @@ tidwall
 timerange
 tmpl
 Toggletip
+toggleable
 toplevel
 toxiproxy
 treeprint

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -938,7 +938,7 @@ function getVariableSet(
     applyMode: 'manual',
     description: t(
       'components.index-scene.get-variable-set.fields-and-metadata-variable.description',
-      'Filter by values extracted from log lines (detected fields from parsers such as JSON or logfmt) and by structured metadata attached to each log line.'
+      'Filter by extracted fields (JSON or logfmt, if enabled) and by structured metadata attached to each log line.'
     ),
     hide: VariableHide.hideVariable,
     label: t('components.index-scene.get-variable-set.fields-and-metadata-variable.label.fields', 'Fields'),

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -58,8 +58,10 @@ import {
   getDataSourceVariable,
   getFieldsAndMetadataVariable,
   getFieldsVariable,
+  getJSONFieldsVariable,
   getLabelsVariable,
   getLevelsVariable,
+  getLineFormatVariable,
   getMetadataVariable,
   getPatternsVariable,
   getUrlParamNameForVariable,
@@ -97,6 +99,7 @@ import {
   updateAssistantContext,
 } from 'services/assistant';
 import { getLevelsFromLogsVolume } from 'services/logsVolume';
+import { getJsonParserSegment, getLogfmtParserSegment, getParserEnabled } from 'services/parserToggle';
 import { PLUGIN_BASE_URL } from 'services/plugin';
 import {
   getJsonParserExpressionBuilder,
@@ -126,11 +129,13 @@ import {
   VAR_FIELDS,
   VAR_FIELDS_AND_METADATA,
   VAR_JSON_FIELDS,
+  VAR_JSON_PARSER,
   VAR_LABELS,
   VAR_LEVELS,
   VAR_LINE_FILTER,
   VAR_LINE_FILTERS,
   VAR_LINE_FORMAT,
+  VAR_LOGFMT_PARSER,
   VAR_LOGS_FORMAT,
   VAR_METADATA,
   VAR_PATTERNS,
@@ -544,6 +549,34 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     }
   };
 
+  /**
+   * Removes filters that can only work when parsers are enabled. Parsed-field filters and JSON-path
+   * drill-downs (json fields / line format) require a `| json`/`| logfmt` parser stage, so they would
+   * produce invalid queries once parsers are turned off. Structured-metadata filters are preserved as
+   * they don't depend on a parser.
+   */
+  public clearParserDependentFilters() {
+    const combinedVariable = getFieldsAndMetadataVariable(this);
+    const metadataFilters = combinedVariable.state.filters.filter((f: AdHocFiltersWithLabelsAndMeta) =>
+      isFilterMetadata(f)
+    );
+    // Updating the combined variable propagates to the fields and metadata variables via
+    // `subscribeToCombinedFieldsVariable`, clearing the parsed fields while keeping metadata.
+    if (metadataFilters.length !== combinedVariable.state.filters.length) {
+      combinedVariable.updateFilters(metadataFilters);
+    }
+
+    const jsonFieldsVariable = getJSONFieldsVariable(this);
+    if (jsonFieldsVariable.state.filters.length) {
+      jsonFieldsVariable.setState({ filters: [] });
+    }
+
+    const lineFormatVariable = getLineFormatVariable(this);
+    if (lineFormatVariable.state.filters.length) {
+      lineFormatVariable.setState({ filters: [] });
+    }
+  }
+
   private setTagProviders() {
     this.setLabelsProviders();
   }
@@ -837,6 +870,10 @@ function getVariableSet(
   const initialMetadataFilters = initialFieldFilters?.filter((f) => f.meta?.parser === 'structuredMetadata');
   const initialParsedFieldFilters = initialFieldFilters?.filter((f) => f.meta?.parser !== 'structuredMetadata');
 
+  const parsersEnabled = getParserEnabled();
+  const jsonParserSegment = getJsonParserSegment(parsersEnabled);
+  const logfmtParserSegment = getLogfmtParserSegment(parsersEnabled);
+
   const labelVariable = new AdHocFiltersVariable({
     allowCustomValue: true,
     datasource: EXPLORATION_DS,
@@ -1002,6 +1039,25 @@ function getVariableSet(
           options: [{ label: MIXED_FORMAT_EXPR, value: MIXED_FORMAT_EXPR }],
           skipUrlSync: true,
           value: MIXED_FORMAT_EXPR,
+        }),
+
+        // Parser pipeline segments toggled by the header "Parsers" switch. When parsers are disabled
+        // both resolve to an empty string, removing the `| json ... | logfmt | drop ...` stages.
+        new CustomConstantVariable({
+          hide: VariableHide.hideVariable,
+          name: VAR_JSON_PARSER,
+          options: [{ label: jsonParserSegment, value: jsonParserSegment }],
+          skipUrlSync: true,
+          text: jsonParserSegment,
+          value: jsonParserSegment,
+        }),
+        new CustomConstantVariable({
+          hide: VariableHide.hideVariable,
+          name: VAR_LOGFMT_PARSER,
+          options: [{ label: logfmtParserSegment, value: logfmtParserSegment }],
+          skipUrlSync: true,
+          text: logfmtParserSegment,
+          value: logfmtParserSegment,
         }),
       ],
     }),

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -99,7 +99,12 @@ import {
   updateAssistantContext,
 } from 'services/assistant';
 import { getLevelsFromLogsVolume } from 'services/logsVolume';
-import { getJsonParserSegment, getLogfmtParserSegment, getParserEnabled } from 'services/parserToggle';
+import {
+  getJsonParserSegment,
+  getLogfmtParserSegment,
+  getParserEnabled,
+  setParserEnabled,
+} from 'services/parserToggle';
 import { PLUGIN_BASE_URL } from 'services/plugin';
 import {
   getJsonParserExpressionBuilder,
@@ -322,6 +327,10 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
     // Sync fields in query variables to support existing urls
     fieldsAndMetadataVariable.updateFilters([...metadataFilters, ...fieldFilters]);
+
+    // When opening a link that carries parser-dependent filters, make sure parsers are enabled so the
+    // incoming filters produce valid queries (the user may have parsers disabled locally).
+    this.enableParserIfRequiredByFilters();
 
     // Update the fields/metadata filters when the combined variable is changed in the variable UI.
     this._subs.add(fieldsAndMetadataVariable.subscribeToState(this.subscribeToCombinedFieldsVariable));
@@ -574,6 +583,25 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     const lineFormatVariable = getLineFormatVariable(this);
     if (lineFormatVariable.state.filters.length) {
       lineFormatVariable.setState({ filters: [] });
+    }
+  }
+
+  /**
+   * Parsed-field, JSON-path and line-format filters require a parser stage. When a
+   * link is opened with any of these filters present but the user has parsers disabled locally, the
+   * filters would render invalid queries, so we re-enable parsers to honor the incoming filters.
+   */
+  private enableParserIfRequiredByFilters() {
+    if (getParserEnabled()) {
+      return;
+    }
+
+    const hasParsedFieldFilters = getFieldsVariable(this).state.filters.length > 0;
+    const hasJsonFieldFilters = getJSONFieldsVariable(this).state.filters.length > 0;
+    const hasLineFormatFilters = getLineFormatVariable(this).state.filters.length > 0;
+
+    if (hasParsedFieldFilters || hasJsonFieldFilters || hasLineFormatFilters) {
+      setParserEnabled(true, this);
     }
   }
 

--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -5,7 +5,14 @@ import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction, useChromeHeaderHeight } from '@grafana/runtime';
-import { SceneComponentProps, SceneFlexLayout, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import {
+  SceneComponentProps,
+  SceneFlexLayout,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneQueryRunner,
+} from '@grafana/scenes';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { syncLogsListPanelHeightFromScene } from '../../services/scenes';
@@ -14,7 +21,7 @@ import {
   getJsonParserVariableVisibility,
   setCollapsibleFiltersState,
 } from '../../services/store';
-import { AppliedPattern } from '../../services/variables';
+import { AppliedPattern, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from '../../services/variables';
 import { EmbeddedLinkScene } from '../EmbeddedLogsExploration/EmbeddedLinkScene';
 import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
 import { GiveFeedbackButton } from './GiveFeedbackButton';
@@ -27,13 +34,23 @@ import {
 } from './LayoutScene';
 import { PatternControls } from './PatternControls';
 import { ResetFiltersButton } from './ResetFiltersButton';
+import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'services/analytics';
+import { CustomConstantVariable } from 'services/CustomConstantVariable';
 import { PageSlugs } from 'services/enums';
+import {
+  getJsonParserSegment,
+  getLogfmtParserSegment,
+  getParserEnabled,
+  setParserEnabled,
+} from 'services/parserToggle';
 import { getDrilldownSlug } from 'services/routing';
+import { testIds } from 'services/testIds';
 
 type HeaderPosition = 'relative' | 'sticky';
 interface VariableLayoutSceneState extends SceneObjectState {
   collapsed?: boolean;
   embeddedLink?: EmbeddedLinkScene;
+  parsersEnabled?: boolean;
   position: HeaderPosition;
 }
 export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneState> {
@@ -43,6 +60,7 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
     super({
       ...props,
       collapsed,
+      parsersEnabled: getParserEnabled(),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -77,13 +95,50 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
     }
   };
 
+  public toggleParser = () => {
+    const parsersEnabled = !this.state.parsersEnabled;
+
+    reportAppInteraction(USER_EVENTS_PAGES.all, USER_EVENTS_ACTIONS.all.parsers_toggled, {
+      enabled: parsersEnabled,
+    });
+
+    setParserEnabled(parsersEnabled);
+
+    const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, this);
+    const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, this);
+    if (jsonParserVariable instanceof CustomConstantVariable) {
+      const segment = getJsonParserSegment(parsersEnabled);
+      jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+    }
+    if (logfmtParserVariable instanceof CustomConstantVariable) {
+      const segment = getLogfmtParserSegment(parsersEnabled);
+      logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+    }
+
+    this.setState({ parsersEnabled });
+
+    const indexScene = sceneGraph.getAncestor(this, IndexScene);
+
+    // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
+    // to avoid sending invalid queries.
+    if (!parsersEnabled) {
+      indexScene.clearParserDependentFilters();
+    }
+
+    // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
+    // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
+    sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
+      queryRunner.runQueries();
+    });
+  };
+
   static Component = ({ model }: SceneComponentProps<VariableLayoutScene>) => {
     const indexScene = sceneGraph.getAncestor(model, IndexScene);
     const { controls, patterns, embedded, kgAnnotationToggle } = indexScene.useState();
     const layoutScene = sceneGraph.getAncestor(model, LayoutScene);
     const { levelsRenderer, lineFilterRenderer } = layoutScene.useState();
     const height = useChromeHeaderHeight();
-    const { collapsed } = model.useState();
+    const { collapsed, parsersEnabled } = model.useState();
     const styles = useStyles2((theme) => getStyles(theme, height ?? 40, collapsed));
     const slug = getDrilldownSlug();
 
@@ -111,20 +166,6 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
               <div className={styles.controlsWrapper}>
                 {!indexScene.state.embedded && <GiveFeedbackButton />}
                 <div className={styles.timeRangeDatasource}>
-                  {slug !== PageSlugs.explore && (
-                    <ToolbarButton
-                      className={collapsed ? styles.iconCollapsed : styles.iconExpanded}
-                      variant={collapsed ? 'active' : 'canvas'}
-                      icon="arrow-from-right"
-                      onClick={model.toggleCollapsedState}
-                      tooltip={
-                        collapsed
-                          ? t('components.index-scene.variable-layout-scene.expand', 'Expand filters')
-                          : t('components.index-scene.variable-layout-scene.collapse', 'Collapse filters')
-                      }
-                    />
-                  )}
-
                   {model.state.embeddedLink && <model.state.embeddedLink.Component model={model.state.embeddedLink} />}
 
                   {controls.map((control) => {
@@ -132,6 +173,40 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
                       <control.Component key={control.state.key} model={control} />
                     ) : null;
                   })}
+
+                  {slug !== PageSlugs.explore && (
+                    <>
+                      <ToolbarButton
+                        className={collapsed ? styles.iconCollapsed : styles.iconExpanded}
+                        variant={collapsed ? 'active' : 'canvas'}
+                        icon="arrow-from-right"
+                        onClick={model.toggleCollapsedState}
+                        tooltip={
+                          collapsed
+                            ? t('components.index-scene.variable-layout-scene.expand', 'Expand filters')
+                            : t('components.index-scene.variable-layout-scene.collapse', 'Collapse filters')
+                        }
+                      />
+                      <ToolbarButton
+                        variant={parsersEnabled ? 'active' : 'canvas'}
+                        onClick={model.toggleParser}
+                        data-testid={testIds.index.parserToggle}
+                        tooltip={
+                          parsersEnabled
+                            ? t(
+                                'components.index-scene.variable-layout.parser-toggle.tooltip-enabled',
+                                'Parsers are on. Click to disable extracting fields from the logs using JSON and logfmt parsers.'
+                              )
+                            : t(
+                                'components.index-scene.variable-layout.parser-toggle.tooltip-disabled',
+                                'Parsers are off. Click to enable JSON and logfmt parsers to extract fields from the log lines.'
+                              )
+                        }
+                      >
+                        {t('components.index-scene.variable-layout.parser-toggle.label', 'P')}
+                      </ToolbarButton>
+                    </>
+                  )}
 
                   <div className={styles.timeRange}>
                     {controls.map((control) => {

--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -5,13 +5,7 @@ import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction, useChromeHeaderHeight } from '@grafana/runtime';
-import {
-  SceneComponentProps,
-  SceneFlexLayout,
-  sceneGraph,
-  SceneObjectBase,
-  SceneObjectState,
-} from '@grafana/scenes';
+import { SceneComponentProps, SceneFlexLayout, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { syncLogsListPanelHeightFromScene } from '../../services/scenes';
@@ -40,7 +34,6 @@ type HeaderPosition = 'relative' | 'sticky';
 interface VariableLayoutSceneState extends SceneObjectState {
   collapsed?: boolean;
   embeddedLink?: EmbeddedLinkScene;
-  parsersEnabled?: boolean;
   position: HeaderPosition;
 }
 export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneState> {

--- a/src/Components/IndexScene/VariableLayoutScene.tsx
+++ b/src/Components/IndexScene/VariableLayoutScene.tsx
@@ -11,7 +11,6 @@ import {
   sceneGraph,
   SceneObjectBase,
   SceneObjectState,
-  SceneQueryRunner,
 } from '@grafana/scenes';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
@@ -21,7 +20,7 @@ import {
   getJsonParserVariableVisibility,
   setCollapsibleFiltersState,
 } from '../../services/store';
-import { AppliedPattern, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from '../../services/variables';
+import { AppliedPattern } from '../../services/variables';
 import { EmbeddedLinkScene } from '../EmbeddedLogsExploration/EmbeddedLinkScene';
 import { CustomVariableValueSelectors } from './CustomVariableValueSelectors';
 import { GiveFeedbackButton } from './GiveFeedbackButton';
@@ -34,17 +33,8 @@ import {
 } from './LayoutScene';
 import { PatternControls } from './PatternControls';
 import { ResetFiltersButton } from './ResetFiltersButton';
-import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'services/analytics';
-import { CustomConstantVariable } from 'services/CustomConstantVariable';
 import { PageSlugs } from 'services/enums';
-import {
-  getJsonParserSegment,
-  getLogfmtParserSegment,
-  getParserEnabled,
-  setParserEnabled,
-} from 'services/parserToggle';
 import { getDrilldownSlug } from 'services/routing';
-import { testIds } from 'services/testIds';
 
 type HeaderPosition = 'relative' | 'sticky';
 interface VariableLayoutSceneState extends SceneObjectState {
@@ -60,7 +50,6 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
     super({
       ...props,
       collapsed,
-      parsersEnabled: getParserEnabled(),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -95,50 +84,13 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
     }
   };
 
-  public toggleParser = () => {
-    const parsersEnabled = !this.state.parsersEnabled;
-
-    reportAppInteraction(USER_EVENTS_PAGES.all, USER_EVENTS_ACTIONS.all.parsers_toggled, {
-      enabled: parsersEnabled,
-    });
-
-    setParserEnabled(parsersEnabled);
-
-    const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, this);
-    const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, this);
-    if (jsonParserVariable instanceof CustomConstantVariable) {
-      const segment = getJsonParserSegment(parsersEnabled);
-      jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
-    }
-    if (logfmtParserVariable instanceof CustomConstantVariable) {
-      const segment = getLogfmtParserSegment(parsersEnabled);
-      logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
-    }
-
-    this.setState({ parsersEnabled });
-
-    const indexScene = sceneGraph.getAncestor(this, IndexScene);
-
-    // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
-    // to avoid sending invalid queries.
-    if (!parsersEnabled) {
-      indexScene.clearParserDependentFilters();
-    }
-
-    // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
-    // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
-    sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
-      queryRunner.runQueries();
-    });
-  };
-
   static Component = ({ model }: SceneComponentProps<VariableLayoutScene>) => {
     const indexScene = sceneGraph.getAncestor(model, IndexScene);
     const { controls, patterns, embedded, kgAnnotationToggle } = indexScene.useState();
     const layoutScene = sceneGraph.getAncestor(model, LayoutScene);
     const { levelsRenderer, lineFilterRenderer } = layoutScene.useState();
     const height = useChromeHeaderHeight();
-    const { collapsed, parsersEnabled } = model.useState();
+    const { collapsed } = model.useState();
     const styles = useStyles2((theme) => getStyles(theme, height ?? 40, collapsed));
     const slug = getDrilldownSlug();
 
@@ -175,37 +127,17 @@ export class VariableLayoutScene extends SceneObjectBase<VariableLayoutSceneStat
                   })}
 
                   {slug !== PageSlugs.explore && (
-                    <>
-                      <ToolbarButton
-                        className={collapsed ? styles.iconCollapsed : styles.iconExpanded}
-                        variant={collapsed ? 'active' : 'canvas'}
-                        icon="arrow-from-right"
-                        onClick={model.toggleCollapsedState}
-                        tooltip={
-                          collapsed
-                            ? t('components.index-scene.variable-layout-scene.expand', 'Expand filters')
-                            : t('components.index-scene.variable-layout-scene.collapse', 'Collapse filters')
-                        }
-                      />
-                      <ToolbarButton
-                        variant={parsersEnabled ? 'active' : 'canvas'}
-                        onClick={model.toggleParser}
-                        data-testid={testIds.index.parserToggle}
-                        tooltip={
-                          parsersEnabled
-                            ? t(
-                                'components.index-scene.variable-layout.parser-toggle.tooltip-enabled',
-                                'Parsers are on. Click to disable extracting fields from the logs using JSON and logfmt parsers.'
-                              )
-                            : t(
-                                'components.index-scene.variable-layout.parser-toggle.tooltip-disabled',
-                                'Parsers are off. Click to enable JSON and logfmt parsers to extract fields from the log lines.'
-                              )
-                        }
-                      >
-                        {t('components.index-scene.variable-layout.parser-toggle.label', 'P')}
-                      </ToolbarButton>
-                    </>
+                    <ToolbarButton
+                      className={collapsed ? styles.iconCollapsed : styles.iconExpanded}
+                      variant={collapsed ? 'active' : 'canvas'}
+                      icon="arrow-from-right"
+                      onClick={model.toggleCollapsedState}
+                      tooltip={
+                        collapsed
+                          ? t('components.index-scene.variable-layout-scene.expand', 'Expand filters')
+                          : t('components.index-scene.variable-layout-scene.collapse', 'Collapse filters')
+                      }
+                    />
                   )}
 
                   <div className={styles.timeRange}>

--- a/src/Components/ServiceScene/Breakdowns/EmptyLayoutScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/EmptyLayoutScene.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { isAssistantAvailable, openAssistant } from '@grafana/assistant';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Box, Button, EmptyState } from '@grafana/ui';
+import { Box, Button, EmptyState, Stack } from '@grafana/ui';
 
 import { emptyStateStyles } from './FieldsBreakdownScene';
 import { getEmptyStateOptions } from 'services/extensions/embedding';
-import { getParserEnabled } from 'services/parserToggle';
+import { getParserEnabled, setParserEnabled } from 'services/parserToggle';
 import { useSharedStyles } from 'styles/shared-styles';
 
 export interface EmptyLayoutSceneState extends SceneObjectState {
@@ -32,8 +32,10 @@ function EmptyLayoutComponent({ model }: SceneComponentProps<EmptyLayoutScene>) 
 
   const embeddedOptions = getEmptyStateOptions(type, model);
 
+  const noFieldsAndParsersDisabled = type === 'fields' && getParserEnabled() === false;
+
   const message = useMemo(() => {
-    if (type === 'fields' && getParserEnabled() === false) {
+    if (noFieldsAndParsersDisabled) {
       return t(
           'components.service-scene.breakdowns.empty-layout-scene.parsed-fields',
           'We did not find any {{type}} for the given time range. Try enabling extracted fields from the log lines.',
@@ -49,7 +51,11 @@ function EmptyLayoutComponent({ model }: SceneComponentProps<EmptyLayoutScene>) 
             type,
           }
         )
-  }, [type]);
+  }, [noFieldsAndParsersDisabled, type]);
+
+  const enableParsers = useCallback(() => {
+    setParserEnabled(true, model);
+  }, [model]);
 
   return (
     <div className={sharedStyles.emptyStateWrap}>
@@ -68,15 +74,25 @@ function EmptyLayoutComponent({ model }: SceneComponentProps<EmptyLayoutScene>) 
         </a>{' '}
         {t('components.service-scene.breakdowns.empty-layout-scene.suffix', 'if you think this is a mistake.')}
         <Box marginTop={1} justifyContent="center">
-          {assistantAvailable && (
-            <Button
-              variant="secondary"
-              onClick={() => solveWithAssistant(type, embeddedOptions?.customPrompt)}
-              icon="ai-sparkle"
-            >
-              {embeddedOptions?.promptCTA ?? 'Ask Grafana Assistant'}
-            </Button>
-          )}
+          <Stack gap={1}>
+            {assistantAvailable && (
+              <Button
+                variant="secondary"
+                onClick={() => solveWithAssistant(type, embeddedOptions?.customPrompt)}
+                icon="ai-sparkle"
+              >
+                {embeddedOptions?.promptCTA ?? t('components.service-scene.breakdowns.empty-layout-scene.ask-assistant', 'Ask Grafana Assistant')}
+              </Button>
+            )}
+            {noFieldsAndParsersDisabled && (
+              <Button
+                variant="primary"
+                onClick={enableParsers}
+              >
+                {t('components.service-scene.breakdowns.empty-layout-scene.enable-parsers', 'Enable extracted fields')}
+              </Button>
+            )}
+          </Stack>
         </Box>
       </EmptyState>
     </div>

--- a/src/Components/ServiceScene/Breakdowns/EmptyLayoutScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/EmptyLayoutScene.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { isAssistantAvailable, openAssistant } from '@grafana/assistant';
 import { t } from '@grafana/i18n';
@@ -7,6 +7,7 @@ import { Box, Button, EmptyState } from '@grafana/ui';
 
 import { emptyStateStyles } from './FieldsBreakdownScene';
 import { getEmptyStateOptions } from 'services/extensions/embedding';
+import { getParserEnabled } from 'services/parserToggle';
 import { useSharedStyles } from 'styles/shared-styles';
 
 export interface EmptyLayoutSceneState extends SceneObjectState {
@@ -31,17 +32,30 @@ function EmptyLayoutComponent({ model }: SceneComponentProps<EmptyLayoutScene>) 
 
   const embeddedOptions = getEmptyStateOptions(type, model);
 
-  return (
-    <div className={sharedStyles.emptyStateWrap}>
-      <EmptyState
-        variant="not-found"
-        message={t(
+  const message = useMemo(() => {
+    if (type === 'fields' && getParserEnabled() === false) {
+      return t(
+          'components.service-scene.breakdowns.empty-layout-scene.parsed-fields',
+          'We did not find any {{type}} for the given time range. Try enabling extracted fields from the log lines.',
+          {
+            type,
+          }
+        );
+    }
+    return t(
           'components.service-scene.breakdowns.empty-layout-scene.title',
           'We did not find any {{type}} for the given time range.',
           {
             type,
           }
-        )}
+        )
+  }, []);
+
+  return (
+    <div className={sharedStyles.emptyStateWrap}>
+      <EmptyState
+        variant="not-found"
+        message={message}
       >
         {t('components.service-scene.breakdowns.empty-layout-scene.prefix', 'Please')}{' '}
         <a

--- a/src/Components/ServiceScene/Breakdowns/EmptyLayoutScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/EmptyLayoutScene.tsx
@@ -49,7 +49,7 @@ function EmptyLayoutComponent({ model }: SceneComponentProps<EmptyLayoutScene>) 
             type,
           }
         )
-  }, []);
+  }, [type]);
 
   return (
     <div className={sharedStyles.emptyStateWrap}>

--- a/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldSelector.tsx
@@ -14,6 +14,7 @@ type Props<T> = {
   label: string;
   onChange: (label: T | undefined) => void;
   options: VariableValueOption[];
+  tooltip?: string;
   value?: T;
 };
 
@@ -23,7 +24,7 @@ export type AsyncFieldSelectorProps = {
   selectOption: (value: string) => void;
 } & Props<string>;
 
-export function FieldSelector<T extends string | number>({ label, onChange, options, value }: Props<T>) {
+export function FieldSelector<T extends string | number>({ label, onChange, options, tooltip, value }: Props<T>) {
   const styles = useStyles2(getStyles);
 
   const selectableOptions: Array<ComboboxOption<T>> = options.map((option) => {
@@ -34,7 +35,7 @@ export function FieldSelector<T extends string | number>({ label, onChange, opti
   });
 
   return (
-    <InlineField className={styles.selectWrapper} label={label}>
+    <InlineField className={styles.selectWrapper} label={label} tooltip={tooltip}>
       <Combobox<T>
         options={selectableOptions}
         value={value}

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -156,6 +156,8 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         logger.warn('Layout is not SceneCSSGridLayout');
       }
     });
+
+    this.updateFieldCount();
   }
 
   private sortChildren(cardinalityMap: Map<string, number>) {
@@ -186,11 +188,9 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
       body: this.build(),
     });
 
-    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
-    if (serviceScene.state.fieldsCount === undefined) {
-      this.updateFieldCount();
-    }
+    this.updateFieldCount();
 
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this._subs.add(serviceScene.state.$detectedFieldsData?.subscribeToState(this.onDetectedFieldsChange));
     this._subs.add(this.subscribeToFieldsVar());
     this._subs.add(

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -90,7 +90,6 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     const detectedFieldsFrame = getDetectedFieldsFrameFromQueryRunnerState(newState);
     const newNamesField = getDetectedFieldsNamesFromQueryRunnerState(newState);
     const newParsersField = getDetectedFieldsParsersFromQueryRunnerState(newState);
-    const cardinalityMap = this.calculateCardinalityMap(newState);
 
     // Iterate through all the layouts
     this.state.body?.state.layouts.forEach((layout) => {
@@ -143,7 +142,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         const options = fieldsToAdd.map((fieldName) => fieldName);
 
         updatedChildren.push(...this.buildChildren(options));
-        updatedChildren.sort(this.sortChildren(cardinalityMap));
+        updatedChildren.sort(this.sortChildren());
 
         updatedChildren.map((child) => {
           this.subscribeToPanel(child);
@@ -160,27 +159,12 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     this.updateFieldCount();
   }
 
-  private sortChildren(cardinalityMap: Map<string, number>) {
+  private sortChildren() {
     return (a: SceneCSSGridItem, b: SceneCSSGridItem) => {
       const aPanel = a.state.body as FieldsVizPanelWrapper;
       const bPanel = b.state.body as FieldsVizPanelWrapper;
-      const aCardinality = cardinalityMap.get(aPanel.state.viz.state.title) ?? 0;
-      const bCardinality = cardinalityMap.get(bPanel.state.viz.state.title) ?? 0;
-      return bCardinality - aCardinality;
+      return aPanel.state.viz.state.title.toLowerCase().localeCompare(bPanel.state.viz.state.title.toLowerCase());
     };
-  }
-
-  private calculateCardinalityMap(newState?: QueryRunnerState) {
-    const detectedFieldsFrame = getDetectedFieldsFrameFromQueryRunnerState(newState);
-    const cardinalityMap = new Map<string, number>();
-    if (detectedFieldsFrame?.length) {
-      for (let i = 0; i < detectedFieldsFrame?.length; i++) {
-        const name: string = detectedFieldsFrame.fields[0].values[i];
-        const cardinality: number = detectedFieldsFrame.fields[1].values[i];
-        cardinalityMap.set(name, cardinality);
-      }
-    }
-    return cardinalityMap;
   }
 
   onActivate() {
@@ -254,9 +238,7 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
 
     const children = this.buildChildren(options);
 
-    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
-    const cardinalityMap = this.calculateCardinalityMap(serviceScene.state.$detectedFieldsData?.state);
-    children.sort(this.sortChildren(cardinalityMap));
+    children.sort(this.sortChildren());
     const childrenClones = children.map((child) => child.clone());
 
     // We must subscribe to the data providers for all children after the clone, or we'll see bugs in the row layout

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -196,6 +196,9 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
     this._subs.add(
       this.subscribeToState((newState, prevState) => {
         if (newState.fieldsPanelsType !== prevState.fieldsPanelsType) {
+          // Cancel any in-flight queries on the current (about to be discarded) body, otherwise
+          // the time series requests keep running even after we switch to the text display.
+          this.cancelInFlightQueries();
           // All query runners need to be rebuilt
           this.setState({
             body: this.build(),
@@ -203,6 +206,23 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         }
       })
     );
+  }
+
+  /**
+   * Cancels in-flight queries on the current body's panels. Used when switching the field display
+   * type so the discarded time series query runners don't keep their requests running.
+   */
+  private cancelInFlightQueries() {
+    const body = this.state.body;
+    if (!body) {
+      return;
+    }
+    const queryRunners = sceneGraph.findDescendents(body, SceneQueryRunner);
+    for (const queryRunner of queryRunners) {
+      if (queryRunner.state.data?.state === LoadingState.Loading) {
+        queryRunner.cancelQuery();
+      }
+    }
   }
 
   private subscribeToFieldsVar() {
@@ -244,8 +264,12 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
       this.subscribeToPanel(child);
     });
 
+    const isText = this.state.fieldsPanelsType === 'text';
+
     return new LayoutSwitcher({
+      // Text panels only support the grid view, so lock it and ignore the stored layout preference.
       active: 'grid',
+      syncLayoutFromStore: !isText,
       layouts: [
         new SceneCSSGridLayout({
           autoRows: this.state.fieldsPanelsType === 'timeseries' ? '200px' : '35px',
@@ -261,8 +285,14 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         }),
       ],
       options: [
-        { label: t('components.service-scene.breakdowns.fields-aggregated-breakdown-scene.label.grid', 'Grid'), value: 'grid' },
-        { label: t('components.service-scene.breakdowns.fields-aggregated-breakdown-scene.label.rows', 'Rows'), value: 'rows' },
+        {
+          label: t('components.service-scene.breakdowns.fields-aggregated-breakdown-scene.label.grid', 'Grid'),
+          value: 'grid',
+        },
+        {
+          label: t('components.service-scene.breakdowns.fields-aggregated-breakdown-scene.label.rows', 'Rows'),
+          value: 'rows',
+        },
       ],
     });
   }
@@ -618,6 +648,10 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
       return <div className={styles.panelWrapper}>{body && <body.Component model={body} />}</div>;
     }
 
-    return <LoadingPlaceholder text={t('components.service-scene.breakdowns.fields-aggregated-breakdown-scene.text-loading', 'Loading...')} />;
+    return (
+      <LoadingPlaceholder
+        text={t('components.service-scene.breakdowns.fields-aggregated-breakdown-scene.text-loading', 'Loading...')}
+      />
+    );
   };
 }

--- a/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene.tsx
@@ -58,6 +58,7 @@ import { SelectLabelActionScene } from './SelectLabelActionScene';
 import { ShowErrorPanelToggle } from './ShowErrorPanelToggle';
 import { ShowFieldDisplayToggle } from './ShowFieldDisplayToggle';
 import { MAX_NUMBER_OF_TIME_SERIES } from './TimeSeriesLimit';
+import { cancelInFlightQueries } from 'services/queries';
 
 export type FieldsPanelsType = 'text' | 'timeseries';
 
@@ -182,7 +183,9 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         if (newState.fieldsPanelsType !== prevState.fieldsPanelsType) {
           // Cancel any in-flight queries on the current (about to be discarded) body, otherwise
           // the time series requests keep running even after we switch to the text display.
-          this.cancelInFlightQueries();
+          if (this.state.body) {
+            cancelInFlightQueries(this.state.body);
+          }
           // All query runners need to be rebuilt
           this.setState({
             body: this.build(),
@@ -190,23 +193,6 @@ export class FieldsAggregatedBreakdownScene extends SceneObjectBase<FieldsAggreg
         }
       })
     );
-  }
-
-  /**
-   * Cancels in-flight queries on the current body's panels. Used when switching the field display
-   * type so the discarded time series query runners don't keep their requests running.
-   */
-  private cancelInFlightQueries() {
-    const body = this.state.body;
-    if (!body) {
-      return;
-    }
-    const queryRunners = sceneGraph.findDescendents(body, SceneQueryRunner);
-    for (const queryRunner of queryRunners) {
-      if (queryRunner.state.data?.state === LoadingState.Loading) {
-        queryRunner.cancelQuery();
-      }
-    }
   }
 
   private subscribeToFieldsVar() {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -15,7 +15,7 @@ import {
   VariableDependencyConfig,
   VariableValueOption,
 } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { Stack, useStyles2 } from '@grafana/ui';
 
 import { areArraysEqual } from '../../../services/comparison';
 import { CustomConstantVariable, CustomConstantVariableState } from '../../../services/CustomConstantVariable';
@@ -332,14 +332,14 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       <div className={cx(styles.labelsMenuWrapper, hideSearch ? styles.labelsMenuWrapperNoSearch : undefined)}>
         {body instanceof FieldsAggregatedBreakdownScene && (
           <>
-            <div className={styles.toggleWrapper}>
+            <Stack justifyContent="space-between">
               {body.state.fieldsPanelsType !== 'text' && (
                 <>
                   <FieldsAggregatedBreakdownScene.ShowErrorPanelToggle model={body} />
                   <FieldsAggregatedBreakdownScene.Selector model={body} />
                 </>
               )}
-            </div>
+            </Stack>
             <FieldsAggregatedBreakdownScene.ShowFieldDisplayToggle model={body} />
           </>
         )}
@@ -420,10 +420,6 @@ function getStyles(theme: GrafanaTheme2) {
       justifyContent: 'space-between',
     }),
     labelsMenuWrapperNoSearch: css({
-      flexDirection: 'row',
-    }),
-    toggleWrapper: css({
-      display: 'flex',
       flexDirection: 'row',
     }),
     valuesMenuWrapper: css({

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -316,6 +316,18 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
     // Trigger re-render on body state change
     body?.useState();
     // @todo small viewport support
+
+    const parserEnabled = getParserEnabled();
+    const tooltip = parserEnabled
+      ? t(
+          'components.service-scene.breakdowns.fields-breakdown-scene.label-field-tooltip',
+          'Structured metadata and parsed fields'
+        )
+      : t(
+          'components.service-scene.breakdowns.fields-breakdown-scene.label-metadata-tooltip',
+          'Structured metadata fields'
+        );
+
     return (
       <div className={cx(styles.labelsMenuWrapper, hideSearch ? styles.labelsMenuWrapperNoSearch : undefined)}>
         {body instanceof FieldsAggregatedBreakdownScene && (
@@ -336,6 +348,7 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
         {!loading && options.length > 1 && (
           <FieldSelector
             label={t('components.service-scene.breakdowns.fields-breakdown-scene.label-field', 'Field')}
+            tooltip={tooltip}
             options={options}
             value={String(value)}
             onChange={model.onFieldSelectorChange}

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -38,7 +38,9 @@ import { NoMatchingLabelsScene } from './NoMatchingLabelsScene';
 import { SortByScene, SortCriteriaChanged } from './SortByScene';
 import { StatusWrapper } from './StatusWrapper';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
+import { extractParserFromString, getDetectedFieldsParserField } from 'services/fields';
 import { getFieldOptions } from 'services/filters';
+import { getParserEnabled } from 'services/parserToggle';
 import { DEFAULT_SORT_DIRECTION, getDefaultSortBy } from 'services/sorting';
 import { getSortByPreference } from 'services/store';
 import { ALL_VARIABLE_VALUE, VAR_FIELD_GROUP_BY, VAR_FIELDS, VAR_LABELS } from 'services/variables';
@@ -187,11 +189,28 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       return;
     }
 
+    // With parsers disabled, parser-based fields can't be queried, so only list structured-metadata fields.
+    const allFieldNames = dataFrame.fields[0].values.map((v) => String(v));
+
+    // Every detected field requires a parser, but parsers are disabled: show a dedicated empty state
+    // explaining how to get fields back instead of an empty breakdown.
+    if (!getParserEnabled() && allFieldNames.length === 0) {
+      this.state.changeFieldCount?.(0);
+      this.setState({
+        body: new EmptyLayoutScene({
+          type: 'fields',
+        }),
+        loading: false,
+      });
+      return;
+    }
+
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     const variable = getFieldGroupByVariable(this);
+
     variable.setState({
       loading: false,
-      options: getFieldOptions(dataFrame.fields[0].values.map((v) => String(v))),
+      options: getFieldOptions(allFieldNames),
       value: serviceScene.state.drillDownLabel ?? ALL_VARIABLE_VALUE,
     });
     this.setState({

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -38,7 +38,6 @@ import { NoMatchingLabelsScene } from './NoMatchingLabelsScene';
 import { SortByScene, SortCriteriaChanged } from './SortByScene';
 import { StatusWrapper } from './StatusWrapper';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
-import { extractParserFromString, getDetectedFieldsParserField } from 'services/fields';
 import { getFieldOptions } from 'services/filters';
 import { getParserEnabled } from 'services/parserToggle';
 import { DEFAULT_SORT_DIRECTION, getDefaultSortBy } from 'services/sorting';
@@ -189,13 +188,8 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       return;
     }
 
-    const parserField = getDetectedFieldsParserField(dataFrame);
     const parserEnabled = getParserEnabled();
-    const allFieldNames = dataFrame.fields[0].values
-      .map((value) => String(value))
-      .filter((_, index) =>
-        parserEnabled ? true : extractParserFromString(parserField?.values?.[index] ?? '') === 'structuredMetadata'
-      );
+    const allFieldNames = dataFrame.fields[0].values.map((value) => String(value));
 
     // No available fields and parsers disabled
     if (!parserEnabled && allFieldNames.length === 0) {

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -322,9 +322,11 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
           <>
             <div className={styles.toggleWrapper}>
               {body.state.fieldsPanelsType !== 'text' && (
-                <FieldsAggregatedBreakdownScene.ShowErrorPanelToggle model={body} />
+                <>
+                  <FieldsAggregatedBreakdownScene.ShowErrorPanelToggle model={body} />
+                  <FieldsAggregatedBreakdownScene.Selector model={body} />
+                </>
               )}
-              <FieldsAggregatedBreakdownScene.Selector model={body} />
             </div>
             <FieldsAggregatedBreakdownScene.ShowFieldDisplayToggle model={body} />
           </>

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -189,28 +189,24 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       return;
     }
 
-    let allFieldNames = dataFrame.fields[0].values.map((v) => String(v));
-
-    // With parsers disabled, parser-based fields (json/logfmt) can't be queried, so only list
-    // structured-metadata fields, which are available without a parser.
-    if (!getParserEnabled()) {
-      const parserField = getDetectedFieldsParserField(dataFrame);
-      allFieldNames = allFieldNames.filter(
-        (_, index) => extractParserFromString(parserField?.values?.[index] ?? '') === 'structuredMetadata'
+    const parserField = getDetectedFieldsParserField(dataFrame);
+    const parserEnabled = getParserEnabled();
+    const allFieldNames = dataFrame.fields[0].values
+      .map((value) => String(value))
+      .filter((_, index) =>
+        parserEnabled ? true : extractParserFromString(parserField?.values?.[index] ?? '') === 'structuredMetadata'
       );
 
-      // Every detected field requires a parser, but parsers are disabled: show a dedicated empty state
-      // explaining how to get fields back instead of an empty breakdown.
-      if (allFieldNames.length === 0) {
-        this.state.changeFieldCount?.(0);
-        this.setState({
-          body: new EmptyLayoutScene({
-            type: 'fields',
-          }),
-          loading: false,
-        });
-        return;
-      }
+    // No available fields and parsers disabled
+    if (!parserEnabled && allFieldNames.length === 0) {
+      this.state.changeFieldCount?.(0);
+      this.setState({
+        body: new EmptyLayoutScene({
+          type: 'fields',
+        }),
+        loading: false,
+      });
+      return;
     }
 
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -412,7 +412,7 @@ function getStyles(theme: GrafanaTheme2) {
       paddingTop: theme.spacing(0),
     }),
     labelsMenuWrapper: css({
-      alignItems: 'top',
+      alignItems: 'center',
       display: 'flex',
       flexDirection: 'row-reverse',
       flexGrow: 0,

--- a/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/FieldsBreakdownScene.tsx
@@ -189,20 +189,28 @@ export class FieldsBreakdownScene extends SceneObjectBase<FieldsBreakdownSceneSt
       return;
     }
 
-    // With parsers disabled, parser-based fields can't be queried, so only list structured-metadata fields.
-    const allFieldNames = dataFrame.fields[0].values.map((v) => String(v));
+    let allFieldNames = dataFrame.fields[0].values.map((v) => String(v));
 
-    // Every detected field requires a parser, but parsers are disabled: show a dedicated empty state
-    // explaining how to get fields back instead of an empty breakdown.
-    if (!getParserEnabled() && allFieldNames.length === 0) {
-      this.state.changeFieldCount?.(0);
-      this.setState({
-        body: new EmptyLayoutScene({
-          type: 'fields',
-        }),
-        loading: false,
-      });
-      return;
+    // With parsers disabled, parser-based fields (json/logfmt) can't be queried, so only list
+    // structured-metadata fields, which are available without a parser.
+    if (!getParserEnabled()) {
+      const parserField = getDetectedFieldsParserField(dataFrame);
+      allFieldNames = allFieldNames.filter(
+        (_, index) => extractParserFromString(parserField?.values?.[index] ?? '') === 'structuredMetadata'
+      );
+
+      // Every detected field requires a parser, but parsers are disabled: show a dedicated empty state
+      // explaining how to get fields back instead of an empty breakdown.
+      if (allFieldNames.length === 0) {
+        this.state.changeFieldCount?.(0);
+        this.setState({
+          body: new EmptyLayoutScene({
+            type: 'fields',
+          }),
+          loading: false,
+        });
+        return;
+      }
     }
 
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -16,7 +16,7 @@ import {
   VariableDependencyConfig,
   VariableValueOption,
 } from '@grafana/scenes';
-import { Alert, useStyles2 } from '@grafana/ui';
+import { Alert, Stack, useStyles2 } from '@grafana/ui';
 
 import { areArraysEqual } from '../../../services/comparison';
 import { CustomConstantVariable, CustomConstantVariableState } from '../../../services/CustomConstantVariable';
@@ -296,11 +296,20 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     const variable = getLabelGroupByVariable(model);
     const { options, value } = variable.useState();
     const styles = useStyles2(getStyles);
+    // Trigger re-render on body state change (e.g. when toggling the volume display)
+    body?.useState();
 
     return (
       <div className={styles.labelsMenuWrapper}>
         {body instanceof LabelValuesBreakdownScene && <LabelValuesBreakdownScene.Selector model={body} />}
-        {body instanceof LabelsAggregatedBreakdownScene && <LabelsAggregatedBreakdownScene.Selector model={body} />}
+        {body instanceof LabelsAggregatedBreakdownScene && (
+          <>
+            <Stack justifyContent="space-between">
+              {body.state.labelsPanelsType !== 'text' && <LabelsAggregatedBreakdownScene.Selector model={body} />}
+            </Stack>
+            <LabelsAggregatedBreakdownScene.ShowLabelDisplayToggle model={body} />
+          </>
+        )}
         {body instanceof LabelValuesBreakdownScene && <search.Component model={search} />}
         {!loading && options.length > 0 && (
           <FieldSelector

--- a/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelBreakdownScene.tsx
@@ -370,7 +370,7 @@ function getStyles(theme: GrafanaTheme2) {
       paddingTop: theme.spacing(0),
     }),
     labelsMenuWrapper: css({
-      alignItems: 'top',
+      alignItems: 'center',
       display: 'flex',
       flexDirection: 'row-reverse',
       flexGrow: 0,

--- a/src/Components/ServiceScene/Breakdowns/LabelsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelsAggregatedBreakdownScene.tsx
@@ -167,25 +167,12 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
 
       updatedChildren.push(...this.buildChildren(options));
 
-      const cardinalityMap = this.calculateCardinalityMap(detectedLabelsFrame);
-      updatedChildren.sort(this.sortChildren(cardinalityMap));
+      updatedChildren.sort(this.sortChildren());
 
       layout.setState({
         children: updatedChildren,
       });
     });
-  }
-
-  private calculateCardinalityMap(detectedLabels?: DataFrame) {
-    const cardinalityMap = new Map<string, number>();
-    if (detectedLabels?.length) {
-      for (let i = 0; i < detectedLabels?.fields.length; i++) {
-        const name: string = detectedLabels.fields[i].name;
-        const cardinality: number = detectedLabels.fields[i].values[0];
-        cardinalityMap.set(name, cardinality);
-      }
-    }
-    return cardinalityMap;
   }
 
   private build(): LayoutSwitcher {
@@ -198,8 +185,7 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     const $detectedLabels = serviceScene.state.$detectedLabelsData;
     if ($detectedLabels?.state.data?.state === LoadingState.Done) {
-      const cardinalityMap = this.calculateCardinalityMap($detectedLabels?.state.data.series[0]);
-      children.sort(this.sortChildren(cardinalityMap));
+      children.sort(this.sortChildren());
     }
 
     const childrenClones = children.map((child) => child.clone());
@@ -304,9 +290,7 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
       if (bPanel.state.title === LEVEL_VARIABLE_VALUE) {
         return 1;
       }
-      const aCardinality = cardinalityMap.get(aPanel.state.title) ?? 0;
-      const bCardinality = cardinalityMap.get(bPanel.state.title) ?? 0;
-      return bCardinality - aCardinality;
+      return aPanel.state.title.toLowerCase().localeCompare(bPanel.state.title.toLowerCase());
     };
   }
 

--- a/src/Components/ServiceScene/Breakdowns/LabelsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelsAggregatedBreakdownScene.tsx
@@ -280,7 +280,7 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
     });
   }
 
-  private sortChildren(cardinalityMap: Map<string, number>) {
+  private sortChildren() {
     return (a: SceneCSSGridItem, b: SceneCSSGridItem) => {
       const aPanel = a.state.body as VizPanel;
       const bPanel = b.state.body as VizPanel;

--- a/src/Components/ServiceScene/Breakdowns/LabelsAggregatedBreakdownScene.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LabelsAggregatedBreakdownScene.tsx
@@ -8,6 +8,7 @@ import {
   SceneCSSGridItem,
   SceneCSSGridLayout,
   SceneDataProvider,
+  SceneDataTransformer,
   sceneGraph,
   SceneObjectBase,
   SceneObjectState,
@@ -20,22 +21,28 @@ import { DrawStyle, LoadingPlaceholder, StackingMode, useStyles2 } from '@grafan
 import { ValueSlugs } from '../../../services/enums';
 import { buildLabelsQuery, LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS } from '../../../services/labels';
 import { getQueryRunner, setLevelColorOverrides } from '../../../services/panel';
+import { getLabelsPanelType } from '../../../services/store';
 import { getFieldsVariable, getLabelGroupByVariable } from '../../../services/variableGetters';
 import { ALL_VARIABLE_VALUE, LEVEL_VARIABLE_VALUE } from '../../../services/variables';
 import { getPanelWrapperStyles, PanelMenu } from '../../Panels/PanelMenu';
 import { ServiceScene } from '../ServiceScene';
+import { FieldsPanelsType } from './FieldsAggregatedBreakdownScene';
 import { LabelBreakdownScene } from './LabelBreakdownScene';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { SelectLabelActionScene } from './SelectLabelActionScene';
+import { ShowLabelDisplayToggle } from './ShowLabelDisplayToggle';
 import { MAX_NUMBER_OF_TIME_SERIES } from './TimeSeriesLimit';
+import { cancelInFlightQueries } from 'services/queries';
 
 export interface LabelsAggregatedBreakdownSceneState extends SceneObjectState {
   body?: LayoutSwitcher;
+  labelsPanelsType: FieldsPanelsType;
 }
 
 export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggregatedBreakdownSceneState> {
   constructor(state: Partial<LabelsAggregatedBreakdownSceneState>) {
     super({
+      labelsPanelsType: getLabelsPanelType() ?? 'timeseries',
       ...state,
     });
 
@@ -71,9 +78,29 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
         this.updateQueriesOnFieldsVariableChange();
       })
     );
+
+    this._subs.add(
+      this.subscribeToState((newState, prevState) => {
+        if (newState.labelsPanelsType !== prevState.labelsPanelsType) {
+          // Cancel any in-flight queries on the current (about to be discarded) body, otherwise
+          // the time series requests keep running even after we switch to the text display.
+          if (this.state.body) {
+            cancelInFlightQueries(this.state.body);
+          }
+          // All query runners need to be rebuilt
+          this.setState({
+            body: this.build(),
+          });
+        }
+      })
+    );
   }
 
   private updateQueriesOnFieldsVariableChange = () => {
+    // Text panels don't run volume queries, so there's nothing to update.
+    if (this.state.labelsPanelsType === 'text') {
+      return;
+    }
     this.state.body?.state.layouts.forEach((layoutObj) => {
       const layout = layoutObj as SceneCSSGridLayout;
       // Iterate through the existing panels
@@ -177,25 +204,35 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
 
     const childrenClones = children.map((child) => child.clone());
 
+    const isText = this.state.labelsPanelsType === 'text';
+
     return new LayoutSwitcher({
+      // Text panels only support the grid view, so lock it and ignore the stored layout preference.
       active: 'grid',
+      syncLayoutFromStore: !isText,
       layouts: [
         new SceneCSSGridLayout({
-          autoRows: '200px',
+          autoRows: isText ? '35px' : '200px',
           children: children,
           isLazy: true,
           templateColumns: LABEL_BREAKDOWN_GRID_TEMPLATE_COLUMNS,
         }),
         new SceneCSSGridLayout({
-          autoRows: '200px',
+          autoRows: isText ? '35px' : '200px',
           children: childrenClones,
           isLazy: true,
           templateColumns: '1fr',
         }),
       ],
       options: [
-        { label: t('components.service-scene.breakdowns.labels-aggregated-breakdown-scene.layout.grid', 'Grid'), value: 'grid' },
-        { label: t('components.service-scene.breakdowns.labels-aggregated-breakdown-scene.layout.rows', 'Rows'), value: 'rows' },
+        {
+          label: t('components.service-scene.breakdowns.labels-aggregated-breakdown-scene.layout.grid', 'Grid'),
+          value: 'grid',
+        },
+        {
+          label: t('components.service-scene.breakdowns.labels-aggregated-breakdown-scene.layout.rows', 'Rows'),
+          value: 'rows',
+        },
       ],
     });
   }
@@ -208,31 +245,53 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
       if (value === ALL_VARIABLE_VALUE || !value) {
         continue;
       }
-      const query = buildLabelsQuery(this, String(option.value), String(option.value));
-      const queryRunner = getQueryRunner([query]);
-
       children.push(
-        new SceneCSSGridItem({
-          body: PanelBuilders.timeseries()
-            .setOption('annotations', { multiLane: true })
-            .setTitle(optionValue)
-            .setData(queryRunner)
-            .setHeaderActions([new SelectLabelActionScene({ fieldType: ValueSlugs.label, labelName: optionValue })])
-            .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
-            .setCustomFieldConfig('fillOpacity', 100)
-            .setCustomFieldConfig('lineWidth', 0)
-            .setCustomFieldConfig('pointSize', 0)
-            .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
-            .setHoverHeader(false)
-            .setShowMenuAlways(true)
-            .setOverrides(setLevelColorOverrides)
-            .setMenu(new PanelMenu({}))
-            .setSeriesLimit(MAX_NUMBER_OF_TIME_SERIES)
-            .build(),
-        })
+        this.state.labelsPanelsType === 'text'
+          ? this.buildTextChild(optionValue)
+          : this.buildTimeSeriesChild(optionValue)
       );
     }
     return children;
+  }
+
+  private buildTimeSeriesChild(optionValue: string): SceneCSSGridItem {
+    const query = buildLabelsQuery(this, optionValue, optionValue);
+    const queryRunner = getQueryRunner([query]);
+
+    return new SceneCSSGridItem({
+      body: PanelBuilders.timeseries()
+        .setOption('annotations', { multiLane: true })
+        .setTitle(optionValue)
+        .setData(queryRunner)
+        .setHeaderActions([new SelectLabelActionScene({ fieldType: ValueSlugs.label, labelName: optionValue })])
+        .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
+        .setCustomFieldConfig('fillOpacity', 100)
+        .setCustomFieldConfig('lineWidth', 0)
+        .setCustomFieldConfig('pointSize', 0)
+        .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+        .setHoverHeader(false)
+        .setShowMenuAlways(true)
+        .setOverrides(setLevelColorOverrides)
+        .setMenu(new PanelMenu({}))
+        .setSeriesLimit(MAX_NUMBER_OF_TIME_SERIES)
+        .build(),
+    });
+  }
+
+  private buildTextChild(optionValue: string): SceneCSSGridItem {
+    const text = PanelBuilders.text()
+      .setTitle(optionValue)
+      // Text panels don't query volume; an empty data provider keeps the panel lightweight.
+      .setData(new SceneDataTransformer({ transformations: [] }))
+      .setHeaderActions([new SelectLabelActionScene({ fieldType: ValueSlugs.label, labelName: optionValue })])
+      .setShowMenuAlways(true)
+      .setMenu(new PanelMenu({}));
+
+    text.setOption('content', '');
+
+    return new SceneCSSGridItem({
+      body: text.build(),
+    });
   }
 
   private sortChildren(cardinalityMap: Map<string, number>) {
@@ -251,6 +310,8 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
     };
   }
 
+  public static ShowLabelDisplayToggle = ShowLabelDisplayToggle;
+
   public static Selector({ model }: SceneComponentProps<LabelsAggregatedBreakdownScene>) {
     const { body } = model.useState();
     return <>{body && <LayoutSwitcher.Selector model={body} />}</>;
@@ -264,6 +325,10 @@ export class LabelsAggregatedBreakdownScene extends SceneObjectBase<LabelsAggreg
       return <div className={styles.panelWrapper}>{body && <body.Component model={body} />}</div>;
     }
 
-    return <LoadingPlaceholder text={t('components.service-scene.breakdowns.labels-aggregated-breakdown-scene.loading', 'Loading...')} />;
+    return (
+      <LoadingPlaceholder
+        text={t('components.service-scene.breakdowns.labels-aggregated-breakdown-scene.loading', 'Loading...')}
+      />
+    );
   };
 }

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import { css } from '@emotion/css';
-
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Field, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { RadioButtonGroup } from '@grafana/ui';
 
 import { getDrilldownSlug } from '../../../services/routing';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -76,19 +76,6 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
 
 function LayoutSwitcherComponent({ model }: { model: LayoutSwitcher }) {
   const { active, options } = model.useState();
-  const styles = useStyles2(getStyles);
 
-  return (
-    <Field className={styles.field}>
-      <RadioButtonGroup options={options} value={active} onChange={model.onLayoutChange} />
-    </Field>
-  );
+  return <RadioButtonGroup options={options} value={active} onChange={model.onLayoutChange} />;
 }
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    field: css({
-      marginBottom: 0,
-    }),
-  };
-};

--- a/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
+++ b/src/Components/ServiceScene/Breakdowns/LayoutSwitcher.tsx
@@ -14,6 +14,8 @@ export interface LayoutSwitcherState extends SceneObjectState {
   active: LayoutType;
   layouts: SceneObject[];
   options: Array<SelectableValue<LayoutType>>;
+  // When false, the active layout is locked and not synced from the stored layout preference.
+  syncLayoutFromStore?: boolean;
 }
 
 export type LayoutType = 'grid' | 'rows';
@@ -53,7 +55,9 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
   };
 
   public onActivate = () => {
-    this.updateLayout();
+    if (this.state.syncLayoutFromStore !== false) {
+      this.updateLayout();
+    }
   };
 
   public static Component = ({ model }: SceneComponentProps<LayoutSwitcher>) => {

--- a/src/Components/ServiceScene/Breakdowns/ShowErrorPanelToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowErrorPanelToggle.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { t, Trans } from '@grafana/i18n';
+import { t } from '@grafana/i18n';
 import { SceneComponentProps } from '@grafana/scenes';
-import { IconButton, InlineSwitch, Label, useStyles2 } from '@grafana/ui';
+import { IconButton, InlineSwitch, Stack, useStyles2 } from '@grafana/ui';
 
 import { FieldsAggregatedBreakdownScene } from './FieldsAggregatedBreakdownScene';
 
@@ -13,15 +13,6 @@ const errorToggleStyles = (theme: GrafanaTheme2) => {
   return {
     toggleIcon: css({
       color: theme.colors.error.main,
-      marginRight: theme.spacing(1),
-    }),
-    toggleLabel: css({
-      display: 'flex',
-
-      marginRight: theme.spacing(2),
-    }),
-    toggleLabelText: css({
-      marginRight: theme.spacing(1),
     }),
   };
 };
@@ -32,7 +23,7 @@ export function ShowErrorPanelToggle({ model }: SceneComponentProps<FieldsAggreg
 
   if (showErrorPanelToggle) {
     return (
-      <Label className={styles.toggleLabel}>
+      <Stack alignItems="center" gap={0}>
         <IconButton
           className={styles.toggleIcon}
           tooltip={t(
@@ -42,15 +33,18 @@ export function ShowErrorPanelToggle({ model }: SceneComponentProps<FieldsAggreg
           name={'exclamation-triangle'}
           variant={'secondary'}
         />
-        <span className={styles.toggleLabelText}>
-          <Trans i18nKey="components.service-scene.breakdowns.show-error-panel-toggle.show-panels-with-errors">Show panels with errors</Trans>
-        </span>
 
         <InlineSwitch
+          label={t(
+            'components.service-scene.breakdowns.show-error-panel-toggle.show-panels-with-errors',
+            'Show panels with errors'
+          )}
+          showLabel
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => model.toggleErrorPanels(event)}
           value={showErrorPanels}
+          transparent
         />
-      </Label>
+      </Stack>
     );
   }
 

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -1,16 +1,13 @@
 import React, { useCallback, useState } from 'react';
 
 import { t } from '@grafana/i18n';
-import { SceneComponentProps, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
-import { Icon, InlineField, InlineSwitch, Stack, Switch, Tooltip } from '@grafana/ui';
+import { SceneComponentProps } from '@grafana/scenes';
+import { Stack, Switch, Tooltip } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
 import { setFieldsPanelTypes } from '../../../services/store';
 import { FieldsAggregatedBreakdownScene } from './FieldsAggregatedBreakdownScene';
-import { IndexScene } from 'Components/IndexScene/IndexScene';
-import { CustomConstantVariable } from 'services/CustomConstantVariable';
-import { setParserEnabled, getJsonParserSegment, getLogfmtParserSegment, getParserEnabled } from 'services/parserToggle';
-import { VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from 'services/variables';
+import { setParserEnabled, getParserEnabled } from 'services/parserToggle';
 
 export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggregatedBreakdownScene>) {
   const { fieldsPanelsType } = model.useState();
@@ -36,32 +33,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
       enabled: parsersEnabled,
     });
 
-    setParserEnabled(parsersEnabled);
-
-    const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, model);
-    const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, model);
-    if (jsonParserVariable instanceof CustomConstantVariable) {
-      const segment = getJsonParserSegment(parsersEnabled);
-      jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
-    }
-    if (logfmtParserVariable instanceof CustomConstantVariable) {
-      const segment = getLogfmtParserSegment(parsersEnabled);
-      logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
-    }
-
-    const indexScene = sceneGraph.getAncestor(model, IndexScene);
-
-    // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
-    // to avoid sending invalid queries.
-    if (!parsersEnabled) {
-      indexScene.clearParserDependentFilters();
-    }
-
-    // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
-    // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
-    sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
-      queryRunner.runQueries();
-    });
+    setParserEnabled(parsersEnabled, model);
 
     setParserEnabledState(parsersEnabled);
   }, [model, parsersEnabledState]);

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -69,7 +69,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
           <label htmlFor="toggle-parser">
             {t(
               'components.service-scene.breakdowns.show-field-display-toggle.options.label.parse-fields',
-              'Extract fields'
+              'Extract fields from logs'
             )}
           </label>
         </Tooltip>

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -41,7 +41,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
   const volumeEnabled = fieldsPanelsType === 'timeseries';
 
   return (
-    <Stack gap={2}>
+    <Stack gap={2} flex={1}>
       <Stack alignItems="center">
         <Tooltip
           content={t(

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
-import { InlineSwitch, Stack, Tooltip } from '@grafana/ui';
+import { Icon, InlineField, InlineSwitch, Stack, Switch, Tooltip } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
 import { setFieldsPanelTypes } from '../../../services/store';
@@ -30,76 +30,83 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
   }, [fieldsPanelsType, model]);
 
   const toggleParser = useCallback(() => {
-      const parsersEnabled = !parsersEnabledState;
+    const parsersEnabled = !parsersEnabledState;
 
-      reportAppInteraction(USER_EVENTS_PAGES.all, USER_EVENTS_ACTIONS.all.parsers_toggled, {
-        enabled: parsersEnabled,
-      });
+    reportAppInteraction(USER_EVENTS_PAGES.all, USER_EVENTS_ACTIONS.all.parsers_toggled, {
+      enabled: parsersEnabled,
+    });
 
-      setParserEnabled(parsersEnabled);
+    setParserEnabled(parsersEnabled);
 
-      const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, model);
-      const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, model);
-      if (jsonParserVariable instanceof CustomConstantVariable) {
-        const segment = getJsonParserSegment(parsersEnabled);
-        jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
-      }
-      if (logfmtParserVariable instanceof CustomConstantVariable) {
-        const segment = getLogfmtParserSegment(parsersEnabled);
-        logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
-      }
+    const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, model);
+    const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, model);
+    if (jsonParserVariable instanceof CustomConstantVariable) {
+      const segment = getJsonParserSegment(parsersEnabled);
+      jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+    }
+    if (logfmtParserVariable instanceof CustomConstantVariable) {
+      const segment = getLogfmtParserSegment(parsersEnabled);
+      logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+    }
 
-      const indexScene = sceneGraph.getAncestor(model, IndexScene);
+    const indexScene = sceneGraph.getAncestor(model, IndexScene);
 
-      // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
-      // to avoid sending invalid queries.
-      if (!parsersEnabled) {
-        indexScene.clearParserDependentFilters();
-      }
+    // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
+    // to avoid sending invalid queries.
+    if (!parsersEnabled) {
+      indexScene.clearParserDependentFilters();
+    }
 
-      // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
-      // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
-      sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
-        queryRunner.runQueries();
-      });
+    // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
+    // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
+    sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
+      queryRunner.runQueries();
+    });
 
-      setParserEnabledState(parsersEnabled);
+    setParserEnabledState(parsersEnabled);
   }, [model, parsersEnabledState]);
 
   const volumeEnabled = fieldsPanelsType === 'timeseries';
 
   return (
-    <Stack>
-      <Tooltip content={t(
-        'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.display-volume',
-        'Query time series for each field showing the distribution of values over time'
-      )}>
-        <InlineSwitch
-          label={t(
-            'components.service-scene.breakdowns.show-field-display-toggle.options.label.display-volume',
-            'Display volume'
-          )}
-          showLabel={true}
+    <Stack gap={2}>
+      <Stack alignItems="center">
+        <Tooltip content={t(
+          'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.display-volume',
+          'Query time series for each field showing the distribution of values over time'
+        )}>
+          <label htmlFor="toggle-volume">
+            {t(
+              'components.service-scene.breakdowns.show-field-display-toggle.options.label.display-volume',
+              'Display volume'
+            )}
+          </label>
+        </Tooltip>
+        <Switch
           value={volumeEnabled}
           onClick={toggleVolume}
-          transparent
+          id="toggle-volume"
         />
-      </Tooltip>
-      <Tooltip content={t(
-        'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.parse-fields',
-        'Apply logftm/JSON parsers to extract fields from the log lines'
-      )}>
-        <InlineSwitch
-          label={t(
-            'components.service-scene.breakdowns.show-field-display-toggle.options.label.parse-fields',
-            'Extract fields'
-          )}
-          showLabel={true}
+      </Stack>
+
+      <Stack alignItems="center">
+        <Tooltip content={t(
+          'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.parse-fields',
+          'Apply logftm/JSON parsers to extract fields from the log lines'
+        )}>
+          <label htmlFor="toggle-parser">
+            {t(
+              'components.service-scene.breakdowns.show-field-display-toggle.options.label.parse-fields',
+              'Extract fields'
+            )}
+          </label>
+        </Tooltip>
+        <Switch
           value={parsersEnabledState}
           onClick={toggleParser}
-          transparent
+          id="toggle-parser"
         />
-      </Tooltip>
+      </Stack>
     </Stack>
   );
 }

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -43,10 +43,12 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
   return (
     <Stack gap={2}>
       <Stack alignItems="center">
-        <Tooltip content={t(
-          'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.display-volume',
-          'Query time series for each field showing the distribution of values over time'
-        )}>
+        <Tooltip
+          content={t(
+            'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.display-volume',
+            'Query time series for each field showing the distribution of values over time'
+          )}
+        >
           <label htmlFor="toggle-volume">
             {t(
               'components.service-scene.breakdowns.show-field-display-toggle.options.label.display-volume',
@@ -54,18 +56,16 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
             )}
           </label>
         </Tooltip>
-        <Switch
-          value={volumeEnabled}
-          onClick={toggleVolume}
-          id="toggle-volume"
-        />
+        <Switch value={volumeEnabled} onClick={toggleVolume} id="toggle-volume" />
       </Stack>
 
       <Stack alignItems="center">
-        <Tooltip content={t(
-          'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.parse-fields',
-          'Enable to apply logftm/JSON parsers to every query and extract fields from the log lines'
-        )}>
+        <Tooltip
+          content={t(
+            'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.parse-fields',
+            'Enable to apply logfmt/JSON parsers to every query and extract fields from the log lines'
+          )}
+        >
           <label htmlFor="toggle-parser">
             {t(
               'components.service-scene.breakdowns.show-field-display-toggle.options.label.parse-fields',
@@ -73,11 +73,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
             )}
           </label>
         </Tooltip>
-        <Switch
-          value={parsersEnabledState}
-          onClick={toggleParser}
-          id="toggle-parser"
-        />
+        <Switch value={parsersEnabledState} onClick={toggleParser} id="toggle-parser" />
       </Stack>
     </Stack>
   );

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -56,7 +56,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
             )}
           </label>
         </Tooltip>
-        <Switch value={volumeEnabled} onClick={toggleVolume} id="toggle-volume" />
+        <Switch value={volumeEnabled} onChange={toggleVolume} id="toggle-volume" />
       </Stack>
 
       <Stack alignItems="center">
@@ -73,7 +73,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
             )}
           </label>
         </Tooltip>
-        <Switch value={parsersEnabledState} onClick={toggleParser} id="toggle-parser" />
+        <Switch value={parsersEnabledState} onChange={toggleParser} id="toggle-parser" />
       </Stack>
     </Stack>
   );

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -1,20 +1,22 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
-import { css } from '@emotion/css';
-
-import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { SceneComponentProps } from '@grafana/scenes';
-import { InlineSwitch } from '@grafana/ui';
+import { SceneComponentProps, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
+import { InlineSwitch, Stack, Tooltip } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
 import { setFieldsPanelTypes } from '../../../services/store';
 import { FieldsAggregatedBreakdownScene } from './FieldsAggregatedBreakdownScene';
+import { IndexScene } from 'Components/IndexScene/IndexScene';
+import { CustomConstantVariable } from 'services/CustomConstantVariable';
+import { setParserEnabled, getJsonParserSegment, getLogfmtParserSegment, getParserEnabled } from 'services/parserToggle';
+import { VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from 'services/variables';
 
 export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggregatedBreakdownScene>) {
   const { fieldsPanelsType } = model.useState();
+  const [parsersEnabledState, setParserEnabledState] = useState(getParserEnabled());
 
-  const toggle = useCallback(() => {
+  const toggleVolume = useCallback(() => {
     const nextPanelType = fieldsPanelsType === 'timeseries' ? 'text' : 'timeseries';
     model.setState({ fieldsPanelsType: nextPanelType });
     setFieldsPanelTypes(nextPanelType);
@@ -27,17 +29,77 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
     );
   }, [fieldsPanelsType, model]);
 
-  const enabled = fieldsPanelsType === 'timeseries';
+  const toggleParser = useCallback(() => {
+      const parsersEnabled = !parsersEnabledState;
+
+      reportAppInteraction(USER_EVENTS_PAGES.all, USER_EVENTS_ACTIONS.all.parsers_toggled, {
+        enabled: parsersEnabled,
+      });
+
+      setParserEnabled(parsersEnabled);
+
+      const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, model);
+      const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, model);
+      if (jsonParserVariable instanceof CustomConstantVariable) {
+        const segment = getJsonParserSegment(parsersEnabled);
+        jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+      }
+      if (logfmtParserVariable instanceof CustomConstantVariable) {
+        const segment = getLogfmtParserSegment(parsersEnabled);
+        logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+      }
+
+      const indexScene = sceneGraph.getAncestor(model, IndexScene);
+
+      // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
+      // to avoid sending invalid queries.
+      if (!parsersEnabled) {
+        indexScene.clearParserDependentFilters();
+      }
+
+      // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
+      // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
+      sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
+        queryRunner.runQueries();
+      });
+
+      setParserEnabledState(parsersEnabled);
+  }, [model, parsersEnabledState]);
+
+  const volumeEnabled = fieldsPanelsType === 'timeseries';
 
   return (
-    <InlineSwitch
-      label={t(
-        'components.service-scene.breakdowns.show-field-display-toggle.options.label.display-volume',
-        'Display volume'
-      )}
-      showLabel={true}
-      value={enabled}
-      onClick={toggle}
-    />
+    <Stack>
+      <Tooltip content={t(
+        'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.display-volume',
+        'Query time series for each field showing the distribution of values over time'
+      )}>
+        <InlineSwitch
+          label={t(
+            'components.service-scene.breakdowns.show-field-display-toggle.options.label.display-volume',
+            'Display volume'
+          )}
+          showLabel={true}
+          value={volumeEnabled}
+          onClick={toggleVolume}
+          transparent
+        />
+      </Tooltip>
+      <Tooltip content={t(
+        'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.parse-fields',
+        'Apply logftm/JSON parsers to extract fields from the log lines'
+      )}>
+        <InlineSwitch
+          label={t(
+            'components.service-scene.breakdowns.show-field-display-toggle.options.label.parse-fields',
+            'Extract fields'
+          )}
+          showLabel={true}
+          value={parsersEnabledState}
+          onClick={toggleParser}
+          transparent
+        />
+      </Tooltip>
+    </Stack>
   );
 }

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -92,7 +92,7 @@ export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggr
       <Stack alignItems="center">
         <Tooltip content={t(
           'components.service-scene.breakdowns.show-field-display-toggle.options.tooltip.parse-fields',
-          'Apply logftm/JSON parsers to extract fields from the log lines'
+          'Enable to apply logftm/JSON parsers to every query and extract fields from the log lines'
         )}>
           <label htmlFor="toggle-parser">
             {t(

--- a/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowFieldDisplayToggle.tsx
@@ -1,62 +1,43 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps } from '@grafana/scenes';
-import { RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { InlineSwitch } from '@grafana/ui';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
 import { setFieldsPanelTypes } from '../../../services/store';
-import { FieldsAggregatedBreakdownScene, FieldsPanelsType } from './FieldsAggregatedBreakdownScene';
+import { FieldsAggregatedBreakdownScene } from './FieldsAggregatedBreakdownScene';
 
 export function ShowFieldDisplayToggle({ model }: SceneComponentProps<FieldsAggregatedBreakdownScene>) {
   const { fieldsPanelsType } = model.useState();
-  const styles = useStyles2(getStyles);
-  const options: Array<SelectableValue<FieldsPanelsType>> = [
-    {
-      label: t('components.service-scene.breakdowns.show-field-display-toggle.options.label.volume', 'Volume'),
-      value: 'timeseries',
-    },
-    {
-      label: t('components.service-scene.breakdowns.show-field-display-toggle.options.label.names', 'Names'),
-      value: 'text',
-    },
-  ];
+
+  const toggle = useCallback(() => {
+    const nextPanelType = fieldsPanelsType === 'timeseries' ? 'text' : 'timeseries';
+    model.setState({ fieldsPanelsType: nextPanelType });
+    setFieldsPanelTypes(nextPanelType);
+    reportAppInteraction(
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.fields_panel_type_toggle,
+      {
+        fieldsPanelType: nextPanelType,
+      }
+    );
+  }, [fieldsPanelsType, model]);
+
+  const enabled = fieldsPanelsType === 'timeseries';
 
   return (
-    <RadioButtonGroup
-      className={styles.radioGroup}
-      options={options}
-      value={fieldsPanelsType}
-      onChange={(panelType) => {
-        model.setState({ fieldsPanelsType: panelType });
-        setFieldsPanelTypes(panelType);
-        reportAppInteraction(
-          USER_EVENTS_PAGES.service_details,
-          USER_EVENTS_ACTIONS.service_details.fields_panel_type_toggle,
-          {
-            fieldsPanelType: panelType,
-          }
-        );
-      }}
+    <InlineSwitch
+      label={t(
+        'components.service-scene.breakdowns.show-field-display-toggle.options.label.display-volume',
+        'Display volume'
+      )}
+      showLabel={true}
+      value={enabled}
+      onClick={toggle}
     />
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    radioGroup: css({
-      [theme.breakpoints.up(theme.breakpoints.values.md)]: {
-        flexDirection: 'row',
-      },
-      // Why do I need to hack the label height?
-      '> div > label': {
-        height: '100%',
-      },
-
-      flexDirection: 'column',
-    }),
-  };
-};

--- a/src/Components/ServiceScene/Breakdowns/ShowLabelDisplayToggle.tsx
+++ b/src/Components/ServiceScene/Breakdowns/ShowLabelDisplayToggle.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback } from 'react';
+
+import { t } from '@grafana/i18n';
+import { SceneComponentProps } from '@grafana/scenes';
+import { Stack, Switch, Tooltip } from '@grafana/ui';
+
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../services/analytics';
+import { setLabelsPanelType } from '../../../services/store';
+import { LabelsAggregatedBreakdownScene } from './LabelsAggregatedBreakdownScene';
+
+export function ShowLabelDisplayToggle({ model }: SceneComponentProps<LabelsAggregatedBreakdownScene>) {
+  const { labelsPanelsType } = model.useState();
+
+  const toggleVolume = useCallback(() => {
+    const nextPanelType = labelsPanelsType === 'timeseries' ? 'text' : 'timeseries';
+    model.setState({ labelsPanelsType: nextPanelType });
+    setLabelsPanelType(nextPanelType);
+    reportAppInteraction(
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.labels_panel_type_toggle,
+      {
+        labelsPanelType: nextPanelType,
+      }
+    );
+  }, [labelsPanelsType, model]);
+
+  const volumeEnabled = labelsPanelsType === 'timeseries';
+
+  return (
+    <Stack gap={2} flex={1}>
+      <Stack alignItems="center">
+        <Tooltip
+          content={t(
+            'components.service-scene.breakdowns.show-label-display-toggle.options.tooltip.display-volume',
+            'Query time series for each label showing the distribution of values over time'
+          )}
+        >
+          <label htmlFor="toggle-label-volume">
+            {t(
+              'components.service-scene.breakdowns.show-label-display-toggle.options.label.display-volume',
+              'Display volume'
+            )}
+          </label>
+        </Tooltip>
+        <Switch value={volumeEnabled} onChange={toggleVolume} id="toggle-label-volume" />
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -384,8 +384,7 @@
           "text-loading": "Loading..."
         },
         "fields-breakdown-scene": {
-          "label-field": "Field",
-          "parsers-disabled": "No fields are available because parsers are disabled. Enable parsers in the query options to extract fields from your log lines."
+          "label-field": "Field"
         },
         "label-breakdown-scene": {
           "label-label": "Label",

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -360,6 +360,7 @@
         },
         "empty-layout-scene": {
           "link": "let us know",
+          "parsed-fields": "We did not find any {{type}} for the given time range. Try enabling extracted fields from the log lines.",
           "prefix": "Please",
           "suffix": "if you think this is a mistake.",
           "title": "We did not find any {{type}} for the given time range."

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -359,6 +359,8 @@
           "no-values-found": "No values found matching “{{filter}}”"
         },
         "empty-layout-scene": {
+          "ask-assistant": "Ask Grafana Assistant",
+          "enable-parsers": "Enable extracted fields",
           "link": "let us know",
           "parsed-fields": "We did not find any {{type}} for the given time range. Try enabling extracted fields from the log lines.",
           "prefix": "Please",
@@ -384,7 +386,9 @@
           "text-loading": "Loading..."
         },
         "fields-breakdown-scene": {
-          "label-field": "Field"
+          "label-field": "Field",
+          "label-field-tooltip": "Structured metadata and parsed fields",
+          "label-metadata-tooltip": "Structured metadata fields"
         },
         "label-breakdown-scene": {
           "label-label": "Label",

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -517,6 +517,16 @@
             }
           }
         },
+        "show-label-display-toggle": {
+          "options": {
+            "label": {
+              "display-volume": "Display volume"
+            },
+            "tooltip": {
+              "display-volume": "Query time series for each label showing the distribution of values over time"
+            }
+          }
+        },
         "sort-by-scene": {
           "aria-label-sort-direction": "Sort direction",
           "description": {

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -248,6 +248,13 @@
           "query-options": "Query options"
         }
       },
+      "variable-layout": {
+        "parser-toggle": {
+          "label": "P",
+          "tooltip-disabled": "Parsers are off. Click to enable JSON and logfmt parsers to extract fields from the log lines.",
+          "tooltip-enabled": "Parsers are on. Click to disable extracting fields from the logs using JSON and logfmt parsers."
+        }
+      },
       "variable-layout-scene": {
         "collapse": "Collapse filters",
         "expand": "Expand filters"
@@ -383,7 +390,8 @@
           "text-loading": "Loading..."
         },
         "fields-breakdown-scene": {
-          "label-field": "Field"
+          "label-field": "Field",
+          "parsers-disabled": "No fields are available because parsers are disabled. Enable parsers in the query options to extract fields from your log lines."
         },
         "label-breakdown-scene": {
           "label-label": "Label",

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -248,13 +248,6 @@
           "query-options": "Query options"
         }
       },
-      "variable-layout": {
-        "parser-toggle": {
-          "label": "P",
-          "tooltip-disabled": "Parsers are off. Click to enable JSON and logfmt parsers to extract fields from the log lines.",
-          "tooltip-enabled": "Parsers are on. Click to disable extracting fields from the logs using JSON and logfmt parsers."
-        }
-      },
       "variable-layout-scene": {
         "collapse": "Collapse filters",
         "expand": "Expand filters"
@@ -511,8 +504,12 @@
         "show-field-display-toggle": {
           "options": {
             "label": {
-              "names": "Names",
-              "volume": "Volume"
+              "display-volume": "Display volume",
+              "parse-fields": "Extract fields"
+            },
+            "tooltip": {
+              "display-volume": "Query time series for each field showing the distribution of values over time",
+              "parse-fields": "Apply logftm/JSON parsers to extract fields from the log lines"
             }
           }
         },

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -509,11 +509,11 @@
           "options": {
             "label": {
               "display-volume": "Display volume",
-              "parse-fields": "Extract fields"
+              "parse-fields": "Extract fields from logs"
             },
             "tooltip": {
               "display-volume": "Query time series for each field showing the distribution of values over time",
-              "parse-fields": "Apply logftm/JSON parsers to extract fields from the log lines"
+              "parse-fields": "Apply logfmt/JSON parsers to extract fields from the log lines"
             }
           }
         },

--- a/src/services/TagKeysProviders.test.ts
+++ b/src/services/TagKeysProviders.test.ts
@@ -1,10 +1,13 @@
 import { dateTime, TimeRange } from '@grafana/data';
 import { DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
-import { AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
+import { AdHocFiltersVariable, sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { LokiDatasource } from './lokiQuery';
+import { getParserEnabled } from './parserToggle';
 import { getDataSource } from './scenes';
-import { getLabelsKeys, getLabelsTagKeysProvider } from './TagKeysProviders';
+import { DetectedFieldsResult } from './TagValuesProviders';
+import { getFieldsKeysProvider, getLabelsKeys, getLabelsTagKeysProvider } from './TagKeysProviders';
+import { LEVEL_VARIABLE_VALUE, VAR_FIELDS_AND_METADATA } from './variables';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -14,10 +17,30 @@ jest.mock('./scenes', () => ({
   ...jest.requireActual('./scenes'),
   getDataSource: jest.fn(),
 }));
+jest.mock('./parserToggle', () => ({
+  getParserEnabled: jest.fn(),
+}));
 
 function mockDsMethod(ds: object): LokiDatasource {
   Object.setPrototypeOf(ds, DataSourceWithBackend.prototype);
   return ds as LokiDatasource;
+}
+
+function mockFieldsDatasource(fields: DetectedFieldsResult): {
+  datasource: LokiDatasource;
+  fetchDetectedFields: jest.Mock;
+} {
+  const fetchDetectedFields = jest.fn().mockResolvedValue(fields);
+  const datasource = mockDsMethod({
+    languageProvider: { fetchDetectedFields },
+  });
+
+  jest.mocked(getDataSource).mockReturnValue('loki-uid');
+  jest.mocked(getDataSourceSrv).mockReturnValue({
+    get: jest.fn().mockResolvedValue(datasource),
+  } as unknown as ReturnType<typeof getDataSourceSrv>);
+
+  return { datasource, fetchDetectedFields };
 }
 
 describe('getLabelsKeys', () => {
@@ -86,6 +109,92 @@ describe('getLabelsTagKeysProvider', () => {
       expect.objectContaining({
         timeRange: sceneTimeRange,
       })
+    );
+  });
+});
+
+describe('getFieldsKeysProvider with parsers disabled', () => {
+  const sceneRef = {} as SceneObject;
+
+  const detectedFields: DetectedFieldsResult = [
+    { cardinality: 1, label: 'trace_id', parsers: null, type: 'string' },
+    { cardinality: 2, label: 'pod', parsers: null, type: 'string' },
+    { cardinality: 3, label: 'level', parsers: ['logfmt'], type: 'string' },
+    { cardinality: 4, label: 'duration', parsers: ['json', 'logfmt'], type: 'string' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getParserEnabled).mockReturnValue(false);
+  });
+
+  it('returns only structured-metadata fields (parsers === null) for VAR_FIELDS_AND_METADATA', async () => {
+    mockFieldsDatasource(detectedFields);
+
+    const result = await getFieldsKeysProvider({
+      expr: '{service_name="test"}',
+      sceneRef,
+      variableType: VAR_FIELDS_AND_METADATA,
+    });
+
+    expect(result.replace).toBe(true);
+    expect(result.values.map((value) => value.text)).toEqual(['trace_id', 'pod']);
+  });
+
+  it('marks the returned structured-metadata fields with the structuredMetadata parser group', async () => {
+    mockFieldsDatasource(detectedFields);
+
+    const result = await getFieldsKeysProvider({
+      expr: '{service_name="test"}',
+      sceneRef,
+      variableType: VAR_FIELDS_AND_METADATA,
+    });
+
+    expect(result.values).toEqual([
+      expect.objectContaining({
+        group: 'structuredMetadata',
+        meta: expect.objectContaining({ parser: 'structuredMetadata' }),
+        text: 'trace_id',
+        value: 'trace_id',
+      }),
+      expect.objectContaining({
+        group: 'structuredMetadata',
+        meta: expect.objectContaining({ parser: 'structuredMetadata' }),
+        text: 'pod',
+        value: 'pod',
+      }),
+    ]);
+  });
+
+  it('excludes parser-dependent fields when no structured-metadata fields exist', async () => {
+    mockFieldsDatasource([
+      { cardinality: 3, label: 'level', parsers: ['logfmt'], type: 'string' },
+      { cardinality: 4, label: 'duration', parsers: ['json', 'logfmt'], type: 'string' },
+    ]);
+
+    const result = await getFieldsKeysProvider({
+      expr: '{service_name="test"}',
+      sceneRef,
+      variableType: VAR_FIELDS_AND_METADATA,
+    });
+
+    expect(result.values).toEqual([]);
+  });
+
+  it('still includes the detected level field even when it requires a parser', async () => {
+    mockFieldsDatasource([
+      { cardinality: 1, label: 'trace_id', parsers: null, type: 'string' },
+      { cardinality: 5, label: LEVEL_VARIABLE_VALUE, parsers: ['logfmt'], type: 'string' },
+    ]);
+
+    const result = await getFieldsKeysProvider({
+      expr: '{service_name="test"}',
+      sceneRef,
+      variableType: VAR_FIELDS_AND_METADATA,
+    });
+
+    expect(result.values.map((value) => value.text)).toEqual(
+      expect.arrayContaining(['trace_id', LEVEL_VARIABLE_VALUE])
     );
   });
 });

--- a/src/services/TagKeysProviders.test.ts
+++ b/src/services/TagKeysProviders.test.ts
@@ -5,8 +5,8 @@ import { AdHocFiltersVariable, sceneGraph, SceneObject } from '@grafana/scenes';
 import { LokiDatasource } from './lokiQuery';
 import { getParserEnabled } from './parserToggle';
 import { getDataSource } from './scenes';
-import { DetectedFieldsResult } from './TagValuesProviders';
 import { getFieldsKeysProvider, getLabelsKeys, getLabelsTagKeysProvider } from './TagKeysProviders';
+import { DetectedFieldsResult } from './TagValuesProviders';
 import { LEVEL_VARIABLE_VALUE, VAR_FIELDS_AND_METADATA } from './variables';
 
 jest.mock('@grafana/runtime', () => ({

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -15,6 +15,7 @@ import { ExpressionBuilder } from './ExpressionBuilder';
 import { LABELS_TO_REMOVE } from './filters';
 import { logger } from './logger';
 import { LokiDatasource, LokiQuery } from './lokiQuery';
+import { getParserEnabled } from './parserToggle';
 import { getDataSource } from './scenes';
 import { DetectedFieldsResult, LokiLanguageProviderWithDetectedLabelValues } from './TagValuesProviders';
 import { LEVEL_VARIABLE_VALUE, ParserType, VAR_FIELDS_AND_METADATA, VAR_LEVELS } from './variables';
@@ -130,7 +131,8 @@ export async function getFieldsKeysProvider({
         }
 
         if (variableType === VAR_FIELDS_AND_METADATA && field.label !== LEVEL_VARIABLE_VALUE) {
-          return true;
+          // With parsers disabled, only structured-metadata fields (no parser) can be queried.
+          return getParserEnabled() ? true : field.parsers === null;
         }
 
         return field.parsers !== null;

--- a/src/services/TagKeysProviders.ts
+++ b/src/services/TagKeysProviders.ts
@@ -124,6 +124,8 @@ export async function getFieldsKeysProvider({
       throw tagKeys;
     }
 
+    const parserEnabled = getParserEnabled();
+
     const result: MetricFindValue[] = tagKeys
       .filter((field) => {
         if (variableType === VAR_LEVELS) {
@@ -132,7 +134,7 @@ export async function getFieldsKeysProvider({
 
         if (variableType === VAR_FIELDS_AND_METADATA && field.label !== LEVEL_VARIABLE_VALUE) {
           // With parsers disabled, only structured-metadata fields (no parser) can be queried.
-          return getParserEnabled() ? true : field.parsers === null;
+          return parserEnabled ? true : field.parsers === null;
         }
 
         return field.parsers !== null;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -138,6 +138,8 @@ export const USER_EVENTS_ACTIONS = {
   [USER_EVENTS_PAGES.all]: {
     interval_too_long: 'interval_too_long',
     open_in_explore_menu_clicked: 'open_in_explore_menu_clicked',
+    // Toggling LogQL parsers on/off from the header query options. Props: enabled
+    parsers_toggled: 'parsers_toggled',
   },
   [USER_EVENTS_PAGES.default_columns_config]: {
     add_record: 'add_record',

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -115,6 +115,8 @@ export const USER_EVENTS_ACTIONS = {
     visualization_init: 'visualization_init',
     // fields rollup viz type toggle
     fields_panel_type_toggle: 'fields_panel_type_toggle',
+    // labels rollup viz type toggle
+    labels_panel_type_toggle: 'labels_panel_type_toggle',
     // table header buttons
     table_columns_header_button_reset_width: 'table_columns_header_button_reset_width',
     table_columns_header_button_show_labels: 'table_columns_header_button_show_labels',

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort/imports */
 import { Observable, Subscriber } from 'rxjs';
 
 import {
@@ -26,13 +25,13 @@ import { FIELDS_TO_REMOVE, LABELS_TO_REMOVE, sortLabelsByCardinality } from './f
 import { logger } from './logger';
 import { requestSupportsSharding } from './logql';
 import { LokiDatasource, LokiQuery } from './lokiQuery';
+import { getParserEnabled } from './parserToggle';
 import { PLUGIN_ID } from './plugin';
 import { sanitizeStreamSelector } from './query';
 import { getDataSource } from './scenes';
 import { runShardSplitQuery } from './shardQuerySplitting';
 import { SERVICE_NAME } from './variables';
 import { getFeatureFlag } from 'featureFlags/openFeature';
-import { getParserEnabled } from './parserToggle';
 
 export const WRAPPED_LOKI_DS_UID = 'wrapped-loki-ds-uid';
 

--- a/src/services/datasource.ts
+++ b/src/services/datasource.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sort/imports */
 import { Observable, Subscriber } from 'rxjs';
 
 import {
@@ -31,6 +32,7 @@ import { getDataSource } from './scenes';
 import { runShardSplitQuery } from './shardQuerySplitting';
 import { SERVICE_NAME } from './variables';
 import { getFeatureFlag } from 'featureFlags/openFeature';
+import { getParserEnabled } from './parserToggle';
 
 export const WRAPPED_LOKI_DS_UID = 'wrapped-loki-ds-uid';
 
@@ -416,8 +418,10 @@ export class WrappedLokiDatasource extends RuntimeDataSource<DataQuery> {
       const typeField: Field = { config: {}, name: DETECTED_FIELDS_TYPE_NAME, type: FieldType.string, values: [] };
       const pathField: Field = { config: {}, name: DETECTED_FIELDS_PATH_NAME, type: FieldType.string, values: [] };
 
+      const parsersEnabled = getParserEnabled();
+
       response.fields?.forEach((field) => {
-        if (!FIELDS_TO_REMOVE.includes(field.label)) {
+        if (!FIELDS_TO_REMOVE.includes(field.label) && (parsersEnabled || field.parsers === null)) {
           nameField.values.push(field.label);
           cardinalityField.values.push(field.cardinality);
           parserField.values.push(field.parsers?.length ? field.parsers.join(', ') : 'structuredMetadata');

--- a/src/services/expressions.test.ts
+++ b/src/services/expressions.test.ts
@@ -1,0 +1,112 @@
+import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
+
+import { getTimeSeriesExpr } from './expressions';
+import { getParserFromFieldsFilters } from './fields';
+import { getParserEnabled } from './parserToggle';
+import { getFieldsVariable } from './variableGetters';
+import {
+  JSON_FORMAT_EXPR,
+  LEVEL_VARIABLE_VALUE,
+  LOGS_FORMAT_EXPR,
+  MIXED_FORMAT_EXPR,
+} from './variables';
+
+jest.mock('./parserToggle');
+jest.mock('./fields');
+jest.mock('./variableGetters');
+
+const getParserEnabledMock = jest.mocked(getParserEnabled);
+const getParserFromFieldsFiltersMock = jest.mocked(getParserFromFieldsFilters);
+const getFieldsVariableMock = jest.mocked(getFieldsVariable);
+
+const sceneRef = {} as SceneObject;
+
+/**
+ * Configure the mocked dependencies for a single test case.
+ */
+function setup(options: {
+  filterCount: number;
+  parser: 'json' | 'logfmt' | 'mixed' | 'structuredMetadata';
+  parserEnabled: boolean;
+}) {
+  getParserEnabledMock.mockReturnValue(options.parserEnabled);
+  getParserFromFieldsFiltersMock.mockReturnValue(options.parser);
+  getFieldsVariableMock.mockReturnValue({
+    state: {
+      filters: new Array(options.filterCount).fill({}),
+    },
+  } as unknown as AdHocFiltersVariable);
+}
+
+describe('getTimeSeriesExpr', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when parsers are disabled', () => {
+    it.each(['json', 'logfmt', 'mixed'] as const)(
+      'does not append the %s parser format even when field filters are present',
+      (parser) => {
+        setup({ filterCount: 2, parser, parserEnabled: false });
+
+        const expr = getTimeSeriesExpr(sceneRef, 'pod');
+
+        expect(expr).not.toContain(JSON_FORMAT_EXPR);
+        expect(expr).not.toContain(LOGS_FORMAT_EXPR);
+        expect(expr).not.toContain(MIXED_FORMAT_EXPR);
+        expect(expr).not.toContain('| json');
+        expect(expr).not.toContain('| logfmt');
+      }
+    );
+
+    it('returns the base query without parser segments when field filters are present', () => {
+      setup({ filterCount: 3, parser: 'json', parserEnabled: false });
+
+      const expr = getTimeSeriesExpr(sceneRef, 'pod');
+
+      expect(expr).toBe(
+        'sum(count_over_time({${filters}}  ${metadata} ${patterns} ${lineFilters} ${fields} ${lineFormat} [$__auto])) by (pod)'
+      );
+    });
+
+    it('produces the same query whether or not field filters exist', () => {
+      setup({ filterCount: 0, parser: 'json', parserEnabled: false });
+      const exprWithoutFilters = getTimeSeriesExpr(sceneRef, 'pod');
+
+      setup({ filterCount: 5, parser: 'json', parserEnabled: false });
+      const exprWithFilters = getTimeSeriesExpr(sceneRef, 'pod');
+
+      expect(exprWithFilters).toBe(exprWithoutFilters);
+    });
+
+    it('still appends the level metadata expression when excluding empty values for the level selector', () => {
+      setup({ filterCount: 2, parser: 'json', parserEnabled: false });
+
+      const expr = getTimeSeriesExpr(sceneRef, LEVEL_VARIABLE_VALUE);
+
+      expect(expr).toContain(`| ${LEVEL_VARIABLE_VALUE} != ""`);
+      expect(expr).not.toContain(JSON_FORMAT_EXPR);
+      expect(expr).toBe(
+        `sum(count_over_time({\${filters}} | ${LEVEL_VARIABLE_VALUE} != "" \${metadata} \${patterns} \${lineFilters} \${fields} \${lineFormat} [$__auto])) by (${LEVEL_VARIABLE_VALUE})`
+      );
+    });
+  });
+
+  describe('when parsers are enabled', () => {
+    it('appends the json parser format when field filters are present', () => {
+      setup({ filterCount: 1, parser: 'json', parserEnabled: true });
+
+      const expr = getTimeSeriesExpr(sceneRef, 'pod');
+
+      expect(expr).toContain(JSON_FORMAT_EXPR);
+    });
+
+    it('does not append a parser format when there are no field filters', () => {
+      setup({ filterCount: 0, parser: 'json', parserEnabled: true });
+
+      const expr = getTimeSeriesExpr(sceneRef, 'pod');
+
+      expect(expr).not.toContain(JSON_FORMAT_EXPR);
+    });
+  });
+});

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -3,6 +3,7 @@ import { SceneObject } from '@grafana/scenes';
 import { UIVariableFilterType } from '../Components/ServiceScene/Breakdowns/AddToFiltersButton';
 import { getParserFromFieldsFilters } from './fields';
 import { logger } from './logger';
+import { getParserEnabled } from './parserToggle';
 import { getFieldsVariable } from './variableGetters';
 import {
   DETECTED_FIELD_AND_METADATA_VALUES_EXPR,
@@ -42,8 +43,8 @@ export function getTimeSeriesExpr(sceneRef: SceneObject, streamSelectorName: str
   const fieldFilters = fieldsVariable.state.filters;
   const parser = getParserFromFieldsFilters(fieldsVariable);
 
-  // if we have fields, we also need to add parsers
-  if (fieldFilters.length) {
+  // if we have fields, we also need to add parsers (unless parsers are disabled via the header toggle)
+  if (getParserEnabled() && fieldFilters.length) {
     if (parser === 'mixed') {
       return `sum(count_over_time({${VAR_LABELS_EXPR}} ${metadataExpressionToAdd} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${MIXED_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${streamSelectorName})`;
     }

--- a/src/services/parserToggle.test.ts
+++ b/src/services/parserToggle.test.ts
@@ -1,0 +1,185 @@
+import { sceneGraph, SceneObject } from '@grafana/scenes';
+
+import { CustomConstantVariable } from './CustomConstantVariable';
+import {
+  getJsonParserSegment,
+  getLogfmtParserSegment,
+  getParserEnabled,
+  PARSER_ENABLED_LOCALSTORAGE_KEY,
+  setParserEnabled,
+} from './parserToggle';
+import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
+
+jest.mock('@grafana/scenes', () => ({
+  ...jest.requireActual('@grafana/scenes'),
+  sceneGraph: {
+    findDescendents: jest.fn(() => []),
+    getAncestor: jest.fn(),
+    lookupVariable: jest.fn(),
+  },
+}));
+
+describe('getParserEnabled', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('defaults to true when nothing is stored', () => {
+    expect(getParserEnabled()).toBe(true);
+  });
+
+  test('returns true when stored value is "true"', () => {
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, 'true');
+    expect(getParserEnabled()).toBe(true);
+  });
+
+  test('returns false when stored value is "false"', () => {
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, 'false');
+    expect(getParserEnabled()).toBe(false);
+  });
+
+  test('returns false when stored value is an empty string', () => {
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, '');
+    expect(getParserEnabled()).toBe(false);
+  });
+});
+
+describe('getJsonParserSegment', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('returns the JSON parser segment when enabled', () => {
+    expect(getJsonParserSegment(true)).toBe(JSON_PARSER_SEGMENT);
+  });
+
+  test('returns an empty string when disabled', () => {
+    expect(getJsonParserSegment(false)).toBe('');
+  });
+
+  test('falls back to the stored value when no argument is passed', () => {
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, 'false');
+    expect(getJsonParserSegment()).toBe('');
+
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, 'true');
+    expect(getJsonParserSegment()).toBe(JSON_PARSER_SEGMENT);
+  });
+});
+
+describe('getLogfmtParserSegment', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('returns the logfmt parser segment when enabled', () => {
+    expect(getLogfmtParserSegment(true)).toBe(LOGFMT_PARSER_SEGMENT);
+  });
+
+  test('returns an empty string when disabled', () => {
+    expect(getLogfmtParserSegment(false)).toBe('');
+  });
+
+  test('falls back to the stored value when no argument is passed', () => {
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, 'false');
+    expect(getLogfmtParserSegment()).toBe('');
+
+    localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, 'true');
+    expect(getLogfmtParserSegment()).toBe(LOGFMT_PARSER_SEGMENT);
+  });
+});
+
+describe('setParserEnabled', () => {
+  let jsonParserVariable: CustomConstantVariable;
+  let logfmtParserVariable: CustomConstantVariable;
+  let clearParserDependentFilters: jest.Mock;
+  let runQueries: jest.Mock;
+
+  const sceneRef = {} as SceneObject;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+
+    jsonParserVariable = new CustomConstantVariable({ name: VAR_JSON_PARSER });
+    logfmtParserVariable = new CustomConstantVariable({ name: VAR_LOGFMT_PARSER });
+    clearParserDependentFilters = jest.fn();
+    runQueries = jest.fn();
+
+    jest.mocked(sceneGraph.lookupVariable).mockImplementation((name: string) => {
+      if (name === VAR_JSON_PARSER) {
+        return jsonParserVariable;
+      }
+      if (name === VAR_LOGFMT_PARSER) {
+        return logfmtParserVariable;
+      }
+      return null;
+    });
+
+    jest.mocked(sceneGraph.getAncestor).mockReturnValue({ clearParserDependentFilters } as any);
+
+    const serviceScene = {} as SceneObject;
+    const queryRunner = { runQueries } as unknown as SceneObject;
+    jest
+      .mocked(sceneGraph.findDescendents)
+      .mockReturnValueOnce([serviceScene] as any)
+      .mockReturnValueOnce([queryRunner] as any);
+  });
+
+  test('persists the enabled value to local storage', () => {
+    setParserEnabled(true, sceneRef);
+    expect(localStorage.getItem(PARSER_ENABLED_LOCALSTORAGE_KEY)).toBe('true');
+
+    setParserEnabled(false, sceneRef);
+    expect(localStorage.getItem(PARSER_ENABLED_LOCALSTORAGE_KEY)).toBe('false');
+  });
+
+  test('updates the parser variables with the enabled segments', () => {
+    setParserEnabled(true, sceneRef);
+
+    expect(jsonParserVariable.state.value).toBe(JSON_PARSER_SEGMENT);
+    expect(jsonParserVariable.state.text).toBe(JSON_PARSER_SEGMENT);
+    expect(jsonParserVariable.state.options).toEqual([{ label: JSON_PARSER_SEGMENT, value: JSON_PARSER_SEGMENT }]);
+
+    expect(logfmtParserVariable.state.value).toBe(LOGFMT_PARSER_SEGMENT);
+    expect(logfmtParserVariable.state.text).toBe(LOGFMT_PARSER_SEGMENT);
+    expect(logfmtParserVariable.state.options).toEqual([{ label: LOGFMT_PARSER_SEGMENT, value: LOGFMT_PARSER_SEGMENT }]);
+  });
+
+  test('clears the parser variables with empty segments when disabled', () => {
+    setParserEnabled(false, sceneRef);
+
+    expect(jsonParserVariable.state.value).toBe('');
+    expect(jsonParserVariable.state.options).toEqual([{ label: '', value: '' }]);
+    expect(logfmtParserVariable.state.value).toBe('');
+    expect(logfmtParserVariable.state.options).toEqual([{ label: '', value: '' }]);
+  });
+
+  test('clears parser-dependent filters only when disabling', () => {
+    setParserEnabled(true, sceneRef);
+    expect(clearParserDependentFilters).not.toHaveBeenCalled();
+
+    setParserEnabled(false, sceneRef);
+    expect(clearParserDependentFilters).toHaveBeenCalledTimes(1);
+  });
+
+  test('re-runs parser-dependent queries on the service scene', () => {
+    setParserEnabled(true, sceneRef);
+    expect(runQueries).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not throw when no service scene is found', () => {
+    jest.mocked(sceneGraph.findDescendents).mockReset();
+    jest.mocked(sceneGraph.findDescendents).mockReturnValue([] as any);
+
+    expect(() => setParserEnabled(true, sceneRef)).not.toThrow();
+    expect(runQueries).not.toHaveBeenCalled();
+  });
+
+  test('does not touch variables that are not CustomConstantVariable instances', () => {
+    jest.mocked(sceneGraph.lookupVariable).mockReturnValue({ setState: jest.fn() } as unknown as ReturnType<
+      typeof sceneGraph.lookupVariable
+    >);
+
+    expect(() => setParserEnabled(true, sceneRef)).not.toThrow();
+  });
+});

--- a/src/services/parserToggle.ts
+++ b/src/services/parserToggle.ts
@@ -1,0 +1,28 @@
+import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT } from './variables';
+
+// Whether LogQL parsers (`| json ... | logfmt | drop __error__, __error_details__`) are appended to
+// queries. Persisted in local storage so the choice is remembered across sessions. Defaults to `true`
+// to preserve the previous (always-on) behavior.
+export const PARSER_ENABLED_LOCALSTORAGE_KEY = `grafana.explore.logs.parserEnabled`;
+
+export function getParserEnabled(): boolean {
+  const stored = localStorage.getItem(PARSER_ENABLED_LOCALSTORAGE_KEY);
+  if (stored === null) {
+    return true;
+  }
+  return !(stored === '' || stored === 'false');
+}
+
+export function setParserEnabled(enabled: boolean): void {
+  localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, enabled.toString());
+}
+
+/** Value of the `${jsonParser}` variable based on whether parsers are enabled. */
+export function getJsonParserSegment(enabled: boolean = getParserEnabled()): string {
+  return enabled ? JSON_PARSER_SEGMENT : '';
+}
+
+/** Value of the `${logfmtParser}` variable based on whether parsers are enabled. */
+export function getLogfmtParserSegment(enabled: boolean = getParserEnabled()): string {
+  return enabled ? LOGFMT_PARSER_SEGMENT : '';
+}

--- a/src/services/parserToggle.ts
+++ b/src/services/parserToggle.ts
@@ -1,4 +1,8 @@
-import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT } from './variables';
+import { sceneGraph, SceneQueryRunner, type SceneObject } from '@grafana/scenes';
+
+import { CustomConstantVariable } from './CustomConstantVariable';
+import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
+import { IndexScene } from 'Components/IndexScene/IndexScene';
 
 // Whether LogQL parsers (`| json ... | logfmt | drop __error__, __error_details__`) are appended to
 // queries. Persisted in local storage so the choice is remembered across sessions. Defaults to `true`
@@ -13,8 +17,33 @@ export function getParserEnabled(): boolean {
   return !(stored === '' || stored === 'false');
 }
 
-export function setParserEnabled(enabled: boolean): void {
+export function setParserEnabled(enabled: boolean, sceneRef: SceneObject): void {
   localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, enabled.toString());
+  
+  const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, sceneRef);
+  const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, sceneRef);
+  if (jsonParserVariable instanceof CustomConstantVariable) {
+    const segment = getJsonParserSegment(enabled);
+    jsonParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+  }
+  if (logfmtParserVariable instanceof CustomConstantVariable) {
+    const segment = getLogfmtParserSegment(enabled);
+    logfmtParserVariable.setState({ options: [{ label: segment, value: segment }], text: segment, value: segment });
+  }
+
+  const indexScene = sceneGraph.getAncestor(sceneRef, IndexScene);
+
+  // Parsed-field, JSON-path and line-format filters require a parser, so remove them when disabling
+  // to avoid sending invalid queries.
+  if (!enabled) {
+    indexScene.clearParserDependentFilters();
+  }
+
+  // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
+  // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
+  sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
+    queryRunner.runQueries();
+  });
 }
 
 /** Value of the `${jsonParser}` variable based on whether parsers are enabled. */

--- a/src/services/parserToggle.ts
+++ b/src/services/parserToggle.ts
@@ -3,6 +3,7 @@ import { sceneGraph, SceneQueryRunner, type SceneObject } from '@grafana/scenes'
 import { CustomConstantVariable } from './CustomConstantVariable';
 import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
+import { ServiceScene } from 'Components/ServiceScene/ServiceScene';
 
 // Whether LogQL parsers (`| json ... | logfmt | drop __error__, __error_details__`) are appended to
 // queries. Persisted in local storage so the choice is remembered across sessions. Defaults to `true`
@@ -19,7 +20,7 @@ export function getParserEnabled(): boolean {
 
 export function setParserEnabled(enabled: boolean, sceneRef: SceneObject): void {
   localStorage.setItem(PARSER_ENABLED_LOCALSTORAGE_KEY, enabled.toString());
-  
+
   const jsonParserVariable = sceneGraph.lookupVariable(VAR_JSON_PARSER, sceneRef);
   const logfmtParserVariable = sceneGraph.lookupVariable(VAR_LOGFMT_PARSER, sceneRef);
   if (jsonParserVariable instanceof CustomConstantVariable) {
@@ -39,11 +40,13 @@ export function setParserEnabled(enabled: boolean, sceneRef: SceneObject): void 
     indexScene.clearParserDependentFilters();
   }
 
-  // Re-run every query under the index scene so the new parser setting is applied immediately. Queries
-  // built from a fixed expression (e.g. breakdown panels) are re-evaluated against the gate when rebuilt.
-  sceneGraph.findDescendents(indexScene, SceneQueryRunner).forEach((queryRunner) => {
-    queryRunner.runQueries();
-  });
+  // Re-run the parser-dependent queries so the new setting is applied immediately.
+  const serviceScene = sceneGraph.findDescendents(indexScene, ServiceScene)[0];
+  if (serviceScene) {
+    sceneGraph.findDescendents(serviceScene, SceneQueryRunner).forEach((queryRunner) => {
+      queryRunner.runQueries();
+    });
+  }
 }
 
 /** Value of the `${jsonParser}` variable based on whether parsers are enabled. */

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -1,0 +1,14 @@
+import { LoadingState } from '@grafana/data';
+import { sceneGraph, SceneObject, SceneQueryRunner } from '@grafana/scenes';
+
+export function cancelInFlightQueries(sceneRef: SceneObject) {
+  const queryRunners = sceneGraph.findDescendents(sceneRef, SceneQueryRunner);
+  for (const queryRunner of queryRunners) {
+    if (
+      queryRunner.state.data?.state === LoadingState.Loading ||
+      queryRunner.state.data?.state === LoadingState.Streaming
+    ) {
+      queryRunner.cancelQuery();
+    }
+  }
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -536,6 +536,19 @@ export function setFieldsPanelTypes(panelTypes: FieldsPanelsType) {
   localStorage.setItem(FIELDS_PANEL_TYPES, panelTypes);
 }
 
+const LABELS_PANEL_TYPES = `${pluginJson.id}.labelsBreakdown.labelsPanelType`;
+export function getLabelsPanelType(): FieldsPanelsType | null {
+  const stored = localStorage.getItem(LABELS_PANEL_TYPES);
+  if (stored === 'text' || stored === 'timeseries') {
+    return stored;
+  }
+  return null;
+}
+
+export function setLabelsPanelType(panelType: FieldsPanelsType) {
+  localStorage.setItem(LABELS_PANEL_TYPES, panelType);
+}
+
 // Collapsible filters
 const COLLAPSIBLE_FILTERS_KEY = `${pluginJson.id}.filters.collapsed`;
 export function getCollapsibleFiltersState(): boolean {

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -59,7 +59,6 @@ export const testIds = {
     addNewLabelTab: 'data-testid Tab Add label tab',
     aggregatedMetricsMenu: 'data-testid aggregated-metrics-menu',
     aggregatedMetricsToggle: 'data-testid aggregated-metrics-toggle',
-    parserToggle: 'data-testid parser-toggle',
     header: {
       showLogsButton: 'data-testid Show logs header',
     },

--- a/src/services/testIds.ts
+++ b/src/services/testIds.ts
@@ -59,6 +59,7 @@ export const testIds = {
     addNewLabelTab: 'data-testid Tab Add label tab',
     aggregatedMetricsMenu: 'data-testid aggregated-metrics-menu',
     aggregatedMetricsToggle: 'data-testid aggregated-metrics-toggle',
+    parserToggle: 'data-testid parser-toggle',
     header: {
       showLogsButton: 'data-testid Show logs header',
     },

--- a/src/services/variableGetters.test.ts
+++ b/src/services/variableGetters.test.ts
@@ -1,0 +1,122 @@
+import { getParserEnabled } from './parserToggle';
+import { getLogsStreamSelector } from './variableGetters';
+import {
+  LOGS_FORMAT_EXPR,
+  LogsQueryOptions,
+  VAR_FIELDS_EXPR,
+  VAR_JSON_FIELDS_EXPR,
+  VAR_LABELS_EXPR,
+  VAR_LEVELS_EXPR,
+  VAR_LINE_FILTERS_EXPR,
+  VAR_METADATA_EXPR,
+  VAR_PATTERNS_EXPR,
+} from './variables';
+
+jest.mock('./parserToggle');
+
+const getParserEnabledMock = jest.mocked(getParserEnabled);
+
+describe('getLogsStreamSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getParserEnabledMock.mockReturnValue(true);
+  });
+
+  describe('when parsers are enabled', () => {
+    test('builds the structuredMetadata selector without a parser stage', () => {
+      const expr = getLogsStreamSelector({ parser: 'structuredMetadata' });
+
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}}  ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR}  ${VAR_FIELDS_EXPR}`
+      );
+      expect(expr).not.toContain('| json');
+      expect(expr).not.toContain('| logfmt');
+    });
+
+    test('builds the json selector with the json parser stage', () => {
+      const expr = getLogsStreamSelector({ parser: 'json' });
+
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}}  ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} | json  ${VAR_JSON_FIELDS_EXPR} | drop __error__, __error_details__  ${VAR_FIELDS_EXPR}`
+      );
+      expect(expr).toContain('| json');
+      expect(expr).toContain('| drop __error__, __error_details__');
+    });
+
+    test('builds the logfmt selector with the logfmt format stage', () => {
+      const expr = getLogsStreamSelector({ parser: 'logfmt' });
+
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}}  ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${LOGS_FORMAT_EXPR}  ${VAR_FIELDS_EXPR}`
+      );
+      expect(expr).toContain(LOGS_FORMAT_EXPR);
+    });
+
+    test('falls back to the mixed json + logfmt selector for an unknown parser', () => {
+      const expr = getLogsStreamSelector({ parser: undefined });
+
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}}  ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} | json  ${VAR_JSON_FIELDS_EXPR} | logfmt | drop __error__, __error_details__   ${VAR_FIELDS_EXPR}`
+      );
+      expect(expr).toContain('| json');
+      expect(expr).toContain('| logfmt');
+    });
+
+    test('interpolates the additional expression fragments into the selector', () => {
+      const options: LogsQueryOptions = {
+        fieldExpressionToAdd: '| foo="bar"',
+        jsonParserPropToAdd: 'level="error"',
+        labelExpressionToAdd: ', service="api"',
+        parser: 'json',
+        structuredMetadataToAdd: '| trace_id="abc"',
+      };
+
+      const expr = getLogsStreamSelector(options);
+
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}, service="api"} | trace_id="abc" ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} | json level="error" ${VAR_JSON_FIELDS_EXPR} | drop __error__, __error_details__ | foo="bar" ${VAR_FIELDS_EXPR}`
+      );
+    });
+
+    test('defaults all optional fragments to empty strings', () => {
+      const expr = getLogsStreamSelector({});
+
+      // No parser supplied -> default branch with the mixed json + logfmt stage.
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}}  ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} | json  ${VAR_JSON_FIELDS_EXPR} | logfmt | drop __error__, __error_details__   ${VAR_FIELDS_EXPR}`
+      );
+    });
+  });
+
+  describe('when parsers are disabled', () => {
+    beforeEach(() => {
+      getParserEnabledMock.mockReturnValue(false);
+    });
+
+    test.each(['json', 'logfmt', undefined] as const)(
+      'drops the parser stage and uses the structuredMetadata selector for parser "%s"',
+      (parser) => {
+        const expr = getLogsStreamSelector({ parser });
+
+        expect(expr).toBe(
+          `{${VAR_LABELS_EXPR}}  ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR}  ${VAR_FIELDS_EXPR}`
+        );
+        expect(expr).not.toContain('| json');
+        expect(expr).not.toContain('| logfmt');
+      }
+    );
+
+    test('still interpolates label and field fragments while omitting the parser stage', () => {
+      const expr = getLogsStreamSelector({
+        fieldExpressionToAdd: '| foo="bar"',
+        labelExpressionToAdd: ', service="api"',
+        parser: 'json',
+        structuredMetadataToAdd: '| trace_id="abc"',
+      });
+
+      expect(expr).toBe(
+        `{${VAR_LABELS_EXPR}, service="api"} | trace_id="abc" ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} | foo="bar" ${VAR_FIELDS_EXPR}`
+      );
+    });
+  });
+});

--- a/src/services/variableGetters.ts
+++ b/src/services/variableGetters.ts
@@ -13,6 +13,7 @@ import { CustomConstantVariable } from './CustomConstantVariable';
 import { isFilterMetadata } from './filters';
 import { logger } from './logger';
 import { narrowFieldValue, NarrowingError } from './narrowing';
+import { getParserEnabled } from './parserToggle';
 import {
   AdHocFieldValue,
   FieldValue,
@@ -56,7 +57,11 @@ export function getLogsStreamSelector(options: LogsQueryOptions) {
     structuredMetadataToAdd = '',
   } = options;
 
-  switch (parser) {
+  // When parsers are disabled via the header toggle, drop the `| json`/`| logfmt` stages entirely by
+  // falling back to the structured-metadata-only selector.
+  const effectiveParser = getParserEnabled() ? parser : 'structuredMetadata';
+
+  switch (effectiveParser) {
     case 'structuredMetadata':
       return `{${VAR_LABELS_EXPR}${labelExpressionToAdd}} ${structuredMetadataToAdd} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${fieldExpressionToAdd} ${VAR_FIELDS_EXPR}`;
     case 'json':

--- a/src/services/variables.ts
+++ b/src/services/variables.ts
@@ -63,6 +63,21 @@ export const VAR_JSON_FIELDS_EXPR = '${jsonFields}';
 export const VAR_LINE_FORMAT = 'lineFormat';
 export const VAR_LINE_FORMAT_EXPR = '${lineFormat}';
 
+// Parser pipeline segments, toggled on/off globally via the header "Parsers" switch.
+// They are kept as two separate variables (rather than one) so the `${jsonFields}` variable
+// stays at the top level of the query expression and resolves in a single interpolation pass.
+export const VAR_JSON_PARSER = 'jsonParser';
+export const VAR_JSON_PARSER_EXPR = '${jsonParser}';
+export const VAR_LOGFMT_PARSER = 'logfmtParser';
+export const VAR_LOGFMT_PARSER_EXPR = '${logfmtParser}';
+// Value of VAR_JSON_PARSER / VAR_LOGFMT_PARSER when parsers are enabled (the default).
+export const JSON_PARSER_SEGMENT = `| json`;
+export const LOGFMT_PARSER_SEGMENT = `| logfmt | drop __error__, __error_details__`;
+// The mixed (json + logfmt) parser pipeline expressed with the toggleable parser variables. Used in
+// every query that applies the mixed format so the header "Parsers" toggle removes parsing everywhere.
+// `${jsonFields}` stays at the top level so it resolves in a single interpolation pass.
+export const PARSER_EXPR = `${VAR_JSON_PARSER_EXPR} ${VAR_JSON_FIELDS_EXPR} ${VAR_LOGFMT_PARSER_EXPR}`;
+
 export const DETECTED_FIELDS_MIXED_FORMAT_EXPR_NO_JSON_FIELDS = `| json | logfmt | drop __error__, __error_details__`;
 export const DETECTED_FIELDS_MIXED_FORMAT_EXPR = `| json ${VAR_JSON_FIELDS_EXPR} | logfmt | drop __error__, __error_details__`;
 export const MIXED_FORMAT_EXPR = `| json ${VAR_JSON_FIELDS_EXPR} | logfmt | drop __error__, __error_details__`;
@@ -80,13 +95,13 @@ export const VAR_LINE_FILTER_EXPR = '${lineFilterV2}';
 // The new multi value line filter (ad-hoc variable)
 export const VAR_LINE_FILTERS = 'lineFilters';
 export const VAR_LINE_FILTERS_EXPR = '${lineFilters}';
-export const LOG_STREAM_SELECTOR_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} | json ${VAR_JSON_FIELDS_EXPR} | logfmt | drop __error__, __error_details__ ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR}`;
+export const LOG_STREAM_SELECTOR_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${PARSER_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR}`;
 // Same as the LOG_STREAM_SELECTOR_EXPR, but without the fields as they will need to be built manually to exclude the current filter value
-export const DETECTED_FIELD_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${MIXED_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
-export const DETECTED_FIELD_AND_METADATA_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${PENDING_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${DETECTED_FIELDS_MIXED_FORMAT_EXPR} ${PENDING_FIELDS_EXPR}`;
-export const DETECTED_METADATA_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${PENDING_FIELDS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
-export const DETECTED_LEVELS_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${PENDING_FIELDS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR}`;
-export const PATTERNS_SAMPLE_SELECTOR_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LOGS_FORMAT_EXPR}`;
+export const DETECTED_FIELD_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${PARSER_EXPR} ${VAR_FIELDS_EXPR}`;
+export const DETECTED_FIELD_AND_METADATA_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${PENDING_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${PARSER_EXPR} ${PENDING_FIELDS_EXPR}`;
+export const DETECTED_METADATA_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_LEVELS_EXPR} ${PENDING_FIELDS_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${PARSER_EXPR} ${VAR_FIELDS_EXPR}`;
+export const DETECTED_LEVELS_VALUES_EXPR = `{${VAR_LABELS_EXPR}} ${PENDING_FIELDS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${PARSER_EXPR} ${VAR_FIELDS_EXPR}`;
+export const PATTERNS_SAMPLE_SELECTOR_EXPR = `{${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${PARSER_EXPR}`;
 export const PRETTY_LOG_STREAM_SELECTOR_EXPR = `${VAR_LABELS_EXPR} ${VAR_LEVELS_EXPR} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR}`;
 export const EXPLORATION_DS = { uid: VAR_DATASOURCE_EXPR };
 export const ALL_VARIABLE_VALUE = '$__all';


### PR DESCRIPTION
This PR adds the possibility of disabling parsed fields from the Fields breakdown. When the setting is off, parsers are not applied to any of the generated queries by Logs Drilldown.

Additionally, the Fields controls have been refactored to be more clear, and tooltips have been added and updated to help users understand UI elements and the current state of the app.

Lastly, fields and labels are now sorted alphabetically, addressing two things: 1) coherent order of the values (so it no longer feels arbitrary and challenging to navigate) and 2) fields with crazy high cardinality are no longer pushed to the top.

<img width="265" height="93" alt="Field" src="https://github.com/user-attachments/assets/5b2e3092-179e-45aa-981f-01d377d27838" />

<img width="1299" height="443" alt="labels" src="https://github.com/user-attachments/assets/5b311ef3-e25c-43ec-a78f-504394b5337f" />

<img width="1232" height="464" alt="imagen" src="https://github.com/user-attachments/assets/b55aa3a0-a072-4595-b5da-959e24dcd294" />

<img width="1251" height="707" alt="Empty" src="https://github.com/user-attachments/assets/f665a6d2-d41c-4f13-b02f-c4ec5f09fe54" />

### Demo

https://github.com/user-attachments/assets/9a71aff3-60f1-46a4-9911-de6a9c5306d1

Closes https://github.com/grafana/logs-drilldown/issues/1497
Closes https://github.com/grafana/logs-drilldown/issues/1523
Closes https://github.com/grafana/logs-drilldown/issues/1520
