### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-router-dom: 7.18.0
+  react-router-dom: 7.18.1
   uuid: 14.0.1
   immutable: 5.1.8
   dompurify: 3.4.12
@@ -16,17 +16,18 @@ overrides:
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@^5: 5.0.7
+  brace-expansion@^1: 1.1.16
+  brace-expansion@^2: 2.1.2
+  brace-expansion@^5: 5.0.8
   ws@^8: 8.21.0
   ws@>=7.0.0 <7.5.11: 7.5.11
   qs: 6.15.3
   '@babel/core@<=7.29.0': 7.29.7
   '@opentelemetry/core@<2.8.0': 2.8.0
-  tar@<=7.5.15: 7.5.19
+  tar@<=7.5.20: 7.5.22
   webpack: 5.108.1
   websocket-driver@<0.7.5: 0.7.5
+  postcss@<8.5.18: 8.5.23
 
 importers:
   .:
@@ -42,7 +43,7 @@ importers:
         version: 13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1))(rxjs@7.8.2)
       '@grafana/assistant':
         specifier: 0.1.25
-        version: 0.1.25(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/scenes@8.9.0(01b636d4cf33fe5ea50cca63dcfa913c))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
+        version: 0.1.25(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/scenes@8.9.0(b72f94879edc7e237defca91dac3f5e3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
       '@grafana/data':
         specifier: 13.1.0
         version: 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
@@ -63,10 +64,10 @@ importers:
         version: 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/scenes':
         specifier: 8.9.0
-        version: 8.9.0(01b636d4cf33fe5ea50cca63dcfa913c)
+        version: 8.9.0(b72f94879edc7e237defca91dac3f5e3)
       '@grafana/scenes-react':
         specifier: 8.9.0
-        version: 8.9.0(01b636d4cf33fe5ea50cca63dcfa913c)
+        version: 8.9.0(b72f94879edc7e237defca91dac3f5e3)
       '@grafana/schema':
         specifier: 13.1.0
         version: 13.1.0
@@ -116,8 +117,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: 7.18.0
-        version: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table:
         specifier: 7.8.0
         version: 7.8.0(react@18.3.1)
@@ -148,7 +149,7 @@ importers:
         version: 9.0.0(@stylistic/eslint-plugin-ts@4.4.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-jsdoc@52.0.4(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@grafana/faro-webpack-plugin':
         specifier: 0.12.0
-        version: 0.12.0(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+        version: 0.12.0(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
       '@grafana/plugin-e2e':
         specifier: 3.9.1
         version: 3.9.1(@playwright/test@1.61.1)
@@ -301,7 +302,7 @@ importers:
         version: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1)
       terser-webpack-plugin:
         specifier: 5.6.1
-        version: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack@5.108.1)
+        version: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack@5.108.1)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.2)(typescript@5.9.3)
@@ -316,7 +317,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: 5.108.1
-        version: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+        version: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
       webpack-bundle-analyzer:
         specifier: 4.10.2
         version: 4.10.2
@@ -1342,7 +1343,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 7.18.0
+      react-router-dom: 7.18.1
       rxjs: ^7.8.1
 
   '@grafana/scenes@8.9.0':
@@ -1357,7 +1358,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 7.18.0
+      react-router-dom: 7.18.1
       rxjs: ^7.8.1
 
   '@grafana/schema@13.1.0':
@@ -3583,10 +3584,10 @@ packages:
     resolution:
       { integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA== }
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     resolution:
-      { integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA== }
-    engines: { node: 18 || 20 || >=22 }
+      { integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg== }
+    engines: { node: 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -5103,7 +5104,7 @@ packages:
       { integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA== }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.23
 
   identity-obj-proxy@3.0.0:
     resolution:
@@ -6139,9 +6140,9 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.11:
+  nanoid@3.3.16:
     resolution:
-      { integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w== }
+      { integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q== }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
@@ -6475,28 +6476,28 @@ packages:
       { integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q== }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.23
 
   postcss-modules-local-by-default@4.2.0:
     resolution:
       { integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw== }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.23
 
   postcss-modules-scope@3.2.1:
     resolution:
       { integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA== }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.23
 
   postcss-modules-values@4.0.0:
     resolution:
       { integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ== }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.23
 
   postcss-selector-parser@7.1.1:
     resolution:
@@ -6507,9 +6508,9 @@ packages:
     resolution:
       { integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ== }
 
-  postcss@8.5.10:
+  postcss@8.5.23:
     resolution:
-      { integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ== }
+      { integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg== }
     engines: { node: ^10 || ^12 || >=14 }
 
   prefix-style@2.0.1:
@@ -6819,11 +6820,11 @@ packages:
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
-      react-router-dom: 7.18.0
+      react-router-dom: 7.18.1
 
-  react-router-dom@7.18.0:
+  react-router-dom@7.18.1:
     resolution:
-      { integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA== }
+      { integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg== }
     engines: { node: '>=20.0.0' }
     peerDependencies:
       react: '>=18'
@@ -6836,9 +6837,9 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  react-router@7.18.0:
+  react-router@7.18.1:
     resolution:
-      { integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ== }
+      { integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg== }
     engines: { node: '>=20.0.0' }
     peerDependencies:
       react: '>=18'
@@ -7597,9 +7598,9 @@ packages:
       { integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A== }
     engines: { node: '>=6' }
 
-  tar@7.5.19:
+  tar@7.5.22:
     resolution:
-      { integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw== }
+      { integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA== }
     engines: { node: '>=18' }
 
   terser-webpack-plugin@5.6.1:
@@ -9213,12 +9214,12 @@ snapshots:
       '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1)
       rxjs: 7.8.2
 
-  '@grafana/assistant@0.1.25(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/scenes@8.9.0(01b636d4cf33fe5ea50cca63dcfa913c))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
+  '@grafana/assistant@0.1.25(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/scenes@8.9.0(b72f94879edc7e237defca91dac3f5e3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
     dependencies:
       '@emotion/css': 11.13.5
       '@grafana/data': 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@grafana/scenes': 8.9.0(01b636d4cf33fe5ea50cca63dcfa913c)
+      '@grafana/scenes': 8.9.0(b72f94879edc7e237defca91dac3f5e3)
       '@grafana/schema': 13.1.0
       '@grafana/ui': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
@@ -9287,7 +9288,7 @@ snapshots:
   '@grafana/faro-bundlers-shared@0.11.0':
     dependencies:
       ansis: 4.3.1
-      tar: 7.5.19
+      tar: 7.5.22
       undici: 8.5.0
 
   '@grafana/faro-core@2.8.0':
@@ -9317,10 +9318,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@grafana/faro-webpack-plugin@0.12.0(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)':
+  '@grafana/faro-webpack-plugin@0.12.0(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)':
     dependencies:
       '@grafana/faro-bundlers-shared': 0.11.0
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -9366,7 +9367,7 @@ snapshots:
       fast-glob: 3.3.3
       node-fetch: 3.3.2
       ora: 9.0.0
-      tar: 7.5.19
+      tar: 7.5.22
       tty-table: 4.2.3
       typescript: 5.9.3
       yargs: 18.0.0
@@ -9438,21 +9439,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@grafana/scenes-react@8.9.0(01b636d4cf33fe5ea50cca63dcfa913c)':
+  '@grafana/scenes-react@8.9.0(b72f94879edc7e237defca91dac3f5e3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
       '@grafana/data': 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/e2e-selectors': 13.1.0
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@grafana/scenes': 8.9.0(01b636d4cf33fe5ea50cca63dcfa913c)
+      '@grafana/scenes': 8.9.0(b72f94879edc7e237defca91dac3f5e3)
       '@grafana/schema': 13.1.0
       '@grafana/ui': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       lodash: 4.18.1
       lru-cache: 10.4.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router-dom: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs: 7.8.2
     transitivePeerDependencies:
@@ -9460,7 +9461,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@grafana/scenes@8.9.0(01b636d4cf33fe5ea50cca63dcfa913c)':
+  '@grafana/scenes@8.9.0(b72f94879edc7e237defca91dac3f5e3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
@@ -9478,7 +9479,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-grid-layout: 1.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer: 1.0.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9549,8 +9550,8 @@ snapshots:
       react-hook-form: 7.72.1(react@18.3.1)
       react-inlinesvg: 4.3.0(react@18.3.1)
       react-loading-skeleton: 3.5.0(react@18.3.1)
-      react-router-dom: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom-v5-compat: 6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom-v5-compat: 6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table: 7.8.0(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11306,17 +11307,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)':
     dependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.108.1)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)':
     dependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.108.1)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.108.1)':
     dependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.108.1)
 
   '@wojtekmaj/date-utils@2.0.2': {}
