### PR TITLE
chore: add warnOnConflicts to i18next config

### DIFF
--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     indentation: 2,
     functions: ['t', '*.t'],
     transComponents: ['Trans'],
+    warnOnConflicts: 'error',
   },
 });


### PR DESCRIPTION
## Summary
- Add `warnOnConflicts: 'error'` to `i18next.config.ts` to align with core Grafana's config
- This will catch translation key conflicts during extraction rather than silently overwriting

## Test plan
- [x] `pnpm i18n-extract-check` passes with no changes