### PR TITLE
fix(assistant): update to latest and fix context bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@bsull/augurs": "0.10.2",
     "@emotion/css": "11.13.5",
     "@grafana/api-clients": "13.1.0",
-    "@grafana/assistant": "0.1.25",
+    "@grafana/assistant": "0.1.33",
     "@grafana/data": "13.1.0",
     "@grafana/faro-web-sdk": "2.8.0",
     "@grafana/faro-web-tracing": "2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,10 +40,10 @@ importers:
         version: 11.13.5
       '@grafana/api-clients':
         specifier: 13.1.0
-        version: 13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1))(rxjs@7.8.2)
+        version: 13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(rxjs@7.8.2)
       '@grafana/assistant':
-        specifier: 0.1.25
-        version: 0.1.25(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/scenes@8.9.0(b72f94879edc7e237defca91dac3f5e3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
+        specifier: 0.1.33
+        version: 0.1.33(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
       '@grafana/data':
         specifier: 13.1.0
         version: 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
@@ -1225,14 +1225,13 @@ packages:
       '@reduxjs/toolkit': ^2.10.0
       rxjs: 7.8.2
 
-  '@grafana/assistant@0.1.25':
+  '@grafana/assistant@0.1.33':
     resolution:
-      { integrity: sha512-ujEq5O2GiD6Y7oPmUUMqRMXUCDwta8kDMOJ1h6u+P7xBddLP5JUhFJKOCliqmQM6tsG+LsO2E0A+yZuIgF0jrA== }
+      { integrity: sha512-lyUXj3egZG21wDdhZawfensmhf7Xr7uj9//38evghyE5prsd/A4zrU0xdO1tEVDlOA4HCMUOrRmBJI3fMTKuqA== }
     peerDependencies:
       '@emotion/css': '>=11.0.0'
       '@grafana/data': '>=12.1.0'
       '@grafana/runtime': '>=12.1.0'
-      '@grafana/scenes': '>=5.41.0'
       '@grafana/schema': '>=12.1.0'
       '@grafana/ui': '>=12.1.0'
       react: '>=18.0.0'
@@ -5764,6 +5763,11 @@ packages:
     resolution:
       { integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w== }
 
+  json-schema-to-ts@3.1.1:
+    resolution:
+      { integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g== }
+    engines: { node: '>=16' }
+
   json-schema-traverse@0.4.1:
     resolution:
       { integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg== }
@@ -7749,6 +7753,10 @@ packages:
       { integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw== }
     engines: { node: '>=18' }
 
+  ts-algebra@2.0.0:
+    resolution:
+      { integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw== }
+
   ts-api-utils@2.5.0:
     resolution:
       { integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA== }
@@ -9211,20 +9219,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@grafana/api-clients@13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1))(rxjs@7.8.2)':
+  '@grafana/api-clients@13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(rxjs@7.8.2)':
     dependencies:
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1)
+      '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       rxjs: 7.8.2
 
-  '@grafana/assistant@0.1.25(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/scenes@8.9.0(b72f94879edc7e237defca91dac3f5e3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
+  '@grafana/assistant@0.1.33(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
     dependencies:
       '@emotion/css': 11.13.5
       '@grafana/data': 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@grafana/scenes': 8.9.0(b72f94879edc7e237defca91dac3f5e3)
       '@grafana/schema': 13.1.0
       '@grafana/ui': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      json-schema-to-ts: 3.1.1
       react: 18.3.1
       rxjs: 7.8.2
 
@@ -10587,7 +10595,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1)':
+  '@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -10597,7 +10605,7 @@ snapshots:
       reselect: 5.2.0
     optionalDependencies:
       react: 18.3.1
-      react-redux: 9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1)
+      react-redux: 9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1)
 
   '@remix-run/router@1.23.3': {}
 
@@ -13793,6 +13801,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -14558,16 +14571,6 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
       react-dom: 18.3.1(react@18.3.1)
       redux: 4.2.1
-
-  react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1):
-    dependencies:
-      '@types/use-sync-external-store': 0.0.6
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.31
-      redux: 4.2.1
-    optional: true
 
   react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1):
     dependencies:
@@ -15378,6 +15381,8 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -394,6 +394,8 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     return () => {
       clearKeyBindings();
       assistantUnregister.forEach((callback) => callback.unregister());
+      // Scenes re-activates this pathname-cached instance — reset so we re-register.
+      this.assistantInitialized = false;
     };
   }
 