@@ -11584,7 +11585,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11809,7 +11810,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.6
       tinyglobby: 0.2.16
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.2)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -11957,16 +11958,16 @@ snapshots:
 
   css-loader@7.1.4(webpack@5.108.1):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.10)
-      postcss: 8.5.10
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.10)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.10)
-      postcss-modules-scope: 3.2.1(postcss@8.5.10)
-      postcss-modules-values: 4.0.0(postcss@8.5.10)
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.23)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.23)
+      postcss-modules-scope: 3.2.1(postcss@8.5.23)
+      postcss-modules-values: 4.0.0(postcss@8.5.23)
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   css-tree@1.1.3:
     dependencies:
@@ -12440,7 +12441,7 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   eslint@9.39.4(jiti@2.7.0):
     dependencies:
@@ -12688,7 +12689,7 @@ snapshots:
       semver: 7.8.5
       tapable: 2.3.2
       typescript: 5.9.3
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -13011,9 +13012,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.10):
+  icss-utils@5.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.23
 
   identity-obj-proxy@3.0.0:
     dependencies:
@@ -13052,7 +13053,7 @@ snapshots:
     dependencies:
       source-map-js: 1.2.1
       strip-comments: 2.0.1
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   imurmurhash@0.1.4: {}
 
@@ -13969,7 +13970,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -13981,16 +13982,16 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack@5.108.1):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack@5.108.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
-      postcss: 8.5.10
+      postcss: 8.5.23
 
   minipass@7.1.3: {}
 
