### PR TITLE
fix(deps): resolve brace-expansion pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,9 @@ overrides:
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
-  brace-expansion@^5: 5.0.6
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
+  brace-expansion@^5: 5.0.7
   ws@^8: 8.21.0
   ws@>=7.0.0 <7.5.11: 7.5.11
   qs: 6.15.3
@@ -3573,17 +3575,17 @@ packages:
     resolution:
       { integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ== }
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     resolution:
-      { integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w== }
+      { integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw== }
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     resolution:
-      { integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA== }
+      { integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA== }
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     resolution:
-      { integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g== }
+      { integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA== }
     engines: { node: 18 || 20 || >=22 }
 
   braces@3.0.3:
@@ -11573,16 +11575,16 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13967,15 +13969,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,9 @@ overrides:
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
-  'brace-expansion@^5': 5.0.6
+  'brace-expansion@<1.1.16': 1.1.16
+  'brace-expansion@>=2.0.0 <2.1.2': 2.1.2
+  'brace-expansion@^5': 5.0.7
   'ws@^8': 8.21.0
   'ws@>=7.0.0 <7.5.11': 7.5.11
   qs: 6.15.3


### PR DESCRIPTION
## Description

`pnpm audit` reported 2 high-severity [brace-expansion ReDoS](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) advisories (GHSA-3jxr-9vmj-r5cp). `brace-expansion` is a transitive, **build-time-only** dependency (via `minimatch` under eslint / typescript-eslint / glob / Jest coverage tooling) — it is not a direct dependency and does not ship in the plugin bundle. The pre-existing `'brace-expansion@^5'` override was stale (pinned `5.0.6`, which is still vulnerable).

Three major lines of `brace-expansion` coexist in the tree, each pinned by a different `minimatch` major, so a single blanket override is unsafe (it would violate each consumer's semver range and cross the CJS→ESM major boundary). Each override therefore pins its major to the nearest patched release within that major.

## Summary of the changes

Updated `pnpm-workspace.yaml` overrides (and regenerated `pnpm-lock.yaml`):

| Vulnerable range | Was | Now |
| --- | --- | --- |
| `<1.1.16` | 1.1.13 | **1.1.16** |
| `>=2.0.0 <2.1.2` | 2.0.3 | **2.1.2** |
| `^5` (`>=3.0.0 <5.0.7`) | 5.0.6 (stale override) | **5.0.7** |

Only `pnpm-workspace.yaml` and `pnpm-lock.yaml` changed.

## How to test

- [x] `pnpm audit` passes with 0 vulnerabilities (prod + dev, all severities)
- [x] `pnpm install` regenerates the lockfile cleanly
- [x] pre-commit hooks (eslint / tsc / prettier) pass