### PR TITLE
fix(parsePrometheusDuration): fix regexp builder.

### DIFF
--- a/src/services/parsePrometheusDuration.ts
+++ b/src/services/parsePrometheusDuration.ts
@@ -7,7 +7,7 @@ enum TimeOptions {
   years = 'y',
 }
 
-const DURATION_REGEXP = new RegExp('^(?:(?<value>\\d+)(?<type>ms|s|m|h|d|w|y))|0$');
+const DURATION_REGEXP = /^(?:(?<value>\d+)(?<type>ms|s|m|h|d|w|y))|0$/;
 const INVALID_FORMAT = new Error(
   `Must be of format "(number)(unit)", for example "1m", or just "0". Available units: ${Object.values(
     TimeOptions

--- a/src/services/parsePrometheusDuration.ts
+++ b/src/services/parsePrometheusDuration.ts
@@ -7,7 +7,7 @@ enum TimeOptions {
   years = 'y',
 }
 
-const DURATION_REGEXP = new RegExp(/^(?:(?<value>\d+)(?<type>ms|s|m|h|d|w|y))|0$/);
+const DURATION_REGEXP = new RegExp('^(?:(?<value>\\d+)(?<type>ms|s|m|h|d|w|y))|0$');
 const INVALID_FORMAT = new Error(
   `Must be of format "(number)(unit)", for example "1m", or just "0". Available units: ${Object.values(
     TimeOptions


### PR DESCRIPTION
While working on something else I noticed an error in the console.

<img width="966" height="231" alt="imagen" src="https://github.com/user-attachments/assets/9ca8fa7b-c514-4d1a-8c56-856a9a7c8bd0" />

Investigating, I found that the group names were being lost at some point.

Regexes:

<img width="743" height="80" alt="Regexes" src="https://github.com/user-attachments/assets/30a03db6-f47f-4e01-b27f-1f3744a80cb0" />

Output:

<img width="390" height="63" alt="Result" src="https://github.com/user-attachments/assets/f4b108f7-be57-436e-9880-5879d12aaeb7" />

Causing errors when trying to parse durations. I'm still not sure if this is a result from minification/compilation.