### PR TITLE
fix(deps): bump grpc and brace-expansion for CVE remediation

### DIFF
--- a/generator/go.mod
+++ b/generator/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 )
 
 require (

--- a/generator/go.sum
+++ b/generator/go.sum
@@ -116,8 +116,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7/go.mod h1:KqHwBx2upmfa1XSi1WuRvC+2VGCLtooKkfmyvRbUmqA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7 h1:eM/YSd5bBFagF51o1E745Ta7RwzpW0h+z+QDNZOgmQ8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ overrides:
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
-  brace-expansion@^1: 1.1.16
-  brace-expansion@^2: 2.1.2
+  brace-expansion@^1: 1.1.17
+  brace-expansion@^2: 2.1.3
   brace-expansion@^5: 5.0.8
   ws@^8: 8.21.0
   ws@>=7.0.0 <7.5.11: 7.5.11
@@ -3576,13 +3576,13 @@ packages:
     resolution:
       { integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ== }
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     resolution:
-      { integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw== }
+      { integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w== }
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     resolution:
-      { integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA== }
+      { integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A== }
 
   brace-expansion@5.0.8:
     resolution:
@@ -11576,12 +11576,12 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -13974,11 +13974,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.17
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,9 @@ allowBuilds:
   protobufjs: true
   unrs-resolver: true
 
+minimumReleaseAgeExclude:
+  - brace-expansion@1.1.17
+
 overrides:
   # react-router itself is deliberately not overridden. The 6.30.4 copy comes from
   # @grafana/ui -> react-router-dom-v5-compat@6.30.4, which imports UNSAFE_useRoutesImpl,
@@ -30,8 +33,8 @@ overrides:
   # 5.0.8 with no 1.x/2.x backport, and v5 changed the CJS export shape, so forcing the
   # whole tree onto v5 breaks minimatch 3/9 ("expand is not a function"). The 1.x/2.x
   # pins below stay flagged by `pnpm audit` until minimatch's consumers move to v10.
-  'brace-expansion@^1': 1.1.16
-  'brace-expansion@^2': 2.1.2
+  'brace-expansion@^1': 1.1.17
+  'brace-expansion@^2': 2.1.3
   'brace-expansion@^5': 5.0.8
   'ws@^8': 8.21.0
   'ws@>=7.0.0 <7.5.11': 7.5.11


### PR DESCRIPTION
## Summary 📝

- Bumps `google.golang.org/grpc` 1.82.0 → **1.82.1** in `generator/go.mod`, closing Dependabot alert **#165** (HIGH, [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) — gRPC-Go xDS RBAC and HTTP/2 vulnerabilities).
- Bumps the `brace-expansion` overrides `^1` → **1.1.17** and `^2` → **2.1.3** (alert **#169**, [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257, DoS via unbounded expansion length). The advisory lists 5.0.8 as the only patched release, but upstream has since backported the same `

## Test 🧪
- [x] ci runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
