### PR TITLE
feat(DefaultColumns): add support for stored multiple values of the same label as a regex

### DIFF
--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 
 import { css } from '@emotion/css';
 
-import { LogsDrilldownDefaultColumnsLogsDefaultColumnsRecord } from '@grafana/api-clients/rtkq/logsdrilldown/v1beta1';
 import { AppPluginMeta, LoadingState, PanelData } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
@@ -40,7 +39,7 @@ import { getMetadataService } from '../../services/metadata';
 import { migrateLineFilterV1 } from '../../services/migrations';
 import { narrowPageOrValueSlug, narrowPageSlug, narrowValueSlug } from '../../services/narrowing';
 import { navigateToDrilldownPage, navigateToIndex, navigateToValueBreakdown } from '../../services/navigate';
-import { isOperatorInclusive, isOperatorRegex } from '../../services/operatorHelpers';
+import { isOperatorInclusive } from '../../services/operatorHelpers';
 import { getDrilldownSlug, getDrilldownValueSlug, getRouteParams } from '../../services/routing';
 import { findObjectOfType } from '../../services/scenes';
 import {
@@ -85,12 +84,10 @@ import { getLogOption, getMaxLines } from 'services/store';
 import {
   DETECTED_FIELD_VALUES_EXPR,
   EMPTY_VARIABLE_VALUE,
-  isAdHocFilterValueUserInput,
   LEVEL_VARIABLE_VALUE,
   LOG_STREAM_SELECTOR_EXPR,
   SERVICE_NAME,
   SERVICE_UI_LABEL,
-  stripAdHocFilterUserInputPrefix,
   VAR_DATASOURCE,
   VAR_FIELDS,
   VAR_LABELS,
@@ -315,6 +312,9 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
 
   private setDefaultColumns() {
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
+    if (!indexScene.state.defaultColumnsRecords) {
+      return;
+    }
     this.setState({
       backendDisplayedFields: getDefaultColumnsForActiveFilters(indexScene.state.defaultColumnsRecords, indexScene),
     });

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -40,7 +40,7 @@ import { getMetadataService } from '../../services/metadata';
 import { migrateLineFilterV1 } from '../../services/migrations';
 import { narrowPageOrValueSlug, narrowPageSlug, narrowValueSlug } from '../../services/narrowing';
 import { navigateToDrilldownPage, navigateToIndex, navigateToValueBreakdown } from '../../services/navigate';
-import { isOperatorInclusive } from '../../services/operatorHelpers';
+import { isOperatorInclusive, isOperatorRegex } from '../../services/operatorHelpers';
 import { getDrilldownSlug, getDrilldownValueSlug, getRouteParams } from '../../services/routing';
 import { findObjectOfType } from '../../services/scenes';
 import {
@@ -76,6 +76,7 @@ import {
   CreateAlertData,
   CreateAlertEvent,
 } from 'Components/Panels/PanelMenu';
+import { getDefaultColumnsForActiveFilters } from 'services/defaultColumns';
 import { LokiQueryDirection } from 'services/lokiQuery';
 import { getQueryRunner, getResourceQueryRunner } from 'services/panel';
 import { getPatternsCount } from 'services/patterns';
@@ -84,10 +85,12 @@ import { getLogOption, getMaxLines } from 'services/store';
 import {
   DETECTED_FIELD_VALUES_EXPR,
   EMPTY_VARIABLE_VALUE,
+  isAdHocFilterValueUserInput,
   LEVEL_VARIABLE_VALUE,
   LOG_STREAM_SELECTOR_EXPR,
   SERVICE_NAME,
   SERVICE_UI_LABEL,
+  stripAdHocFilterUserInputPrefix,
   VAR_DATASOURCE,
   VAR_FIELDS,
   VAR_LABELS,
@@ -312,42 +315,8 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
 
   private setDefaultColumns() {
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
-    const records = indexScene.state.defaultColumnsRecords;
-    const labelsVariable = getLabelsVariable(this);
-    const inclusiveFilters = labelsVariable.state.filters.filter((f) => isOperatorInclusive(f.operator));
-    // Remove records that are more specific than our current label set
-    const filteredRecords = records?.filter((f) => f.labels.length <= inclusiveFilters.length);
-
-    // init map
-    const filtersMap = new Set<string>();
-    inclusiveFilters.forEach((f) => filtersMap.add(f.key + f.value));
-
-    // Assign a score to each record
-    const recordsScore: Array<LogsDrilldownDefaultColumnsLogsDefaultColumnsRecord & { score: number }> | undefined =
-      filteredRecords?.map((r) => {
-        const score = r.labels.reduce((accumulator, label) => {
-          const usedInQuery = filtersMap.has(label.key + label.value);
-          if (usedInQuery) {
-            return accumulator + 1;
-          }
-          return accumulator;
-        }, 0);
-        return { ...r, score };
-      });
-
-    let highScore = 0;
-    let highScoreIdx = -1;
-    recordsScore?.forEach((r, idx) => {
-      if (r.score > highScore) {
-        highScore = r.score;
-        highScoreIdx = idx;
-      }
-    });
-
-    const bestMatch = highScoreIdx !== -1 ? recordsScore?.[highScoreIdx] : undefined;
-
     this.setState({
-      backendDisplayedFields: bestMatch?.columns,
+      backendDisplayedFields: getDefaultColumnsForActiveFilters(indexScene.state.defaultColumnsRecords, indexScene),
     });
   }
 

--- a/src/services/defaultColumns.test.ts
+++ b/src/services/defaultColumns.test.ts
@@ -1,0 +1,185 @@
+import { LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords } from '@grafana/api-clients/rtkq/logsdrilldown/v1beta1';
+import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
+
+import { getDefaultColumnsForActiveFilters } from './defaultColumns';
+import { FilterOp } from './filterTypes';
+import { getLabelsVariable } from './variableGetters';
+import { addAdHocFilterUserInputPrefix, VAR_LABELS } from './variables';
+
+jest.mock('./variableGetters', () => ({
+  ...jest.requireActual('./variableGetters'),
+  getLabelsVariable: jest.fn(),
+}));
+
+type Filter = { key: string; operator: string; value: string };
+
+function mockLabelsFilters(filters: Filter[]) {
+  jest.mocked(getLabelsVariable).mockReturnValue(
+    new AdHocFiltersVariable({
+      name: VAR_LABELS,
+      filters,
+    })
+  );
+}
+
+const sceneRef = {} as SceneObject;
+
+describe('getDefaultColumnsForActiveFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when there are no records', () => {
+    mockLabelsFilters([{ key: 'service_name', operator: FilterOp.Equal, value: 'api' }]);
+    expect(getDefaultColumnsForActiveFilters([], sceneRef)).toBeUndefined();
+  });
+
+  it('returns undefined when no record scores above zero', () => {
+    mockLabelsFilters([{ key: 'service_name', operator: FilterOp.Equal, value: 'api' }]);
+    const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+      { columns: ['level', 'msg'], labels: [{ key: 'service_name', value: 'other' }] },
+    ];
+    expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toBeUndefined();
+  });
+
+  it('returns the columns of the matching record', () => {
+    mockLabelsFilters([{ key: 'service_name', operator: FilterOp.Equal, value: 'api' }]);
+    const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+      { columns: ['level', 'msg'], labels: [{ key: 'service_name', value: 'api' }] },
+    ];
+    expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['level', 'msg']);
+  });
+
+  it('picks the record with the highest score', () => {
+    mockLabelsFilters([
+      { key: 'service_name', operator: FilterOp.Equal, value: 'api' },
+      { key: 'namespace', operator: FilterOp.Equal, value: 'prod' },
+    ]);
+    const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+      { columns: ['single'], labels: [{ key: 'service_name', value: 'api' }] },
+      {
+        columns: ['both'],
+        labels: [
+          { key: 'service_name', value: 'api' },
+          { key: 'namespace', value: 'prod' },
+        ],
+      },
+    ];
+    expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['both']);
+  });
+
+  it('ignores records that are more specific than the active filter set', () => {
+    mockLabelsFilters([{ key: 'service_name', operator: FilterOp.Equal, value: 'api' }]);
+    const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+      {
+        columns: ['too-specific'],
+        labels: [
+          { key: 'service_name', value: 'api' },
+          { key: 'namespace', value: 'prod' },
+        ],
+      },
+    ];
+    expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toBeUndefined();
+  });
+
+  it('ignores non-inclusive filters', () => {
+    mockLabelsFilters([{ key: 'service_name', operator: FilterOp.NotEqual, value: 'api' }]);
+    const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+      { columns: ['level'], labels: [{ key: 'service_name', value: 'api' }] },
+    ];
+    expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toBeUndefined();
+  });
+
+  describe('multi-value regex filters', () => {
+    it('expands `key=~__CVΩ__value1|value2` and matches a record with both values', () => {
+      mockLabelsFilters([
+        {
+          key: 'service_name',
+          operator: FilterOp.RegexEqual,
+          value: addAdHocFilterUserInputPrefix('api|web'),
+        },
+      ]);
+      const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+        {
+          columns: ['multi'],
+          labels: [
+            { key: 'service_name', value: 'api' },
+            { key: 'service_name', value: 'web' },
+          ],
+        },
+      ];
+      expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['multi']);
+    });
+
+    it('matches a record referencing a single one of the piped values', () => {
+      mockLabelsFilters([
+        {
+          key: 'service_name',
+          operator: FilterOp.RegexEqual,
+          value: addAdHocFilterUserInputPrefix('api|web'),
+        },
+      ]);
+      const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+        { columns: ['just-web'], labels: [{ key: 'service_name', value: 'web' }] },
+      ];
+      expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['just-web']);
+    });
+
+    it('prefers the record that matches more of the expanded values', () => {
+      mockLabelsFilters([
+        {
+          key: 'service_name',
+          operator: FilterOp.RegexEqual,
+          value: addAdHocFilterUserInputPrefix('api|web|db'),
+        },
+      ]);
+      const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+        { columns: ['one'], labels: [{ key: 'service_name', value: 'api' }] },
+        {
+          columns: ['two'],
+          labels: [
+            { key: 'service_name', value: 'api' },
+            { key: 'service_name', value: 'db' },
+          ],
+        },
+      ];
+      expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['two']);
+    });
+
+    it('expands values when scoring alongside other filters', () => {
+      mockLabelsFilters([
+        {
+          key: 'service_name',
+          operator: FilterOp.RegexEqual,
+          value: addAdHocFilterUserInputPrefix('api|web'),
+        },
+        { key: 'namespace', operator: FilterOp.Equal, value: 'prod' },
+      ]);
+      const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+        {
+          columns: ['match'],
+          labels: [
+            { key: 'service_name', value: 'web' },
+            { key: 'namespace', value: 'prod' },
+          ],
+        },
+      ];
+      expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['match']);
+    });
+
+    it('does not expand a regex filter without the user-input prefix', () => {
+      mockLabelsFilters([{ key: 'service_name', operator: FilterOp.RegexEqual, value: 'api|web' }]);
+      const records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords = [
+        {
+          columns: ['multi'],
+          labels: [
+            { key: 'service_name', value: 'api' },
+            { key: 'service_name', value: 'web' },
+          ],
+        },
+        { columns: ['literal'], labels: [{ key: 'service_name', value: 'api|web' }] },
+      ];
+      expect(getDefaultColumnsForActiveFilters(records, sceneRef)).toEqual(['literal']);
+    });
+  });
+});