@@ -543,6 +545,9 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   private provideAssistantContext() {
     const setAssistantContext = providePageContext(`${PLUGIN_BASE_URL}/**`, []);
 
+    // Set the initial context right away — the subscriptions below only fire on changes.
+    updateAssistantContext(this, setAssistantContext);
+
     this._subs.add(
       getDataSourceVariable(this).subscribeToState(async () => {
         await updateAssistantContext(this, setAssistantContext);
@@ -561,6 +566,28 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     this._subs.add(
       getFieldsVariable(this).subscribeToState(async () => {
         await updateAssistantContext(this, setAssistantContext);
+      })
+    );
+    this._subs.add(
+      getMetadataVariable(this).subscribeToState(async () => {
+        await updateAssistantContext(this, setAssistantContext);
+      })
+    );
+    this._subs.add(
+      getLineFiltersVariable(this).subscribeToState(async () => {
+        await updateAssistantContext(this, setAssistantContext);
+      })
+    );
+    this._subs.add(
+      getPatternsVariable(this).subscribeToState(async () => {
+        await updateAssistantContext(this, setAssistantContext);
+      })
+    );
+    this._subs.add(
+      sceneGraph.getTimeRange(this).subscribeToState(async (newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this.assistantInitialized = true;

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -544,7 +544,6 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   private provideAssistantContext() {
     const setAssistantContext = providePageContext(`${PLUGIN_BASE_URL}/**`, []);
 
-    // Set the initial context right away (fire-and-forget) — the subscriptions below only fire on changes.
     updateAssistantContext(this, setAssistantContext).catch((error) => {
       logger.error(error, { msg: 'Failed to set initial assistant context' });
     });

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -549,38 +549,52 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     });
 
     this._subs.add(
-      getDataSourceVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getDataSourceVariable(this).subscribeToState(async (newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(
-      getLabelsVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getLabelsVariable(this).subscribeToState(async (newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(
-      getLevelsVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getLevelsVariable(this).subscribeToState(async (newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(
-      getFieldsVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getFieldsVariable(this).subscribeToState(async (newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(
-      getMetadataVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getMetadataVariable(this).subscribeToState(async (newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(
-      getLineFiltersVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getLineFiltersVariable(this).subscribeToState(async (newState, prevState) => {
+        if (!areArraysEqual(newState.filters, prevState.filters)) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(
-      getPatternsVariable(this).subscribeToState(async () => {
-        await updateAssistantContext(this, setAssistantContext);
+      getPatternsVariable(this).subscribeToState(async (newState, prevState) => {
+        if (newState.value !== prevState.value) {
+          await updateAssistantContext(this, setAssistantContext);
+        }
       })
     );
     this._subs.add(

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -394,7 +394,6 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     return () => {
       clearKeyBindings();
       assistantUnregister.forEach((callback) => callback.unregister());
-      // Scenes re-activates this pathname-cached instance — reset so we re-register.
       this.assistantInitialized = false;
     };
   }

--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -545,8 +545,10 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
   private provideAssistantContext() {
     const setAssistantContext = providePageContext(`${PLUGIN_BASE_URL}/**`, []);
 
-    // Set the initial context right away — the subscriptions below only fire on changes.
-    updateAssistantContext(this, setAssistantContext);
+    // Set the initial context right away (fire-and-forget) — the subscriptions below only fire on changes.
+    updateAssistantContext(this, setAssistantContext).catch((error) => {
+      logger.error(error, { msg: 'Failed to set initial assistant context' });
+    });
 
     this._subs.add(
       getDataSourceVariable(this).subscribeToState(async () => {

--- a/src/Components/Panels/PanelMenu.tsx
+++ b/src/Components/Panels/PanelMenu.tsx
@@ -166,6 +166,7 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
               text: t('components.panels.panel-menu.text.explain-in-assistant', 'Explain in Assistant'),
               onClick: () => {
                 openAssistant({
+                  appendContext: true,
                   origin: 'logs-drilldown-panel',
                   prompt:
                     'Help me understand this query and provide a summary of the data. Be concise and to the point.',

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -1004,6 +1004,7 @@
     },
     "update-assistant-context": {
       "title": {
+        "current-logs-query-and-time-range": "Current logs query and time range",
         "parsed-fields-filters": "Parsed fields filters",
         "structured-metadata-filters": "Structured metadata filters"
       }

--- a/src/services/assistant.test.ts
+++ b/src/services/assistant.test.ts
@@ -1,13 +1,18 @@
 import { createAssistantContextItem } from '@grafana/assistant';
-import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
+import { AdHocFiltersVariable, SceneFlexLayout, SceneObject, SceneTimeRange } from '@grafana/scenes';
 
 import { updateAssistantContext } from './assistant';
 import { FilterOp } from './filterTypes';
+import { interpolateExpression } from './query';
 import { getLokiDatasource } from './scenes';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable, getMetadataVariable } from './variableGetters';
 import { VAR_FIELDS, VAR_LABELS, VAR_LEVELS, VAR_METADATA } from './variables';
 
 jest.mock('./scenes');
+// No requireActual: pulling the real ./query module drags in a circular import graph that fails at init
+jest.mock('./query', () => ({
+  interpolateExpression: jest.fn(() => '{service_name="frontend"} | logfmt'),
+}));
 jest.mock('./variableGetters', () => ({
   ...jest.requireActual('./variableGetters'),
   getFieldsVariable: jest.fn(),
@@ -38,9 +43,32 @@ describe('assistant', () => {
     type: 'loki',
   };
 
+  // The expected shape of the query context item appended to every non-empty context
+  const expectedQueryContext = {
+    node: {
+      data: {
+        bypassLimits: true,
+        data: {
+          datasourceUid: 'loki-uid-123',
+          instructions: expect.any(String),
+          logqlQuery: '{service_name="frontend"} | logfmt',
+          timeRangeFromMs: expect.any(Number),
+          timeRangeToMs: expect.any(Number),
+        },
+        hidden: true,
+        title: 'Current logs query and time range',
+      },
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    mockModel = {} as SceneObject;
+    jest.mocked(interpolateExpression).mockReturnValue('{service_name="frontend"} | logfmt');
+    // A real scene with a time range so sceneGraph.getTimeRange resolves
+    mockModel = new SceneFlexLayout({
+      $timeRange: new SceneTimeRange({ from: 'now-1h', to: 'now' }),
+      children: [],
+    }) as SceneObject;
     mockSetAssistantContext = jest.fn();
     jest.mocked(getLabelsVariable).mockReturnValue(
       new AdHocFiltersVariable({
@@ -121,11 +149,13 @@ describe('assistant', () => {
         datasourceUid: 'loki-uid-123',
         labelName: 'service',
         labelValue: 'frontend',
+        operator: FilterOp.Equal,
       });
       expect(mockCreateAssistantContextItem).toHaveBeenCalledWith('label_value', {
         datasourceUid: 'loki-uid-123',
         labelName: 'environment',
         labelValue: 'production',
+        operator: FilterOp.Equal,
       });
     });
 
@@ -147,6 +177,7 @@ describe('assistant', () => {
         datasourceUid: 'loki-uid-123',
         labelName: 'app',
         labelValue: 'api-server',
+        operator: FilterOp.Equal,
       });
     });
 
@@ -242,6 +273,7 @@ describe('assistant', () => {
               datasourceUid: 'loki-uid-123',
               labelName: 'label',
               labelValue: 'value',
+              operator: '=',
             },
           },
         },
@@ -251,6 +283,7 @@ describe('assistant', () => {
               datasourceUid: 'loki-uid-123',
               labelName: 'detected_level',
               labelValue: 'error',
+              operator: '=',
             },
           },
         },
@@ -260,6 +293,7 @@ describe('assistant', () => {
               datasourceUid: 'loki-uid-123',
               labelName: 'detected_level',
               labelValue: 'warning',
+              operator: '=',
             },
           },
         },
@@ -271,7 +305,8 @@ describe('assistant', () => {
                 fieldName: 'metadata1',
                 fieldValue: 'value1',
                 instructions:
-                  'Do not use this in stream selectors, use this with a pipe filter: `| fieldName="fieldValue"`',
+                  'Do not use this in stream selectors, use this with a pipe filter: `| fieldName operator "fieldValue"`',
+                operator: '=',
               },
               hidden: true,
               title: 'Structured metadata filters',
@@ -284,9 +319,10 @@ describe('assistant', () => {
               data: {
                 datasourceUid: 'loki-uid-123',
                 fieldName: 'metadata2',
-                fieldValue: '!=value2',
+                fieldValue: 'value2',
                 instructions:
-                  'Do not use this in stream selectors, use this with a pipe filter: `| fieldName="fieldValue"`',
+                  'Do not use this in stream selectors, use this with a pipe filter: `| fieldName operator "fieldValue"`',
+                operator: '!=',
               },
               hidden: true,
               title: 'Structured metadata filters',
@@ -300,6 +336,7 @@ describe('assistant', () => {
                 datasourceUid: 'loki-uid-123',
                 fieldName: 'field1',
                 fieldValue: 'value1',
+                operator: '=',
                 parser: 'logfmt',
               },
               hidden: true,
@@ -313,7 +350,8 @@ describe('assistant', () => {
               data: {
                 datasourceUid: 'loki-uid-123',
                 fieldName: 'field2',
-                fieldValue: '!=value2',
+                fieldValue: 'value2',
+                operator: '!=',
                 parser: 'json',
               },
               hidden: true,
@@ -321,6 +359,7 @@ describe('assistant', () => {
             },
           },
         },
+        expectedQueryContext,
       ]);
     });
   });

--- a/src/services/assistant.test.ts
+++ b/src/services/assistant.test.ts
@@ -43,7 +43,7 @@ describe('assistant', () => {
     type: 'loki',
   };
 
-  // The expected shape of the query context item appended to every non-empty context
+  // The expected shape of the query context item appended whenever a datasource resolves, even with no filters
   const expectedQueryContext = {
     node: {
       data: {

--- a/src/services/assistant.ts
+++ b/src/services/assistant.ts
@@ -1,9 +1,9 @@
 import { createAssistantContextItem, providePageContext, provideQuestions } from '@grafana/assistant';
 import { t } from '@grafana/i18n';
-import { SceneObject } from '@grafana/scenes';
+import { sceneGraph, SceneObject } from '@grafana/scenes';
 
-import { FilterOp } from './filterTypes';
 import { PLUGIN_BASE_URL } from './plugin';
+import { interpolateExpression } from './query';
 import { getLokiDatasource } from './scenes';
 import {
   getFieldsVariable,
@@ -12,7 +12,7 @@ import {
   getMetadataVariable,
   getValueFromFieldsFilter,
 } from './variableGetters';
-import { stripAdHocFilterUserInputPrefix } from './variables';
+import { LOG_STREAM_SELECTOR_EXPR, stripAdHocFilterUserInputPrefix } from './variables';
 
 export const updateAssistantContext = async (
   model: SceneObject,
@@ -38,7 +38,8 @@ export const updateAssistantContext = async (
         createAssistantContextItem('label_value', {
           datasourceUid: ds.uid,
           labelName: filter.key,
-          labelValue: `${inequalityPrefix(filter.operator)}${stripAdHocFilterUserInputPrefix(filter.value)}`,
+          labelValue: stripAdHocFilterUserInputPrefix(filter.value),
+          operator: filter.operator,
         })
       )
     );
@@ -52,6 +53,7 @@ export const updateAssistantContext = async (
           datasourceUid: ds.uid,
           labelName: filter.key,
           labelValue: filter.value,
+          operator: filter.operator,
         })
       )
     );
@@ -70,9 +72,10 @@ export const updateAssistantContext = async (
           data: {
             datasourceUid: ds.uid,
             fieldName: filter.key,
-            fieldValue: `${inequalityPrefix(filter.operator)}${stripAdHocFilterUserInputPrefix(filter.value)}`,
+            fieldValue: stripAdHocFilterUserInputPrefix(filter.value),
+            operator: filter.operator,
             instructions:
-              'Do not use this in stream selectors, use this with a pipe filter: `| fieldName="fieldValue"`',
+              'Do not use this in stream selectors, use this with a pipe filter: `| fieldName operator "fieldValue"`',
           },
         });
       })
@@ -91,19 +94,37 @@ export const updateAssistantContext = async (
             datasourceUid: ds.uid,
             fieldName: filter.key,
             parser: parsedFilter.parser,
-            fieldValue: `${inequalityPrefix(filter.operator)}${stripAdHocFilterUserInputPrefix(parsedFilter.value)}`,
+            fieldValue: stripAdHocFilterUserInputPrefix(parsedFilter.value),
+            operator: filter.operator,
           },
         });
       })
     );
   }
 
+  // No assistant context types exist for time range, line filters, or patterns — ship the rendered query and window instead.
+  const timeRange = sceneGraph.getTimeRange(model).state.value;
+  contexts.push(
+    createAssistantContextItem('structured', {
+      title: t(
+        'services.update-assistant-context.title.current-logs-query-and-time-range',
+        'Current logs query and time range'
+      ),
+      hidden: true,
+      bypassLimits: true,
+      data: {
+        datasourceUid: ds.uid,
+        logqlQuery: interpolateExpression(model, LOG_STREAM_SELECTOR_EXPR),
+        timeRangeFromMs: timeRange.from.valueOf(),
+        timeRangeToMs: timeRange.to.valueOf(),
+        instructions:
+          'The exact LogQL query and time range for the logs the user is currently viewing in Logs Drilldown. timeRangeFromMs/timeRangeToMs are unix millisecond timestamps — pass them directly as the start/end parameters of Loki tools without converting them. Prefer this query and time range when reading, querying, or summarizing the logs.',
+      },
+    })
+  );
+
   setAssistantContext(contexts);
 };
-
-function inequalityPrefix(operator: string) {
-  return operator !== FilterOp.Equal ? operator : '';
-}
 
 export function provideServiceSelectionQuestions() {
   return provideQuestions(`${PLUGIN_BASE_URL}/**`, [


### PR DESCRIPTION
## Summary 📝

- Fixes assistant context provisioning: filter operators are passed on context items instead of encoded into values, initial context is registered on activation (not after the first filter change), metadata/line-filter/pattern/time-range changes now refresh the context, and `assistantInitialized` resets on deactivation so the pathname-cached scene re-registers.
- Adds a hidden "Current logs query and time range" context item carrying the fully rendered LogQL and unix-ms window — shaped 1:1 to the assistant's Loki tool `query`/`start`/`end` params, with instructions to pass the timestamps through without converting.
- Bumps `@grafana/assistant` 0.1.25 → 0.1.33.

## Test 🧪

### Run it locally

1. Run local core Grafana with a plugin path that includes this plugin's `dist/` **and** a `grafana-assistant-app` checkout, with the assistant feature toggles and unsigned-plugin allowance in your `custom.ini`, plus assistant provisioning (`conf/provisioning/plugins/assistant.yaml` → `backendUrl: http://localhost:9091`).
2. In `grafana-assistant-app`: build the plugin backend (`cd apps/plugin && mage -v`), start the API stack (`docker compose --env-file .env up db api nats` — `.env` needs `ANTHROPIC_API_KEY`), and run the plugin frontend watch (`pnpm --filter @grafana/assistant-plugin run dev`).
3. In this repo: `pnpm dev`, and `docker compose -f docker-compose.local.yaml up -d loki generator` for test data.
4. Start Grafana with `GF_PLUGINS_FORWARD_HOST_ENV_VARS=grafana-assistant-app GF_DEFAULT_APP_MODE=development make run` (plus the frontend build).
5. Sanity check: `curl -su admin:admin localhost:3000/api/plugins/grafana-assistant-app/settings` — the version must match `apps/plugin/dist/plugin.json` (a stale assistant build elsewhere in the scan path can shadow it).

To inspect what actually reaches the assistant, watch the `messages?audience=user` POST in DevTools → Network — `contextItems` is the ground truth (chips only show non-hidden items).

### Scenarios to verify

- **Initial context:** load a drilldown logs page fresh, open the assistant, start a new conversation — filter chips appear without touching any filter.
- **Operators:** add `!=`/`=~` label filters, an excluded level, a metadata exclude (e.g. `pod != …`), and a fields exclude — each arrives with a clean value plus a separate `operator` field (metadata/fields items are hidden; check the payload).
- **Subscriptions:** mid-conversation, include a pattern, add/remove a line filter, and change the time range — the "Current logs query and time range" item tracks each change (`|>` stage appears, window updates).
- **Re-registration:** navigate to another app and back to drilldown, open the assistant — context is present and current (pre-fix, the pathname-cached scene stopped registering).
- **Panel action:** "Explain in Assistant" on the logs/volume panels — the data summary reflects the visible window, not the last hour; asking "what's the time range for this query" should answer from context without epoch→ISO conversion in the thinking trace.

Dev 
Here you can see !=dev-eu-west
<img width="1896" height="933" alt="Screenshot 2026-08-05 at 9 42 58 AM" src="https://github.com/user-attachments/assets/ede2bfc2-0c10-4447-a658-a2822245d22a" />

Updated 
Here the operator != is sent automatically instead of parsded
<img width="1916" height="919" alt="Screenshot 2026-08-05 at 2 41 11 PM" src="https://github.com/user-attachments/assets/b33c2343-c8fa-4201-a431-78a664768c5c" />
