### PR TITLE
fix(embed): do not show the welcome banner in embed

### DIFF
--- a/src/Components/IndexScene/LayoutScene.tsx
+++ b/src/Components/IndexScene/LayoutScene.tsx
@@ -49,7 +49,7 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
 
   static Component = ({ model }: SceneComponentProps<LayoutScene>) => {
     const indexScene = sceneGraph.getAncestor(model, IndexScene);
-    const { contentScene } = indexScene.useState();
+    const { contentScene, embedded } = indexScene.useState();
     const { interceptDismissed, variableLayout } = model.useState();
     const styles = useStyles2(getStyles);
 
@@ -60,7 +60,7 @@ export class LayoutScene extends SceneObjectBase<LayoutSceneState> {
     return (
       <div className={styles.bodyContainer}>
         <div className={styles.container}>
-          {!interceptDismissed && (
+          {!embedded && !interceptDismissed && (
             <InterceptBanner
               onRemove={() => {
                 model.dismiss();


### PR DESCRIPTION
## Summary 📝

- Fixes [#2001](https://github.com/grafana/logs-drilldown/issues/2001) — [BUG]: Don't show the "Welcome to Grafana Logs Drilldown" banner when displayed embedded (e.g. in the Entity Catalog).
- The `InterceptBanner` in `LayoutScene` is now gated on the ancestor `IndexScene`'s `embedded` state, so it never renders in embedded mode — regardless of whether the user has previously dismissed it. Its call-to-action links pointed at the standalone Drilldown app, which was confusing inside the embed.

## Test 🧪

- [ ] `pnpm run start` (local stack + watcher).
- [ ] Control case — banner still shows in the standalone app: open `/a/grafana-lokiexplore-app/explore`, run `localStorage.removeItem('grafana-lokiexplore-app.interceptBannerStorageKey')` in DevTools, reload, and confirm the "Welcome to Grafana Logs Drilldown!" banner appears.
- [ ] Fix — banner is gone when embedded: open the embed route `/a/grafana-lokiexplore-app/embed` and confirm the banner does **not** render, even with the localStorage key cleared.
- [ ] Existing embed e2e suite passes: `pnpm run e2e -- embed.spec.ts`.
