### PR TITLE
feat(store): refactor expanded/collapsed logs storage

### DIFF
--- a/src/services/store.test.ts
+++ b/src/services/store.test.ts
@@ -1,11 +1,22 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
+import { SceneObject } from '@grafana/scenes';
 
-import { getDefaultDatasourceFromDatasourceSrv } from './store';
+import pluginJson from '../plugin.json';
+import { isEmbeddedLogs } from './extensions/embedding';
+import { getDefaultDatasourceFromDatasourceSrv, getExpandedLogsView } from './store';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: jest.fn(),
+}));
+
+jest.mock('./extensions/embedding', () => ({
+  isEmbeddedLogs: jest.fn(),
+}));
+
+jest.mock('./logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
 }));
 
 function makeDs(overrides: Partial<DataSourceInstanceSettings>): DataSourceInstanceSettings {
@@ -93,5 +104,58 @@ describe('getDefaultDatasourceFromDatasourceSrv', () => {
     } as any);
 
     expect(getDefaultDatasourceFromDatasourceSrv()).toBe('grafanacloud-mystack-logs');
+  });
+});
+
+describe('getExpandedLogsView', () => {
+  // isEmbeddedLogs walks the scene graph, so mock its result. Everything else uses real localStorage (jsdom).
+  const sceneRef = {} as SceneObject;
+  const NON_EMBEDDED_KEY = `${pluginJson.id}.logs.expanded`;
+  const EMBEDDED_KEY = `${pluginJson.id}.logs.embedded.expanded`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('when not embedded', () => {
+    beforeEach(() => jest.mocked(isEmbeddedLogs).mockReturnValue(false));
+
+    it('returns false when nothing is stored', () => {
+      expect(getExpandedLogsView(sceneRef)).toBe(false);
+    });
+
+    it('returns true when stored value is "true"', () => {
+      localStorage.setItem(NON_EMBEDDED_KEY, 'true');
+      expect(getExpandedLogsView(sceneRef)).toBe(true);
+    });
+
+    it('returns false when stored value is "false"', () => {
+      localStorage.setItem(NON_EMBEDDED_KEY, 'false');
+      expect(getExpandedLogsView(sceneRef)).toBe(false);
+    });
+
+    it('returns false and logs when the stored value is not valid JSON', () => {
+      localStorage.setItem(NON_EMBEDDED_KEY, 'not-json');
+      expect(getExpandedLogsView(sceneRef)).toBe(false);
+    });
+  });
+
+  describe('when embedded', () => {
+    beforeEach(() => jest.mocked(isEmbeddedLogs).mockReturnValue(true));
+
+    it('defaults to true when nothing is stored', () => {
+      expect(getExpandedLogsView(sceneRef)).toBe(true);
+    });
+
+    it('respects a stored "false" preference over the embedded default', () => {
+      localStorage.setItem(EMBEDDED_KEY, 'false');
+      expect(getExpandedLogsView(sceneRef)).toBe(false);
+    });
+
+    it('respects a stored "true" preference over the embedded default', () => {
+      localStorage.setItem(EMBEDDED_KEY, 'true');
+      expect(getExpandedLogsView(sceneRef)).toBe(true);
+    });
   });
 });

--- a/src/services/store.test.ts
+++ b/src/services/store.test.ts
@@ -135,7 +135,7 @@ describe('getExpandedLogsView', () => {
       expect(getExpandedLogsView(sceneRef)).toBe(false);
     });
 
-    it('returns false and logs when the stored value is not valid JSON', () => {
+    it('returns false the stored value is not valid JSON', () => {
       localStorage.setItem(NON_EMBEDDED_KEY, 'not-json');
       expect(getExpandedLogsView(sceneRef)).toBe(false);
     });

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -7,6 +7,7 @@ import { CollapsablePanelText, TimeSeriesPanelType } from '../Components/Panels/
 import { FieldsPanelsType } from '../Components/ServiceScene/Breakdowns/FieldsAggregatedBreakdownScene';
 import { SortDirection } from '../Components/ServiceScene/Breakdowns/SortByScene';
 import pluginJson from '../plugin.json';
+import { isEmbeddedLogs } from './extensions/embedding';
 import { escapePrimaryLabel } from './extensions/links';
 import { isDedupStrategy } from './guards';
 import { logger } from './logger';
@@ -570,9 +571,14 @@ export function setTableLogLine(value: LogLineState) {
 
 // Logs view size
 export function getExpandedLogsView(sceneRef: SceneObject) {
-  const PREFIX = getExplorationPrefix(sceneRef);
+  const embedded = isEmbeddedLogs(sceneRef);
+  const stored = localStorage.getItem(`${pluginJson.id}.logs${embedded ? '.embedded' : ''}.expanded`);
+  // When embedded, default to an expanded logs view unless the user has set a preference.
+  if (stored === null && embedded) {
+    return true;
+  }
   try {
-    return Boolean(JSON.parse(String(localStorage.getItem(`${pluginJson.id}.${PREFIX}.logs.expanded`))));
+    return Boolean(JSON.parse(String(stored)));
   } catch (e) {
     logger.error(e);
   }
@@ -580,6 +586,6 @@ export function getExpandedLogsView(sceneRef: SceneObject) {
 }
 
 export function setExpandedLogsView(sceneRef: SceneObject, expanded: boolean) {
-  const PREFIX = getExplorationPrefix(sceneRef);
-  localStorage.setItem(`${pluginJson.id}.${PREFIX}.logs.expanded`, JSON.stringify(expanded));
+  const embedded = isEmbeddedLogs(sceneRef);
+  localStorage.setItem(`${pluginJson.id}.logs${embedded ? '.embedded' : ''}.expanded`, JSON.stringify(expanded));
 }


### PR DESCRIPTION
This PR fixes two things:

1. When logs are embeded, default to the expanded view. Otherwise it results on a very tiny Logs Drilldown that might confuse users and it's not trivial to fix.
2. Remove the exploration prefix from the stored expanded/collapsed preferences. Otherwise users need to set this property every time they browse a given set of logs.

Can be tested combining the [default URL](http://localhost:3000/a/grafana-lokiexplore-app/explore) with the [embedded URL](http://localhost:3000/a/grafana-lokiexplore-app/embed).