### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,6 @@ overrides:
   tar@<=7.5.15: 7.5.19
   webpack: 5.108.1
   websocket-driver@<0.7.5: 0.7.5
-  brace-expansion: '>=5.0.7'
 
 importers:
   .:
@@ -3557,6 +3556,10 @@ packages:
     peerDependencies:
       '@babel/core': 7.29.7
 
+  balanced-match@1.0.2:
+    resolution:
+      { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
+
   balanced-match@4.0.4:
     resolution:
       { integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA== }
@@ -3571,6 +3574,14 @@ packages:
   body@5.1.0:
     resolution:
       { integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ== }
+
+  brace-expansion@1.1.16:
+    resolution:
+      { integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw== }
+
+  brace-expansion@2.1.2:
+    resolution:
+      { integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA== }
 
   brace-expansion@5.0.7:
     resolution:
@@ -3829,6 +3840,10 @@ packages:
   compute-scroll-into-view@3.1.1:
     resolution:
       { integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw== }
+
+  concat-map@0.0.1:
+    resolution:
+      { integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg== }
 
   configstore@5.0.1:
     resolution:
@@ -11547,6 +11562,8 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.19: {}
@@ -11557,6 +11574,15 @@ snapshots:
       error: 7.2.1
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
+
+  brace-expansion@1.1.16:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.7:
     dependencies:
@@ -11739,6 +11765,8 @@ snapshots:
       dot-prop: 5.3.0
 
   compute-scroll-into-view@3.1.1: {}
+
+  concat-map@0.0.1: {}
 
   configstore@5.0.1:
     dependencies:
@@ -13945,11 +13973,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,11 @@ overrides:
   react-router-dom: 7.18.0
   uuid: 14.0.1
   immutable: 5.1.8
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   serialize-javascript: 7.0.6
   strip-ansi: 6.0.1
   js-yaml: 4.3.0
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
@@ -27,6 +27,7 @@ overrides:
   tar@<=7.5.15: 7.5.19
   webpack: 5.108.1
   websocket-driver@<0.7.5: 0.7.5
+  brace-expansion: '>=5.0.7'
 
 importers:
   .:
@@ -3556,10 +3557,6 @@ packages:
     peerDependencies:
       '@babel/core': 7.29.7
 
-  balanced-match@1.0.2:
-    resolution:
-      { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
-
   balanced-match@4.0.4:
     resolution:
       { integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA== }
@@ -3574,14 +3571,6 @@ packages:
   body@5.1.0:
     resolution:
       { integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ== }
-
-  brace-expansion@1.1.16:
-    resolution:
-      { integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw== }
-
-  brace-expansion@2.1.2:
-    resolution:
-      { integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA== }
 
   brace-expansion@5.0.7:
     resolution:
@@ -3840,10 +3829,6 @@ packages:
   compute-scroll-into-view@3.1.1:
     resolution:
       { integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw== }
-
-  concat-map@0.0.1:
-    resolution:
-      { integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg== }
 
   configstore@5.0.1:
     resolution:
@@ -4227,9 +4212,9 @@ packages:
     resolution:
       { integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA== }
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     resolution:
-      { integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw== }
+      { integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg== }
 
   dot-prop@5.3.0:
     resolution:
@@ -4619,9 +4604,9 @@ packages:
     resolution:
       { integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg== }
 
-  fast-uri@3.1.2:
+  fast-uri@3.1.4:
     resolution:
-      { integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ== }
+      { integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw== }
 
   fast-wrap-ansi@0.2.0:
     resolution:
@@ -9236,7 +9221,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       eventemitter3: 5.0.1
       history: 4.10.1
       lodash: 4.18.1
@@ -11372,7 +11357,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11562,8 +11547,6 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.19: {}
@@ -11574,15 +11557,6 @@ snapshots:
       error: 7.2.1
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
-
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.7:
     dependencies:
@@ -11765,8 +11739,6 @@ snapshots:
       dot-prop: 5.3.0
 
   compute-scroll-into-view@3.1.1: {}
-
-  concat-map@0.0.1: {}
 
   configstore@5.0.1:
     dependencies:
@@ -12111,7 +12083,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -12586,7 +12558,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -13973,11 +13945,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.7
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,4 +32,3 @@ overrides:
   tar@<=7.5.15: 7.5.19
   webpack: 5.108.1
   'websocket-driver@<0.7.5': 0.7.5
-  brace-expansion: '>=5.0.7'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,12 +12,12 @@ overrides:
   react-router-dom: 7.18.0
   uuid: 14.0.1
   immutable: 5.1.8
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   serialize-javascript: 7.0.6
   strip-ansi: 6.0.1
   js-yaml: 4.3.0
   # Security patches for transitive vulnerabilities (pnpm audit)
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
@@ -32,3 +32,4 @@ overrides:
   tar@<=7.5.15: 7.5.19
   webpack: 5.108.1
   'websocket-driver@<0.7.5': 0.7.5
+  brace-expansion: '>=5.0.7'


### PR DESCRIPTION
## Summary
- Updates pnpm overrides in `pnpm-workspace.yaml` to resolve `pnpm audit` findings
- brace-expansion >=5.0.7 (high — DoS via exponential-time expansion)
- dompurify >=3.4.12 (low — CUSTOM_ELEMENT_HANDLING bypass)
- fast-uri >=3.1.4 (high — host confusion vulnerabilities)

## Test plan
- [x] `pnpm audit` passes with 0 vulnerabilities