### PR TITLE
fix(levels): use neutral blue for info level instead of green

### DIFF
--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -53,8 +53,11 @@ export const logsLabelLevelsMatches: Record<string, RegExp> = {
 };
 
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
+  // Info is a neutral level, not a success signal, so use a neutral blue rather
+  // than green. Kept brighter than debug's semi-dark-blue so the two remain
+  // distinguishable within the neutral-blue family.
   overrides.matchFieldsWithNameByRegex(INFO_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({
-    fixedColor: 'semi-dark-green',
+    fixedColor: 'blue',
     mode: 'fixed',
   });
   overrides.matchFieldsWithNameByRegex(DEBUG_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({


### PR DESCRIPTION
## What

Recolor the **info** log level from green (`semi-dark-green`) to a neutral **blue**.

## Why

Green reads as "success/health". `info` is a *neutral* severity — the most common, baseline log level — not a positive signal. Coloring the bulk of normal traffic green is misleading and, in a volume panel, visually implies "all good" even when the interesting signal is elsewhere.

Proposed semantic:

- 🔵 **blue** → neutral (info, and by extension status-unset)
- 🟢 **green** → reserved for a genuine success signal (currently unused for levels)
- 🟠 orange → warning, 🔴 red → error, 🟣 purple → critical (unchanged)

This is the logs half of a cross-app color-semantics proposal; the traces-drilldown counterpart recolors the neutral `rate` series off green → blue in the same spirit (grafana/traces-drilldown#814).

## Changes

- `services/panel.ts` — `setLevelColorOverrides`: `info` `semi-dark-green` → `blue`

`info` uses plain `blue` while `debug` keeps `semi-dark-blue`, so the two neutral levels stay in a blue family but remain distinguishable. `unknown`/`logs` is left as `darkgray` (also neutral, but intentionally a distinct "no level" gray) — happy to revisit if reviewers want it folded into the blue family too.

## Open question

This deviates from Grafana core's `LogLevelColor`, where `info` is green. Filing as a **draft** to align on whether we want Logs Drilldown to lead on this neutral-vs-success semantic or stay consistent with core. If we'd rather change it centrally, this can move upstream instead.

## Validation

`pnpm typecheck` clean; `src/services/panel.test.ts` passes (asserts on matchers, not color values, so unaffected).