--- a/src/services/defaultColumns.ts
+++ b/src/services/defaultColumns.ts
@@ -1,0 +1,61 @@
+import {
+  LogsDrilldownDefaultColumnsLogsDefaultColumnsRecord,
+  LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords,
+} from '@grafana/api-clients/rtkq/logsdrilldown/v1beta1';
+import { SceneObject } from '@grafana/scenes';
+
+import { isOperatorInclusive, isOperatorRegex } from './operatorHelpers';
+import { getLabelsVariable } from './variableGetters';
+import { isAdHocFilterValueUserInput, stripAdHocFilterUserInputPrefix } from './variables';
+
+export function getDefaultColumnsForActiveFilters(
+  records: LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords,
+  sceneRef: SceneObject
+): string[] | undefined {
+  const labelsVariable = getLabelsVariable(sceneRef);
+  const inclusiveFilters = labelsVariable.state.filters.filter((f) => isOperatorInclusive(f.operator));
+
+  // Expand multi-value regex filters (e.g. `key=~__CVΩ__value1|value2`) into individual
+  // key/value pairs so they score the same as `key=value1 key=value2`.
+  const expandedFilters = inclusiveFilters.flatMap((f) => {
+    if (isOperatorRegex(f.operator) && isAdHocFilterValueUserInput(f.value)) {
+      return stripAdHocFilterUserInputPrefix(f.value)
+        .split('|')
+        .map((value) => ({ key: f.key, value }));
+    }
+    return [{ key: f.key, value: f.value }];
+  });
+
+  // Remove records that are more specific than our current label set
+  const filteredRecords = records?.filter((f) => f.labels.length <= expandedFilters.length);
+
+  // init map
+  const filtersMap = new Set<string>();
+  expandedFilters.forEach((f) => filtersMap.add(f.key + f.value));
+
+  // Assign a score to each record
+  const recordsScore: Array<LogsDrilldownDefaultColumnsLogsDefaultColumnsRecord & { score: number }> | undefined =
+    filteredRecords?.map((r) => {
+      const score = r.labels.reduce((accumulator, label) => {
+        const usedInQuery = filtersMap.has(label.key + label.value);
+        if (usedInQuery) {
+          return accumulator + 1;
+        }
+        return accumulator;
+      }, 0);
+      return { ...r, score };
+    });
+
+  let highScore = 0;
+  let highScoreIdx = -1;
+  recordsScore?.forEach((r, idx) => {
+    if (r.score > highScore) {
+      highScore = r.score;
+      highScoreIdx = idx;
+    }
+  });
+
+  const bestMatch = highScoreIdx !== -1 ? recordsScore?.[highScoreIdx] : undefined;
+
+  return bestMatch?.columns;
+}


### PR DESCRIPTION
When these kind of filters are saved to the query library:

<img width="417" height="86" alt="imagen" src="https://github.com/user-attachments/assets/16398013-4473-4c4f-8c56-985a7584a86b" />

The underlying query which is saved is:

<img width="721" height="60" alt="imagen" src="https://github.com/user-attachments/assets/d4e70729-6fe5-4dc0-873e-7cc9172c6dd8" />

Which, when reconstructing the state on load changes to:

<img width="350" height="74" alt="imagen" src="https://github.com/user-attachments/assets/17c155c4-6c8e-4858-95dc-071a503277dd" />

This PR adds suppor for these type of queries and default columns.