### PR TITLE
fix(uuid): use uuid v4 instead of secure-context-only crypto.randomUUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     "react-table": "7.8.0",
     "rxjs": "7.8.2",
     "semver": "7.8.5",
-    "tslib": "2.8.1"
+    "tslib": "2.8.1",
+    "uuid": "14.0.1"
   },
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
+      uuid:
+        specifier: 14.0.1
+        version: 14.0.1
     devDependencies:
       '@babel/core':
         specifier: 7.29.7

--- a/src/services/saveSearch.ts
+++ b/src/services/saveSearch.ts
@@ -1,6 +1,7 @@
 import { ReactNode, useCallback, useState } from 'react';
 
 import semver from 'semver/preload';
+import { v4 as uuidv4 } from 'uuid';
 
 import { config } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -85,7 +86,7 @@ function saveInLocalStorage({ query, title, description, dsUid }: Omit<SavedSear
     query,
     timestamp: new Date().getTime(),
     title,
-    uid: crypto.randomUUID(),
+    uid: uuidv4(),
   });
 
   localStorage.setItem(SAVED_SEARCHES_KEY, JSON.stringify(stored));

--- a/src/services/shardQuerySplitting.test.ts
+++ b/src/services/shardQuerySplitting.test.ts
@@ -6,9 +6,9 @@ import { getMockFrames } from './combineResponses.test';
 import { LokiDatasource, LokiQuery } from './lokiQuery';
 import { runShardSplitQuery } from './shardQuerySplitting';
 
-beforeAll(() => {
-  jest.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000000');
-});
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('uuid'),
+}));
 
 const originalLog = console.log;
 const originalWarn = console.warn;

--- a/src/services/shardQuerySplitting.ts
+++ b/src/services/shardQuerySplitting.ts
@@ -1,4 +1,5 @@
 import { Observable, Subscriber, Subscription } from 'rxjs';
+import { v4 as uuidv4 } from 'uuid';
 
 import { DataFrame, DataQueryRequest, DataQueryResponse, LoadingState, QueryResultMetaStat } from '@grafana/data';
 
@@ -62,7 +63,7 @@ function splitQueriesByStreamShard(
   splittingTargets: LokiQuery[]
 ) {
   let shouldStop = false;
-  let mergedResponse: DataQueryResponse = { data: [], key: crypto.randomUUID(), state: LoadingState.Streaming };
+  let mergedResponse: DataQueryResponse = { data: [], key: uuidv4(), state: LoadingState.Streaming };
   let subquerySubscription: Subscription | null = null;
   let retriesMap = new Map<number, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary 📝

- Fixes #2016 (`[BUG]: crypto.randomUUID is not a function`) — saving a search crashed when Grafana is served over plain HTTP, because `crypto.randomUUID` is only defined in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). Replaced with `v4` from `uuid`, which uses `crypto.randomUUID` when available and falls back to `crypto.getRandomValues` (not secure-context gated) otherwise.
- Also fixes the same latent crash in `shardQuerySplitting.ts`, which would have thrown over HTTP on every sharded query.
- Effectively a revert of the `uuid` → `crypto.randomUUID` half of #1941; the `src/` changes restore the exact pre-#1941 blobs. Costs **+30 bytes** of bundle, because `uuid@14.0.1` already ships in `module.js` as a dependency of `@grafana/scenes` (which is bundled, not external) and the pin dedupes against that copy.

> [!NOTE]
> `generateUUID` from `@grafana/data` would look like the obvious fix, but it isn't safe here: `@grafana/data` is a webpack external, so we get the *host* Grafana's copy, and that util only landed in core on 2026-05-27 (grafana/grafana#125309). `grafanaDependency` in `plugin.json` allows Grafana `>=11.6.11`, so on 11.6/12.x we would have traded `randomUUID is not a function` for `generateUUID is not a function`.

## Test 🧪

1. Serve Grafana over plain **HTTP** (not `localhost`, which counts as a secure context — use a LAN IP or hostname, e.g. `http://<your-ip>:3000`).
2. Open Logs Drilldown and run a search.
3. Click **Save search**, and confirm it saves with no `crypto.randomUUID is not a function` in the browser console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
