### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-router-dom: 7.18.1
+  react-router-dom: 7.18.2
   uuid: 14.0.1
   immutable: 5.1.8
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   serialize-javascript: 7.0.6
   strip-ansi: 6.0.1
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   fast-uri: 3.1.5
   undici: 8.9.0
   protobufjs: 8.6.5
@@ -29,6 +29,7 @@ overrides:
   webpack: 5.108.1
   websocket-driver@<0.7.5: 0.7.5
   postcss@<8.5.18: 8.5.23
+  nanoid: 3.3.17
 
 importers:
   .:
@@ -41,7 +42,7 @@ importers:
         version: 11.13.5
       '@grafana/api-clients':
         specifier: 13.1.0
-        version: 13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(rxjs@7.8.2)
+        version: 13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1))(rxjs@7.8.2)
       '@grafana/assistant':
         specifier: 0.1.33
         version: 0.1.33(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)
@@ -65,10 +66,10 @@ importers:
         version: 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/scenes':
         specifier: 8.9.0
-        version: 8.9.0(b72f94879edc7e237defca91dac3f5e3)
+        version: 8.9.0(7d6ef6a06bff44a03ef27bade8c7a063)
       '@grafana/scenes-react':
         specifier: 8.9.0
-        version: 8.9.0(b72f94879edc7e237defca91dac3f5e3)
+        version: 8.9.0(7d6ef6a06bff44a03ef27bade8c7a063)
       '@grafana/schema':
         specifier: 13.1.0
         version: 13.1.0
@@ -118,8 +119,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: 7.18.1
-        version: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.18.2
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table:
         specifier: 7.8.0
         version: 7.8.0(react@18.3.1)
@@ -1346,7 +1347,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 7.18.1
+      react-router-dom: 7.18.2
       rxjs: ^7.8.1
 
   '@grafana/scenes@8.9.0':
@@ -1361,7 +1362,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 7.18.1
+      react-router-dom: 7.18.2
       rxjs: ^7.8.1
 
   '@grafana/schema@13.1.0':
@@ -4231,9 +4232,9 @@ packages:
     resolution:
       { integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA== }
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     resolution:
-      { integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg== }
+      { integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ== }
 
   dot-prop@5.3.0:
     resolution:
@@ -5730,9 +5731,9 @@ packages:
     resolution:
       { integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ== }
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     resolution:
-      { integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q== }
+      { integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ== }
     hasBin: true
 
   jsdoc-type-pratt-parser@4.1.0:
@@ -6148,9 +6149,9 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.16:
+  nanoid@3.3.17:
     resolution:
-      { integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q== }
+      { integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g== }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
@@ -6828,11 +6829,11 @@ packages:
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
-      react-router-dom: 7.18.1
+      react-router-dom: 7.18.2
 
-  react-router-dom@7.18.1:
+  react-router-dom@7.18.2:
     resolution:
-      { integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg== }
+      { integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw== }
     engines: { node: '>=20.0.0' }
     peerDependencies:
       react: '>=18'
@@ -6845,9 +6846,9 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  react-router@7.18.1:
+  react-router@7.18.2:
     resolution:
-      { integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg== }
+      { integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg== }
     engines: { node: '>=20.0.0' }
     peerDependencies:
       react: '>=18'
@@ -9148,7 +9149,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9220,10 +9221,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@grafana/api-clients@13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(rxjs@7.8.2)':
+  '@grafana/api-clients@13.1.0(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1))(rxjs@7.8.2)':
     dependencies:
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      '@reduxjs/toolkit': 2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1)
       rxjs: 7.8.2
 
   '@grafana/assistant@0.1.33(@emotion/css@11.13.5)(@grafana/data@13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/runtime@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@grafana/schema@13.1.0)(@grafana/ui@13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)(rxjs@7.8.2)':
@@ -9249,7 +9250,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       eventemitter3: 5.0.1
       history: 4.10.1
       lodash: 4.18.1
@@ -9451,21 +9452,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@grafana/scenes-react@8.9.0(b72f94879edc7e237defca91dac3f5e3)':
+  '@grafana/scenes-react@8.9.0(7d6ef6a06bff44a03ef27bade8c7a063)':
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
       '@grafana/data': 13.1.0(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/e2e-selectors': 13.1.0
       '@grafana/runtime': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@grafana/scenes': 8.9.0(b72f94879edc7e237defca91dac3f5e3)
+      '@grafana/scenes': 8.9.0(7d6ef6a06bff44a03ef27bade8c7a063)
       '@grafana/schema': 13.1.0
       '@grafana/ui': 13.1.0(@babel/runtime@7.29.2)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       lodash: 4.18.1
       lru-cache: 10.4.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs: 7.8.2
     transitivePeerDependencies:
@@ -9473,7 +9474,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@grafana/scenes@8.9.0(b72f94879edc7e237defca91dac3f5e3)':
+  '@grafana/scenes@8.9.0(7d6ef6a06bff44a03ef27bade8c7a063)':
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
@@ -9491,7 +9492,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-grid-layout: 1.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer: 1.0.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9562,8 +9563,8 @@ snapshots:
       react-hook-form: 7.72.1(react@18.3.1)
       react-inlinesvg: 4.3.0(react@18.3.1)
       react-loading-skeleton: 3.5.0(react@18.3.1)
-      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom-v5-compat: 6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom-v5-compat: 6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table: 7.8.0(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9790,7 +9791,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -10596,7 +10597,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+  '@reduxjs/toolkit@2.10.1(react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1))(react@18.3.1)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -10606,7 +10607,7 @@ snapshots:
       reselect: 5.2.0
     optionalDependencies:
       react: 18.3.1
-      react-redux: 9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1)
+      react-redux: 9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1)
 
   '@remix-run/router@1.23.3': {}
 
