### PR TITLE
fix(generator): add otel address

### DIFF
--- a/config/tempo.yaml
+++ b/config/tempo.yaml
@@ -12,9 +12,13 @@ distributor:
     zipkin:
     otlp:
       protocols:
+        # Newer OTel Collector versions (bundled in Tempo 2.10.x) default the OTLP receiver to
+        # localhost, which is unreachable from other containers (e.g. the generator). Bind to
+        # 0.0.0.0 so cross-container trace push works.
         http:
+          endpoint: 0.0.0.0:4318
         grpc:
-    opencensus:
+          endpoint: 0.0.0.0:4317
 
 compactor:
   compaction:


### PR DESCRIPTION
## Summary 📝

- Fix the local dev trace pipeline: Tempo's OTLP receiver in `config/tempo.yaml` had no explicit `endpoint`, so with the newer OTel Collector bundled in Tempo 2.10.x it defaulted to `localhost` — unreachable from the `generator` container. Traces never reached Tempo and Traces Drilldown showed "No data". Bind OTLP gRPC/HTTP explicitly to `0.0.0.0:4317` / `0.0.0.0:4318`.
- Remove the deprecated `opencensus` receiver from the Tempo distributor config.

## Test 🧪

- [x] Restarted Tempo and confirmed the OTLP gRPC server now listens on `[::]:4317` (previously `127.0.0.1:4317`).
- [x] `tempo_distributor_spans_received_total` went from `0` to >27k after the change — Tempo is ingesting spans again.
- [x] `generator` logs no longer emit `dial tcp …:4317: connect: connection refused`; traces render in Traces Drilldown.

