### PR TITLE
fix(InterceptBanner): add padding around the message

### DIFF
--- a/src/Components/IndexScene/InterceptBanner.tsx
+++ b/src/Components/IndexScene/InterceptBanner.tsx
@@ -9,7 +9,7 @@ import { Alert, useStyles2 } from '@grafana/ui';
 export function InterceptBanner(props: { onRemove: () => void }) {
   const styles = useStyles2(getStyles);
   return (
-    <>
+    <div className={styles.bannerContainer}>
       <Alert
         className={styles.alert}
         severity={'info'}
@@ -57,7 +57,7 @@ export function InterceptBanner(props: { onRemove: () => void }) {
           </Trans>
         </div>
       </Alert>
-    </>
+    </div>
   );
 }
 
@@ -65,6 +65,9 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     alert: css({
       flex: 'none',
+    }),
+    bannerContainer: css({
+      padding: theme.spacing(2, 2, 0, 2),
     }),
   };
 }


### PR DESCRIPTION
<img width="1156" height="343" alt="imagen" src="https://github.com/user-attachments/assets/2ff39c9e-3bcd-4e9b-883c-07683f4f8cdf" />

Closes https://github.com/grafana/logs-drilldown/issues/1197