@@ -14033,7 +14034,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.6
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -14294,26 +14295,26 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.10):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.23
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.10):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.23):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.10)
-      postcss: 8.5.10
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.10):
+  postcss-modules-scope@3.2.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.5.10):
+  postcss-modules-values@4.0.0(postcss@8.5.23):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.10)
-      postcss: 8.5.10
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -14322,9 +14323,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.10:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14581,27 +14582,27 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom-v5-compat@6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  react-router-dom-v5-compat@6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.3
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.4(react@18.3.1)
-      react-router-dom: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   react-router@6.30.4(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.3
       react: 18.3.1
 
-  react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cookie: 1.1.1
       react: 18.3.1
@@ -14855,7 +14856,7 @@ snapshots:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.101.0
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   sass@1.101.0:
     dependencies:
@@ -15243,7 +15244,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.108.1):
     dependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   style-mod@4.1.3: {}
 
@@ -15265,7 +15266,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   symbol-tree@3.2.4: {}
 
@@ -15279,7 +15280,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -15287,16 +15288,16 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack@5.108.1):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack@5.108.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
-      postcss: 8.5.10
+      postcss: 8.5.23
 
   terser@5.46.1:
     dependencies:
@@ -15646,7 +15647,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -15657,7 +15658,7 @@ snapshots:
       portfinder: 1.0.38
       schema-utils: 4.3.3
       tiny-lr: 1.1.1
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15672,11 +15673,11 @@ snapshots:
   webpack-subresource-integrity@5.1.0(webpack@5.108.1):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1)
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack-cli@6.0.1):
+  webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@6.0.1):
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
@@ -15694,7 +15695,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.10)(webpack@5.108.1)
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack@5.108.1)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,12 @@ allowBuilds:
   unrs-resolver: true
 
 overrides:
-  react-router-dom: 7.18.0
+  # react-router itself is deliberately not overridden. The 6.30.4 copy comes from
+  # @grafana/ui -> react-router-dom-v5-compat@6.30.4, which imports UNSAFE_useRoutesImpl,
+  # UNSAFE_useRouteId and UNSAFE_logV6DeprecationWarnings — none of which react-router 7
+  # exports. The 7.x advisory is only patched in 8.3.0, which requires React >= 19.2.7
+  # (this plugin is on 18.3.1). Both need an upstream bump, not an override here.
+  react-router-dom: 7.18.1
   uuid: 14.0.1
   immutable: 5.1.8
   dompurify: 3.4.12
