### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,14 @@ overrides:
   serialize-javascript: 7.0.6
   strip-ansi: 6.0.1
   js-yaml: 4.3.0
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
+  undici: 8.9.0
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
-  brace-expansion@^1: 1.1.17
-  brace-expansion@^2: 2.1.3
-  brace-expansion@^5: 5.0.8
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^2: 2.1.4
+  brace-expansion@^5: 5.0.9
   ws@^8: 8.21.0
   ws@>=7.0.0 <7.5.11: 7.5.11
   qs: 6.15.3
@@ -3579,17 +3580,17 @@ packages:
     resolution:
       { integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ== }
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     resolution:
-      { integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w== }
+      { integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw== }
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     resolution:
-      { integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A== }
+      { integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg== }
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     resolution:
-      { integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg== }
+      { integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg== }
     engines: { node: 20 || >=22 }
 
   braces@3.0.3:
@@ -4623,9 +4624,9 @@ packages:
     resolution:
       { integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg== }
 
-  fast-uri@3.1.4:
+  fast-uri@3.1.5:
     resolution:
-      { integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw== }
+      { integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw== }
 
   fast-wrap-ansi@0.2.0:
     resolution:
@@ -7878,9 +7879,9 @@ packages:
     resolution:
       { integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w== }
 
-  undici@8.5.0:
+  undici@8.9.0:
     resolution:
-      { integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg== }
+      { integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA== }
     engines: { node: '>=22.19.0' }
 
   unicorn-magic@0.3.0:
@@ -9292,7 +9293,7 @@ snapshots:
     dependencies:
       ansis: 4.3.1
       tar: 7.5.22
-      undici: 8.5.0
+      undici: 8.9.0
 
   '@grafana/faro-core@2.8.0':
     dependencies:
@@ -11376,7 +11377,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11579,16 +11580,16 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12590,7 +12591,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -13973,15 +13974,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.17
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -15500,7 +15501,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@8.5.0: {}
+  undici@8.9.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ allowBuilds:
   unrs-resolver: true
 
 minimumReleaseAgeExclude:
-  - brace-expansion@1.1.17
+  - brace-expansion@1.1.18
 
 overrides:
   # react-router itself is deliberately not overridden. The 6.30.4 copy comes from
@@ -25,7 +25,8 @@ overrides:
   strip-ansi: 6.0.1
   js-yaml: 4.3.0
   # Security patches for transitive vulnerabilities (pnpm audit)
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
+  undici: 8.9.0
   protobufjs: 8.6.5
   js-cookie: 3.0.8
   '@ungap/structured-clone': 1.3.2
@@ -33,9 +34,9 @@ overrides:
   # 5.0.8 with no 1.x/2.x backport, and v5 changed the CJS export shape, so forcing the
   # whole tree onto v5 breaks minimatch 3/9 ("expand is not a function"). The 1.x/2.x
   # pins below stay flagged by `pnpm audit` until minimatch's consumers move to v10.
-  'brace-expansion@^1': 1.1.17
-  'brace-expansion@^2': 2.1.3
-  'brace-expansion@^5': 5.0.8
+  'brace-expansion@^1': 1.1.18
+  'brace-expansion@^2': 2.1.4
+  'brace-expansion@^5': 5.0.9
   'ws@^8': 8.21.0
   'ws@>=7.0.0 <7.5.11': 7.5.11
   qs: 6.15.3


### PR DESCRIPTION
## Summary

Bumps `pnpm-workspace.yaml` overrides for the packages flagged by `pnpm audit`. No unrelated override lines were touched.

| Package | From | To |
| --- | --- | --- |
| `fast-uri` | 3.1.4 | **3.1.5** |
| `undici` | _(no override; 8.5.0 resolved)_ | **8.9.0** |
| `brace-expansion@^1` | 1.1.17 | **1.1.18** |
| `brace-expansion@^2` | 2.1.3 | **2.1.4** |
| `brace-expansion@^5` | 5.0.8 | **5.0.9** |

`undici` is a new override. Only 8.x is present in the tree (`@grafana/faro-webpack-plugin` -> `@grafana/faro-bundlers-shared` -> `undici`), so a bare key is correct rather than a version-scoped one. This single bump clears 5 advisories.

The three `brace-expansion` entries stay split per major, as the existing comment explains: v5 changed the CJS export shape, so collapsing the tree onto v5 breaks minimatch 3/9 with "expand is not a function". Each major is pinned to its newest release instead.

In `minimumReleaseAgeExclude`, the stale `brace-expansion@1.1.17` entry was replaced with `1.1.18`, since 1.1.17 no longer resolves. No other entries were added — install was verified to succeed without them, so the exclude list is not expanded beyond what is actually required.

Verified post-install that each override actually resolved (an override can sit in the lockfile while remaining inert):

    node_modules/.pnpm/brace-expansion@1.1.18
    node_modules/.pnpm/brace-expansion@2.1.4
    node_modules/.pnpm/brace-expansion@5.0.9
    node_modules/.pnpm/fast-uri@3.1.5
    node_modules/.pnpm/undici@8.9.0

## Known remaining

`pnpm audit` still reports 3 findings, all `react-router`, and all deliberately left alone. `pnpm audit` exits non-zero as a result.

| Advisory | Vulnerable | Patched | Why it stays |
| --- | --- | --- | --- |
| GHSA-wrjc-x8rr-h8h6 (moderate) | >=6.0.0 <7.18.0 | >=7.18.0 | This is the 6.30.4 copy pulled in by `@grafana/ui` -> `react-router-dom-v5-compat@6.30.4`, which imports `UNSAFE_useRoutesImpl`, `UNSAFE_useRouteId` and `UNSAFE_logV6DeprecationWarnings` — none of which react-router 7 exports. Needs an upstream bump in `@grafana/ui`, not an override here. |
| GHSA-337j-9hxr-rhxg (moderate) | >=6.4.0 <7.18.0 | >=7.18.0 | Same 6.30.4 copy and same upstream constraint as above. |
| GHSA-qwww-vcr4-c8h2 (high) | >=7.12.0 <8.3.0 | >=8.3.0 | The 7.18.1 copy. Only patched in react-router 8.3.0, which peers `react >= 19.2.7`; this plugin is on React 18.3.1. Blocked until the plugin moves to React 19. |

`react-router-dom` is already overridden to 7.18.1 and is not flagged; note that 6.30.5 was never published to npm, so there is no 6.x patch route either.

No audit suppressions or ignore entries were added. Forcing either bump would break the build rather than fix anything.

## Test plan

- `pnpm install --no-frozen-lockfile` — clean; lockfile passes supply-chain policies (1487 entries).
- `pnpm audit` — **12 findings (6 high / 6 moderate) -> 3 findings (1 high / 2 moderate)**, all react-router per the table above.
- `pnpm run typecheck` — passes.
- `pnpm run build` — passes (webpack 5.108.1, only the pre-existing asset-size warning).
- Because `brace-expansion` majors moved, verified the minimatch CJS-interop regression the override comment warns about did **not** occur. `tsc` cannot catch this since it never loads the module, so each installed minimatch was exercised directly and all expand braces correctly:

  | minimatch | brace expansion |
  | --- | --- |
  | 3.1.5 | OK |
  | 9.0.9 | OK |
  | 10.2.5 | OK |