### PR TITLE
revert(augurs): remove WASM init fallback fixed upstream

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -33,7 +33,6 @@ const App = lazy(async () => {
   // Initialize i18n for this plugin
   await initPluginI18n();
 
-  const { logger } = await import('services/logger');
   const { setWasmSortInit, wasmSupported } = await import('services/sorting');
 
   const { default: initRuntimeDs } = await import('services/datasource');
@@ -43,13 +42,8 @@ const App = lazy(async () => {
   initRuntimeDs();
 
   if (wasmSupported()) {
-    try {
-      await Promise.all([initChangepoint(), initOutlier()]);
-      setWasmSortInit(true);
-    } catch (e) {
-      logger.warn('WebAssembly init failed, ML sorting disabled.');
-      setWasmSortInit(false);
-    }
+    await Promise.all([initChangepoint(), initOutlier()]);
+    setWasmSortInit(true);
   }
 
   return import('Components/App');


### PR DESCRIPTION
## Summary 📝

- Removes the `try/catch` fallback around augurs WASM init in `src/module.tsx`, restoring a plain `await Promise.all([initChangepoint(), initOutlier()])` + `setWasmSortInit(true)`. Closes [#1887 — [FEAT]: Augurs WASM fixed upstream](https://github.com/grafana/logs-drilldown/issues/1887).
- The mitigation from #1757 is obsolete: `@opentelemetry/instrumentation-fetch` no longer wraps `globalThis.fetch` in a `Proxy` ([opentelemetry-js#6521](https://github.com/open-telemetry/opentelemetry-js/pull/6521)), and this repo resolves `0.219.0`, which contains the fix.

## Test 🧪
<img width="619" height="272" alt="Screenshot 2026-07-24 at 12 18 38 PM" src="https://github.com/user-attachments/assets/e0e97f82-0748-46d7-915e-ce1a38fbad6a" />