@@ -11842,14 +11843,14 @@ snapshots:
   cosmiconfig@8.0.0:
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
 
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -11859,7 +11860,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -12124,7 +12125,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -13763,7 +13764,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -14051,7 +14052,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.6
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -14342,7 +14343,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14573,6 +14574,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       redux: 4.2.1
 
+  react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      redux: 4.2.1
+    optional: true
+
   react-redux@9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
@@ -14589,27 +14600,27 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom-v5-compat@6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  react-router-dom-v5-compat@6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.3
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.4(react@18.3.1)
-      react-router-dom: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   react-router@6.30.4(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.3
       react: 18.3.1
 
-  react-router@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cookie: 1.1.1
       react: 18.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,15 +15,20 @@ overrides:
   # react-router itself is deliberately not overridden. The 6.30.4 copy comes from
   # @grafana/ui -> react-router-dom-v5-compat@6.30.4, which imports UNSAFE_useRoutesImpl,
   # UNSAFE_useRouteId and UNSAFE_logV6DeprecationWarnings — none of which react-router 7
-  # exports. The 7.x advisory is only patched in 8.3.0, which requires React >= 19.2.7
-  # (this plugin is on 18.3.1). Both need an upstream bump, not an override here.
-  react-router-dom: 7.18.1
+  # exports. A bare `react-router` override would collapse both majors onto 7.x and break
+  # @grafana/ui at runtime.
+  # The 7.x advisory (GHSA-qwww-vcr4-c8h2, <7.18.2) is fixed below: react-router-dom@7.18.2
+  # pins react-router 7.18.2 exactly, so the core fix arrives transitively.
+  # Still flagged: GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg (>=6.0.0 <7.18.0) match the
+  # 6.30.4 copy. The react-router 6.x line ends at 6.30.4 — there is no 6.x patch, so this
+  # needs an upstream @grafana/ui bump off v5-compat, not an override here.
+  react-router-dom: 7.18.2
   uuid: 14.0.1
   immutable: 5.1.8
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   serialize-javascript: 7.0.6
   strip-ansi: 6.0.1
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   # Security patches for transitive vulnerabilities (pnpm audit)
   fast-uri: 3.1.5
   undici: 8.9.0
@@ -46,3 +51,4 @@ overrides:
   webpack: 5.108.1
   'websocket-driver@<0.7.5': 0.7.5
   'postcss@<8.5.18': 8.5.23
+  nanoid: 3.3.17


### PR DESCRIPTION
## Summary

Updates pnpm overrides in `pnpm-workspace.yaml` to resolve `pnpm audit` findings.

`pnpm audit`: **6 vulnerabilities (3 high, 3 moderate) → 2 (2 moderate)**

| Package | Before | After | Advisory |
| --- | --- | --- | --- |
| `react-router-dom` | 7.18.1 | 7.18.2 | GHSA-qwww-vcr4-c8h2 (high) |
| `js-yaml` | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (high) |
| `nanoid` | 3.3.16 | 3.3.17 (new override) | GHSA-2v37-7h3g-55p8 (high) |
| `dompurify` | 3.4.12 | 3.4.13 | GHSA-55q2-fjhq-7xh7 (moderate) |

### On react-router

`react-router` is still **not** overridden directly, per the existing note. The tree
holds two majors — `6.30.4` (from `@grafana/ui` → `react-router-dom-v5-compat`) and the
7.x line — so a bare `react-router` key would collapse both onto 7.x and break
`@grafana/ui`, which imports `UNSAFE_useRoutesImpl`, `UNSAFE_useRouteId` and
`UNSAFE_logV6DeprecationWarnings` (none exported by v7).

The high advisory is instead cleared transitively: `react-router-dom@7.18.2` pins
`react-router: 7.18.2` exactly. Verified post-install that **both** `react-router@6.30.4`
and `react-router@7.18.2` are still present, so the v5-compat path is intact.

The in-file comment claiming the 7.x advisory is "only patched in 8.3.0, which requires
React >= 19.2.7" was **out of date** and has been corrected: `react-router-dom@7.18.2`
peers `react >=18` and installs fine on this plugin's React 18.3.1.

## Known remaining (no installable patch)

- **GHSA-wrjc-x8rr-h8h6** and **GHSA-337j-9hxr-rhxg** (`react-router`, moderate) — both
  cover `>=6.0.0 <7.18.0`, matching only the `6.30.4` copy. The `react-router` 6.x line
  ends at **6.30.4** (the flagged version; `npm view react-router versions` confirms no
  6.30.5+), and `react-router-dom@6.30.5` was never published. There is no 6.x patch to
  override to, and forcing v7 breaks `@grafana/ui`. Requires an upstream `@grafana/ui`
  bump off `react-router-dom-v5-compat`.

No audit suppressions were added.

## Test plan

- [x] `pnpm install --no-frozen-lockfile` succeeds (no supply-chain settings disabled)
- [x] `pnpm audit` — 6 → 2, only the unfixable react-router 6.x moderates remain
- [x] `pnpm run typecheck` passes
- [x] Verified resolved versions in `node_modules/.pnpm/`: `react-router@6.30.4` **and** `react-router@7.18.2`, `js-yaml@4.3.1`, `dompurify@3.4.13`, `nanoid@3.3.17`