### PR TITLE
chore(release): show chore in changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
     { "section": "🏗️ Builds", "type": "build" },
     { "section": "🤖 Continuous Integrations", "type": "ci" },
     { "section": "⏪ Reverts", "type": "revert" },
-    { "section": "🧹 Chore", "type": "chore", "hidden": true },
+    { "section": "🧹 Chore", "type": "chore" },
     { "section": "🚫 Omit", "type": "omit", "hidden": true },
     { "section": "🚫 Skip", "type": "skip", "hidden": true },
     { "section": "🔒 Internal", "type": "internal", "hidden": true }


### PR DESCRIPTION
### ✨ Description

Related issue(s): follow-up to #2020 / release PR #2004

Chore-typed commits were excluded from release notes: `release-please-config.json` marked the `chore` changelog section as `"hidden": true`, so user-facing changes squash-merged with a `chore(...)` title (e.g. #2020, the patterns table overflow fix) never appeared in the release PR body or `CHANGELOG.md`, even though they ship in the release.

This unhides the 🧹 Chore section so chore commits are listed in the changelog:

- Retroactive for the open release PR: release-please regenerates #2004 from all commits since `v2.4.0` on its next run on `main`, so the chores merged since then (#2018, #2020, #2023, and this PR itself) will appear under 🧹 Chore.
- Version-bump semantics are unchanged — chores are listed but still don't drive the version; that remains `feat`/`fix`.
- `omit`, `skip`, and `internal` stay hidden as an escape hatch for commits that genuinely shouldn't appear in release notes.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/logs-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

Merge to `main` and check the next "Release Please" workflow run: the release PR (#2004) body and `CHANGELOG.md` diff should gain a 🧹 Chore section listing the chore commits since `v2.4.0`, including this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)