### PR TITLE
fix(levels): use neutral blue for info level instead of green

### DIFF
--- a/src/services/highlight.tsx
+++ b/src/services/highlight.tsx
@@ -171,7 +171,7 @@ export const getLogsHighlightStyles = (theme: GrafanaTheme2) => {
     critical: '#B877D9',
     debug: '#6E9FFF',
     error: theme.colors.error.text,
-    info: '#6CCF8E',
+    info: '#6E9FFF',
     metadata: theme.colors.text.primary,
     parsedField: theme.colors.text.primary,
     trace: '#6ed0e0',

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -54,7 +54,7 @@ export const logsLabelLevelsMatches: Record<string, RegExp> = {
 
 export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<FieldConfig>) {
   overrides.matchFieldsWithNameByRegex(INFO_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({
-    fixedColor: 'semi-dark-green',
+    fixedColor: 'semi-dark-blue',
     mode: 'fixed',
   });
   overrides.matchFieldsWithNameByRegex(DEBUG_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({


### PR DESCRIPTION
## What

Recolor the **info** log level from green (`semi-dark-green`) to a neutral **blue**.

## Why

Green reads as "success/health". `info` is a *neutral* severity — the most common, baseline log level — not a positive signal. Coloring the bulk of normal traffic green is misleading and, in a volume panel, visually implies "all good" even when the interesting signal is elsewhere.

Proposed semantic:

- 🔵 **blue** → neutral (info, and by extension status-unset)
- 🟢 **green** → reserved for a genuine success signal (currently unused for levels)
- 🟠 orange → warning, 🔴 red → error, 🟣 purple → critical (unchanged)

This is the logs half of a cross-app color-semantics proposal; the traces-drilldown counterpart recolors the neutral `rate` series off green → blue in the same spirit (grafana/traces-drilldown#814).

Core PR: https://github.com/grafana/grafana/pull/128119