### PR TITLE
feat(LogsVolumePanel): update color for the visible range

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -10,6 +10,11 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
     ports: !override
       - 3001:3000/tcp
+    environment:
+      # Force Query Library off so the Playwright e2e suite deterministically exercises the local
+      # saved-search fallback across all Grafana versions. Nightly ships queryLibrary enabled by
+      # default, which swaps in Grafana's Saved Queries UI and breaks the savedSearches tests.
+      GF_FEATURE_TOGGLES_queryLibrary: 'false'
     extra_hosts:
       # This allows us to connect to other services running on the host machine.
       # 172.17.0.1 is the default Docker bridge network gateway IP address

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -143,7 +143,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     const isCollapsed = getLogsVolumeOption('collapsed');
     // Overrides are defined by setLogsVolumeFieldConfigOverrides, any overrides added here will be overwritten!
     const viz = PanelBuilders.timeseries()
-      .setOption('annotations', { multiLane: true })
       .setTitle(this.getTitle(serviceScene.state.totalLogsCount, serviceScene.state.logsCount))
       .setOption('legend', {
         calcs: ['sum'],

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -936,7 +936,7 @@
     "get-visible-range-frame": {
       "frame": {
         "text": {
-          "range-oldest-newest-display": "Range from oldest to newest logs in display"
+          "range-oldest-newest-display": "Current time range for the logs in display"
         }
       }
     },

--- a/src/services/logsFrame.ts
+++ b/src/services/logsFrame.ts
@@ -10,6 +10,7 @@ import {
   Labels,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 
 // these are like Labels, but their values can be
 // arbitrary structures, not just strings
@@ -214,11 +215,11 @@ export const VISIBLE_RANGE_NAME = 'Visible range';
 export function getVisibleRangeFrame(start: number, end: number) {
   const frame = arrayToDataFrame([
     {
-      color: 'rgba(58, 113, 255, 0.3)',
+      color: config.theme2.colors.text.primary,
       isRegion: true,
       text: t(
         'services.get-visible-range-frame.frame.text.range-oldest-newest-display',
-        'Range from oldest to newest logs in display'
+        'Current time range for the logs in display'
       ),
       time: start,
       timeEnd: end,


### PR DESCRIPTION
Since multi-lane annotations were enabled, the visible range could no longer be displayed as a region, making it much less visible.

<img width="1364" height="275" alt="imagen" src="https://github.com/user-attachments/assets/74a81466-6581-4636-a417-efb9e8177201" />

We're now using a higher contrast color, that is also neutral, so it's not confused to any type of log level or other type of situation.

Light theme:

<img width="1361" height="315" alt="Light" src="https://github.com/user-attachments/assets/32cddeef-371d-4368-a3d5-5e9c1953163b" />

Dark theme:

<img width="1362" height="300" alt="Dark" src="https://github.com/user-attachments/assets/26f3dd1a-a3b9-47f4-9065-92f6a9e2ac46" />
