### PR TITLE
chore(faro): duplicate rudderstack events as faro events

### DIFF
--- a/src/faro/faroInit.ts
+++ b/src/faro/faroInit.ts
@@ -3,6 +3,7 @@ import { config, getAppPluginVersion } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { getFaro, setFaro } from './faroInstance';
 import { getFaroEnvironment } from './getFaroEnv';
+import { registerFaroInteractionEchoBackend } from './interactionEchoBackend';
 import { logger } from 'services/logger';
 import { PLUGIN_BASE_URL, PLUGIN_ID } from 'services/plugin';
 
@@ -52,6 +53,10 @@ export const initFaro = async () => {
         },
       })
     );
+
+    // mirror this plugin's reportInteraction events into faro
+    registerFaroInteractionEchoBackend();
+
     logger.info('Plugin loaded successfully', { pluginId: PLUGIN_ID, appName, environment, pluginVersion });
   } catch (error) {
     logger.error(error instanceof Error ? error : new Error(String(error)), {

--- a/src/faro/interactionEchoBackend.ts
+++ b/src/faro/interactionEchoBackend.ts
@@ -1,0 +1,51 @@
+import { EchoBackend, EchoEventType, InteractionEchoEvent, registerEchoBackend } from '@grafana/runtime';
+
+import pluginJson from '../plugin.json';
+import { getFaro } from './faroInstance';
+
+// interaction name prefixes owned by this plugin: reportAppInteraction derives names
+// from the plugin id, while older direct reportInteraction call sites use grafana_logs_app
+const PLUGIN_INTERACTION_PREFIXES = [`${pluginJson.id.replace(/-/g, '_')}_`, 'grafana_logs_app_'];
+
+const isPluginInteraction = (interactionName: string) =>
+  PLUGIN_INTERACTION_PREFIXES.some((prefix) => interactionName.startsWith(prefix));
+
+// faro event attributes must be strings
+const toEventAttributes = (properties: Record<string, unknown> = {}): Record<string, string> => {
+  const attributes: Record<string, string> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    attributes[key] = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  }
+  return attributes;
+};
+
+// echo backend that mirrors this plugin's reportInteraction events into faro as events.
+// EchoSrv fans every interaction out to registered backends, so we filter to our own names
+class FaroInteractionEchoBackend implements EchoBackend<InteractionEchoEvent, {}> {
+  options = {};
+  supportedEvents = [EchoEventType.Interaction];
+
+  addEvent = (event: InteractionEchoEvent) => {
+    const { interactionName, properties } = event.payload;
+    if (!isPluginInteraction(interactionName)) {
+      return;
+    }
+    getFaro()?.api.pushEvent(interactionName, toEventAttributes(properties));
+  };
+
+  // faro batches and sends internally, nothing to flush here
+  flush = () => {};
+}
+
+let registered = false;
+
+export const registerFaroInteractionEchoBackend = () => {
+  if (registered) {
+    return;
+  }
+  registered = true;
+  registerEchoBackend(new FaroInteractionEchoBackend());
+};


### PR DESCRIPTION
### ✨ Description

Fixes: #2022
Related issue(s):

registers an echo backend (via the public `registerEchoBackend()` API) that mirrors this plugin's `reportInteraction` events into the plugin's faro instance as faro events:

- `src/faro/interactionEchoBackend.ts`: subscribes to `EchoEventType.Interaction`, filters to interaction names owned by this plugin — `grafana_lokiexplore_app_*` (from `reportAppInteraction`) and the legacy `grafana_logs_app_*` direct call sites — and forwards them with `faro.api.pushEvent()`. properties are stringified since faro event attributes must be strings
- `src/faro/faroInit.ts`: registers the backend right after faro initializes, so it's a no-op when faro is disabled for the environment

notes for reviewers:
1. the shared `grafana_explore_shortened_link_clicked` name is deliberately excluded — core Explore fires the same name, so forwarding it would ingest clicks from outside the plugin
2. the existing faro `beforeSend` page-url filter also applies to these events, so interactions fired while embedded outside the plugin's pages are dropped (matches current faro behavior)
3. `silent: true` interactions never reach echo backends by design

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/logs-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

1. run the plugin locally against a grafana instance with a faro environment configured (so `initFaro` actually initializes)
2. click around service selection / service details (e.g. select a service, add a filter)
3. observe the faro collector requests in the network tab: each interaction should appear as a faro event with the interaction name and stringified properties, alongside the existing rudderstack call