### PR TITLE
chore: replace deprecated Select with Combobox in tab popover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Refer to `.config/AGENTS/instructions.md` for Grafana plugin–specific rules. N
 
 - **Frontend security** — Follow workspace rules for HTML sanitization (DOMPurify), URLs (`textUtil.sanitizeUrl`), and avoiding unsafe DOM APIs.
 
+### Code comments
+
+- **One line max** — Keep code comments to a single line. State the constraint or workaround the code can't express by itself; move longer explanations to the commit message or PR description.
+
 ### TypeScript and DOM events
 
 - **No `unknown` double-casts for events** — Do not recover legacy fields with `(e as unknown as { srcElement?: … }).srcElement`. Prefer `event.currentTarget`, typed handlers, `instanceof` checks, or a small well-named helper with a real type guard.

--- a/src/Components/ServiceSelectionScene/ServiceSelectionTabsScene.tsx
+++ b/src/Components/ServiceSelectionScene/ServiceSelectionTabsScene.tsx
@@ -208,6 +208,12 @@ export class ServiceSelectionTabsScene extends SceneObjectBase<ServiceSelectionT
     });
   };
 
+  setShowPopover = (showPopover: boolean) => {
+    if (showPopover !== this.state.showPopover) {
+      this.setState({ showPopover });
+    }
+  };
+
   getLabelsFromQueryRunnerState(state = this.state.$labelsData?.state): LabelOptions[] | undefined {
     return state.data?.series?.[0]?.fields.map((f) => {
       return {

--- a/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
+++ b/src/Components/ServiceSelectionScene/TabPopoverScene.tsx
@@ -1,18 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Select, Stack, useStyles2 } from '@grafana/ui';
+import { Combobox, ComboboxOption, Stack, useStyles2 } from '@grafana/ui';
 
 import { ServiceSelectionScene } from './ServiceSelectionScene';
-import { ServiceSelectionTabsScene, TabOption } from './ServiceSelectionTabsScene';
+import { ServiceSelectionTabsScene } from './ServiceSelectionTabsScene';
 
 export interface TabPopoverSceneState extends SceneObjectState {}
 
-// TODO: update combobox to auto open in grafana/ui the update the select here to combobox
 export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
   public static Component = ({ model }: SceneComponentProps<TabPopoverScene>) => {
     const serviceSelectionScene = sceneGraph.getAncestor(model, ServiceSelectionScene);
@@ -20,40 +19,41 @@ export class TabPopoverScene extends SceneObjectBase<TabPopoverSceneState> {
     const { showPopover, tabOptions } = serviceSelectionTabsScene.useState();
     const popoverStyles = useStyles2(getPopoverStyles);
 
-    const tabOptionsWithIcon: TabOption[] = tabOptions.map((opt) => {
+    // Combobox never positions a dropdown that is open on first render (0x0 menu), so mount closed and open a render later
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+      setMounted(true);
+    }, []);
+
+    const comboboxOptions: Array<ComboboxOption<string>> = tabOptions.map((opt) => {
       return {
-        ...opt,
         icon: opt.saved ? 'save' : undefined,
-        label: `${opt.label}`,
+        label: opt.label,
+        value: opt.value,
       };
     });
 
     return (
       <Stack direction="column" gap={0} role="tooltip">
         <div className={popoverStyles.card.body}>
-          {/* eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: Combobox when grafana/ui supports open-on-focus in this popover */}
-          <Select<string, { options: TabOption[] }>
-            menuShouldPortal={false}
-            menuPosition={'absolute'}
+          <Combobox<string>
             width={50}
-            onBlur={() => {
-              serviceSelectionTabsScene.toggleShowPopover();
-            }}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={true}
-            isOpen={showPopover}
+            isOpen={mounted && showPopover}
+            onIsOpenChange={(isOpen) => {
+              serviceSelectionTabsScene.setShowPopover(isOpen);
+            }}
             placeholder={t(
               'components.service-selection-scene.tab-popover-scene.placeholder-search-labels',
               'Search labels'
             )}
-            options={tabOptionsWithIcon}
-            isSearchable={true}
-            openMenuOnFocus={true}
+            options={comboboxOptions}
             onChange={(option) => {
               // Add value to variable
               if (option.value) {
                 // Hide the popover
-                serviceSelectionTabsScene.toggleShowPopover();
+                serviceSelectionTabsScene.setShowPopover(false);
                 // Set new tab
                 serviceSelectionScene.setSelectedTab(option.value);
               }

--- a/tests/exploreServices.spec.ts
+++ b/tests/exploreServices.spec.ts
@@ -497,10 +497,11 @@ test.describe('explore services page', () => {
           // Click "New" tab
           await addNewTab.click();
 
-          // Dropdown should be open
-          await expect(selectNewLabelSelect).toContainText('Search labels');
+          // Popover should be open with the combobox dropdown auto-opened
+          await expect(selectNewLabelSelect.getByPlaceholder('Search labels')).toBeVisible();
+          await expect(page.getByRole('listbox')).toBeVisible();
 
-          // Add "namespace" as a new tab — type to filter the dropdown so the option is in viewport
+          // Add "namespace" as a new tab — type to filter the dropdown so the option is rendered
           await page.keyboard.type('namespace');
           await page.getByRole('option', { name: 'namespace', exact: true }).click();
           await expect(newNamespaceTabLoc).toHaveCount(1);
@@ -508,10 +509,13 @@ test.describe('explore services page', () => {
           // Click "New" tab
           await addNewTab.click();
 
-          // Dropdown should be open
-          await expect(selectNewLabelSelect).toContainText('Search labels');
-          await page.getByRole('option', { name: 'level' }).click();
-          // await page.getByText(/level/, { exact: true }).click();
+          // Popover should be open with the combobox dropdown auto-opened
+          await expect(selectNewLabelSelect.getByPlaceholder('Search labels')).toBeVisible();
+          await expect(page.getByRole('listbox')).toBeVisible();
+
+          // Type to filter the dropdown so the option is rendered
+          await page.keyboard.type('level');
+          await page.getByRole('option', { name: 'level', exact: true }).click();
 
           // Assert we have 4 tabs open
           await expect(allTabLoc).toHaveCount(4);
@@ -674,12 +678,14 @@ test.describe('explore services page', () => {
         await expect(addNewTab).toHaveCount(1);
         await addNewTab.click();
 
-        // Dropdown should be open
+        // Popover should be open with the combobox dropdown auto-opened
         const selectNewLabelSelect = page.locator('[role="tooltip"]');
-        await expect(selectNewLabelSelect).toContainText('Search labels');
+        await expect(selectNewLabelSelect.getByPlaceholder('Search labels')).toBeVisible();
+        await expect(page.getByRole('listbox')).toBeVisible();
 
-        // Add "namespace" as a new tab
-        await page.getByText('namespace', { exact: true }).click();
+        // Add "namespace" as a new tab — type to filter the dropdown so the option is rendered
+        await page.keyboard.type('namespace');
+        await page.getByRole('option', { name: 'namespace', exact: true }).click();
         const newNamespaceTabLoc = page.getByTestId('data-testid Tab namespace');
         await expect(newNamespaceTabLoc).toHaveCount(1);
 


### PR DESCRIPTION
## Summary 📝

- Fixes [#1855 — [FEAT]: Combobox enable auto-open](https://github.com/grafana/logs-drilldown/issues/1855): migrates `TabPopoverScene` from the deprecated `Select` to `Combobox`, using the controlled `isOpen`/`onIsOpenChange` props added in [grafana/grafana#122992](https://github.com/grafana/grafana/pull/122992) (available in `@grafana/ui` 13.1.0) to auto-open the dropdown when the add-label-tab popover is shown. This removes the last deprecated `Select` usage in the plugin.
- Adds `setShowPopover(boolean)` to `ServiceSelectionTabsScene` so the combobox open-state callback sets state explicitly instead of racing through `toggleShowPopover`; Escape, outside click, and option selection all close the popover through the single `onIsOpenChange` path.
- Updates the tabs e2e assertions for Combobox rendering: the placeholder is an input attribute (not a text node like Select), the options list is portaled and virtualized, so tests now assert the visible `listbox` (exercising auto-open directly) and type to filter before clicking options.


## Test 🧪

- [x] e2e
- [x] Manually click Add label
<img width="537" height="456" alt="Screenshot 2026-08-03 at 9 54 08 AM" src="https://github.com/user-attachments/assets/b42e11a0-a202-45a7-8ea7-83873a819135" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)