@@ -21,14 +26,19 @@ overrides:
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
-  'brace-expansion@<1.1.16': 1.1.16
-  'brace-expansion@>=2.0.0 <2.1.2': 2.1.2
-  'brace-expansion@^5': 5.0.7
+  # Each line is pinned to its newest release. GHSA-mh99-v99m-4gvg is only patched in
+  # 5.0.8 with no 1.x/2.x backport, and v5 changed the CJS export shape, so forcing the
+  # whole tree onto v5 breaks minimatch 3/9 ("expand is not a function"). The 1.x/2.x
+  # pins below stay flagged by `pnpm audit` until minimatch's consumers move to v10.
+  'brace-expansion@^1': 1.1.16
+  'brace-expansion@^2': 2.1.2
+  'brace-expansion@^5': 5.0.8
   'ws@^8': 8.21.0
   'ws@>=7.0.0 <7.5.11': 7.5.11
   qs: 6.15.3
   '@babel/core@<=7.29.0': 7.29.7
   '@opentelemetry/core@<2.8.0': 2.8.0
-  tar@<=7.5.15: 7.5.19
+  tar@<=7.5.20: 7.5.22
   webpack: 5.108.1
   'websocket-driver@<0.7.5': 0.7.5
+  'postcss@<8.5.18': 8.5.23


### PR DESCRIPTION
## Summary 📝

Bumps `pnpm-workspace.yaml` overrides to clear the fixable advisories from `pnpm audit`. Went from **7 advisories (4 high / 3 moderate)** to **4 (2 high / 2 moderate)**.

### Fixed

| Package | Before | After | Advisory |
| --- | --- | --- | --- |
| `postcss` | 8.5.10 | 8.5.23 | [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q), [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — arbitrary file read / path traversal via `sourceMappingURL` |
| `tar` | 7.5.19 | 7.5.22 | [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) — uncontrolled recursion DoS |
| `react-router-dom` | 7.18.0 | 7.18.1 | patch bump, keeps us on the patched line |

### Not fixable by override

Each of these was attempted and reverted after verifying it breaks:

- **`brace-expansion`** ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), high) — the advisory declares a single `<= 5.0.7` range with `5.0.8` as the only patched version; there is no 1.x or 2.x backport (1.1.16 and 2.1.2 are the newest in their lines). v5 changed its CJS export from a default function to a named export, so forcing the whole tree onto 5.0.8 breaks `minimatch` 3 and 9 with `TypeError: expand is not a function` — which would silently break glob matching under eslint, jest, and webpack. Each line is now pinned to its newest release instead.
- **`react-router` 6.30.4** ([GHSA-wrjc-x8rr-h8h6](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6), [GHSA-337j-9hxr-rhxg](https://github.com/advisories/GHSA-337j-9hxr-rhxg), moderate) — comes from `@grafana/ui` → `react-router-dom-v5-compat@6.30.4`, which pins `react-router` to exactly `6.30.4` and imports `UNSAFE_useRoutesImpl`, `UNSAFE_useRouteId` and `UNSAFE_logV6DeprecationWarnings`. None of the three are exported by react-router 7, so lifting it to 7.18.1 breaks Grafana's routing.
- **`react-router` 7.18.1** ([GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), high) — patched only in 8.3.0, which requires `react >= 19.2.7`. This plugin is on React 18.3.1. Also RSC-mode-only, so not reachable from a client-rendered Grafana plugin.

Both react-router advisories need an upstream bump in `@grafana/ui`; they can't be resolved from this repo.

## Test 🧪

- [x] `pnpm install --frozen-lockfile` — lockfile valid
- [x] `tsc --noEmit` — clean
- [x] `jest` — 828/828 tests pass (73 suites)
- [x] `eslint .` — 0 errors (41 pre-existing `getDataSourceSrv` deprecation warnings, unrelated)
- [x] `webpack --env production` — build succeeds
- [x] Verified `minimatch` 3.1.5 / 9.0.9 / 10.2.5 all brace-expand correctly with the pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)