### PR TITLE
docs: document recent UI changes and standardize product name usage

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -23,7 +23,7 @@ cards:
       height: 24
     - title: Get started
       href: ./get-started/
-      description: Install Grafana Logs Drilldown and take a tour of Grafana Logs Drilldown using your own data.
+      description: Install Grafana Logs Drilldown and take a tour of Logs Drilldown using your own data.
       height: 24
     - title: Learn about Labels and Fields
       href: ./labels-and-fields/
@@ -53,7 +53,7 @@ Welcome to our new experience for Loki. Grafana Logs Drilldown lets you automati
 
 {{< docs/learning-journeys title="Explore logs using Logs Drilldown" url="https://grafana.com/docs/learning-journeys/drilldown-logs/" >}}
 
-Using Grafana Logs Drilldown you can:
+Using Logs Drilldown you can:
 
 - Easily find logs and log volumes for all of your services.
 - Effortlessly filter logs based on their labels, fields, or patterns.
@@ -67,11 +67,11 @@ Using Grafana Logs Drilldown you can:
 
 ## Who is Grafana Logs Drilldown for?
 
-Grafana Logs Drilldown is for engineers of all levels of operational expertise. You no longer need to be an SRE wizard to get value from your logs.
+Logs Drilldown is for engineers of all levels of operational expertise. You no longer need to be an SRE wizard to get value from your logs.
 
 Traditionally, you'd need a deep understanding of your systems and Loki's query language, LogQL, in order to get the most out of Loki.
 
-With Grafana Logs Drilldown, you get the same powerful insights, by just viewing and clicking in visualizations which are automatically generated from your log data.
+With Logs Drilldown, you get the same powerful insights, by just viewing and clicking in visualizations which are automatically generated from your log data.
 
 ## Explore
 
@@ -79,10 +79,10 @@ With Grafana Logs Drilldown, you get the same powerful insights, by just viewing
 
 ## Share your feedback
 
-Use the **Give feedback** link on each Grafana Logs Drilldown page to share your thoughts with the team building Grafana Logs Drilldown.
+Use the **Give feedback** link on each Logs Drilldown page to share your thoughts with the team building Logs Drilldown.
 
-You can also fill out [this Google form](https://forms.gle/1sYWCTPvD72T1dPH9) to send your thoughts directly to the team building Grafana Logs Drilldown.
+You can also fill out [this Google form](https://forms.gle/1sYWCTPvD72T1dPH9) to send your thoughts directly to the team building Logs Drilldown.
 
 ## What's next?
 
-Dive into [Get started with Grafana Logs Drilldown](get-started/) to learn how to set up Grafana Logs Drilldown and take a tour of the feature using your own data.
+Dive into [Get started with Grafana Logs Drilldown](get-started/) to learn how to set up Logs Drilldown and take a tour of the feature using your own data.

--- a/docs/sources/access/_index.md
+++ b/docs/sources/access/_index.md
@@ -19,7 +19,7 @@ To use Grafana Logs Drilldown to view your log data, you can either access it in
 
 ## Access in Grafana and Grafana Cloud
 
-Grafana Logs Drilldown is installed by default in both Grafana and Grafana Cloud. To access Grafana Logs Drilldown:
+Logs Drilldown is installed by default in both Grafana and Grafana Cloud. To access Logs Drilldown:
 
 1. Open your Grafana stack in a web browser.
 1. In the main menu, select **Drilldown** > **Logs**.
@@ -32,7 +32,7 @@ Logs Drilldown is installed by default in current Grafana releases. If you are u
 
 ### Install via Plugins catalog
 
-For Enterprise and OSS Grafana users, you can install Grafana Logs Drilldown via the [Grafana Plugins catalog](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/).
+For Enterprise and OSS Grafana users, you can install Logs Drilldown via the [Grafana Plugins catalog](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/).
 
 1. Open [https://grafana.com/grafana/plugins/grafana-lokiexplore-app/](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/) in a web browser
 1. Click the **Installation** tab.
@@ -72,7 +72,7 @@ GF_INSTALL_PLUGINS="https://storage.googleapis.com/integration-artifacts/grafana
 
 ### Install using Grafana CLI
 
-You can install Grafana Logs Drilldown in your own Grafana instance using the Grafana CLI. For more information, refer to the [Grafana CLI documentation](https://grafana.com/docs/grafana/latest/cli/).
+You can install Logs Drilldown in your own Grafana instance using the Grafana CLI. For more information, refer to the [Grafana CLI documentation](https://grafana.com/docs/grafana/latest/cli/).
 
 Run the following command:
 
@@ -86,7 +86,7 @@ All the Grafana Drilldown apps require the `datasources:explore` permission in G
 
 ## Test with Docker Compose
 
-You can test the app using the following command to spin up Grafana, Loki, and the Grafana Logs Drilldown App:
+You can test the app using the following command to spin up Grafana, Loki, and the Logs Drilldown App:
 
 ```sh
 curl -L https://github.com/grafana/explore-logs/raw/main/scripts/run.sh | sh
@@ -96,7 +96,7 @@ This will download the [run.sh](https://github.com/grafana/explore-logs/blob/mai
 
 That shell file will download some configuration files into your `/tmp/explore-logs` directory and start the Docker containers via `docker compose` from there.
 
-Once the Docker container has started, navigate to `http://localhost:3000/a/grafana-lokiexplore-app/explore` to access Grafana Logs Drilldown.
+Once the Docker container has started, navigate to `http://localhost:3000/a/grafana-lokiexplore-app/explore` to access Logs Drilldown.
 
 ## Having trouble?
 
@@ -104,7 +104,7 @@ Refer to the [troubleshooting guide](../troubleshooting/) for tips on how to sol
 
 ## What next?
 
-Before you can use Grafana Logs Drilldown, an administrator must configure a Loki data source in order to access your logs in Grafana Logs Drilldown.
+Before you can use Logs Drilldown, an administrator must configure a Loki data source in order to access your logs in Logs Drilldown.
 Refer to the [Loki data source documentation](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/loki/) for instructions.
 
 After installing, you can customize default settings such as time range, data source, and display fields. Refer to [Configure Logs Drilldown](./configure/) for details.

--- a/docs/sources/access/configure.md
+++ b/docs/sources/access/configure.md
@@ -51,7 +51,7 @@ The **Configuration** tab has four settings, all aimed at an administrator setti
 
 To view the **Configuration** tab:
 
-1. Open the Grafana Logs Drilldown app's settings by navigating to **Administration** > **Plugins and data** > **Plugins** > **Grafana Logs Drilldown**.
+1. Open the Logs Drilldown app's settings by navigating to **Administration** > **Plugins and data** > **Plugins** > **Grafana Logs Drilldown**.
 1. Select the **Configuration** tab.
 
 {{< admonition type="note" >}}
@@ -81,6 +81,8 @@ Default fields requires Grafana 12.4 or later. If this version requirement is no
 ### How Default fields work
 
 Default field rules are scoped to a specific data source and one or more label and value pairs. When a user views logs for a service that matches all configured labels in a rule, the specified fields are displayed by default in the logs table view. The configured fields can replace the full log line or be displayed next to it.
+
+When a rule stores multiple values for the same label, those values are matched as a regular expression, so a rule can apply to several label values at once.
 
 ### Configure Default fields
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -14,7 +14,7 @@ weight: 300
 # Get started with Grafana Logs Drilldown
 
 The best way to see what Grafana Logs Drilldown can do for you is to use it to explore your own log data.
-If you have a Grafana Cloud account, you can access Grafana Logs Drilldown by selecting **Drilldown** > **Logs**, or you can [install Grafana Logs Drilldown](../access/) in your own Grafana instance.
+If you have a Grafana Cloud account, you can access Logs Drilldown by selecting **Drilldown** > **Logs**, or you can [install Logs Drilldown](../access/) in your own Grafana instance.
 
 <!-- Comment - NEEDS TO BE REPLACED WITH UPDATED VIDEO
 To learn more, check out our overview video:
@@ -23,13 +23,13 @@ To learn more, check out our overview video:
 
 ## Guided tour
 
-While you are browsing your log data in Grafana Logs Drilldown, watch for any unexpected spikes in your logs. Or perhaps one of your services is down and has stopped logging. Maybe you're seeing an increase in errors after a recent release.
+While you are browsing your log data in Logs Drilldown, watch for any unexpected spikes in your logs. Or perhaps one of your services is down and has stopped logging. Maybe you're seeing an increase in errors after a recent release.
 
 <!-- Make updating the screenshots easier by putting the Logs Drilldown version in the file name. This lets everyone know the last time the screenshots were updated.-->
 
 {{< figure alt="Grafana Logs Drilldown Service overview page" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-overview.png" caption="Overview page" >}}
 
-To take a tour of Grafana Logs Drilldown, follow these steps:
+To take a tour of Logs Drilldown, follow these steps:
 
 1. Open your Grafana stack in a web browser.
 1. From the Grafana main menu, select **Drilldown** > **Logs**.
@@ -39,6 +39,13 @@ To take a tour of Grafana Logs Drilldown, follow these steps:
    - With the standard time range picker on the top right.
    - By clicking and dragging the time range on any time series visualization.
 1. Services are shown based on log volume. You can use the service search field to find a service by name.
+1. Each service panel shows a preview of recent log lines. Click a log line to open its menu, where you can:
+   - **Show context**: View the log line in the context of the logs that occurred before and after it.
+   - **Go to log line**: Open the service details page focused on that specific log line.
+   - **Show similar logs**: Open the service details page filtered to log lines like the one you selected.
+
+   You can also click a value in a preview log line to add it as a line filter and open the service details page with that filter applied.
+
 1. If you want to view services by label instead of by service name, click **(+) Add label** and either select a label from the menu or search for a label.
 
    {{< admonition type="tip" >}}
@@ -59,11 +66,11 @@ To take a tour of Grafana Logs Drilldown, follow these steps:
    - Use line wrapping controls to adapt the log display for easier reading, choosing between disabled, enabled, and enabled with JSON formatting.
 1. On the service details page, click the **Labels** tab to see visualizations of log volume for each label. ([No labels?](../troubleshooting/#there-are-no-labels))
 1. On the **Labels** tab, to select a label to see the log volume for each value of that label, click the **Select** button.
-   Grafana Logs Drilldown shows you the volume of logs with specific labels and fields. Refer to [Labels and Fields](../labels-and-fields/).
+   Logs Drilldown shows you the volume of logs with specific labels and fields. Refer to [Labels and Fields](../labels-and-fields/).
 1. Select the **Fields** tab to see visualizations of log volume for each field. To drill down into details the same way as labels, click **Select** for a field.
 1. Click the **Patterns** tab to see log volume for each automatically detected pattern.
    Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful. Refer to [Log Patterns](../patterns/).
-1. Click the **Logs** tab. Click the menu icon (three vertical dots) on either panel and select **Explore**. Grafana displays the Explore page, with a query based on the selections you made in Logs Drilldown.
+1. Click the **Logs** tab. Click the menu icon (three vertical dots) on either panel to open the panel menu, then select **Explore**. Grafana displays the Explore page, with a query based on the selections you made in Logs Drilldown. The panel menu also includes options such as **Add to Dashboard** and **Create alert**. For details, refer to [View logs](../view-logs/#panel-menu).
 
 ## Further resources
 

--- a/docs/sources/labels-and-fields/_index.md
+++ b/docs/sources/labels-and-fields/_index.md
@@ -19,7 +19,7 @@ Grafana Logs Drilldown visualizes log volume for labels attached to your log lin
 The type of data being expressed in a label or field may require different treatments. For example, fields expressing `bytes` are visualized differently than other types of data. [Share your feedback](https://forms.gle/1sYWCTPvD72T1dPH9) if you have suggestions for how to improve this experience.
 {{< /admonition >}}
 
-Grafana Logs Drilldown adds a special `detected_level` label to all log lines where Loki assigns a level of the log line, including `debug`, `info`, `warn`, `error`, `fatal`, `critical`, `trace`, or `unknown` if no level could be determined.
+Logs Drilldown adds a special `detected_level` label to all log lines where Loki assigns a level of the log line, including `debug`, `info`, `warn`, `error`, `fatal`, `critical`, `trace`, or `unknown` if no level could be determined.
 
 Label visualizations are helpful for:
 
@@ -49,7 +49,7 @@ Labels tab user interface:
 - **Label** filter: Lets you search for or select label names from the menu.
 - **Grid / Rows**: Lets you select how labels are displayed.
 - **Select** or **Include** button: Click to access a breakdown of the label's values, seeing the log volumes visualized along the way.
-- **Menu** (three dots): Click to navigate to [Grafana Explore](https://grafana.com/docs/grafana-cloud/visualizations/explore/).
+- **Menu** (three dots): Opens the panel menu, where you can navigate to [Grafana Explore](https://grafana.com/docs/grafana-cloud/visualizations/explore/) and access other options. For details, refer to [View logs](../view-logs/#panel-menu).
 
 ## Filtering logs by label
 
@@ -81,9 +81,10 @@ Fields tab user interface:
 - **Field** filter: Lets you search for or select field names from the menu.
 - **Grid / Rows**: Lets you select how fields are displayed.
 - **Volume / Names**: Lets you toggle between showing field volume graphs and showing field names only.
+- **Extract fields from logs**: Toggle on to apply logfmt and JSON parsers to your queries so that fields detected in the log lines appear alongside indexed labels and structured metadata.
 - **Include** or **Add to filter** button: Lets you filter log results by a specific field value. The button label varies depending on the field type.
 - **Select** button (value breakdown): Click to access a breakdown of the field's values, seeing the log volumes visualized along the way.
-- **Menu** (three dots): Click to navigate to [Grafana Explore](https://grafana.com/docs/grafana-cloud/visualizations/explore/).
+- **Menu** (three dots): Opens the panel menu, where you can navigate to [Grafana Explore](https://grafana.com/docs/grafana-cloud/visualizations/explore/) and access other options. For details, refer to [View logs](../view-logs/#panel-menu).
 
 ## Filtering logs by field
 

--- a/docs/sources/patterns/_index.md
+++ b/docs/sources/patterns/_index.md
@@ -99,7 +99,7 @@ You can follow these steps to perform some common use cases using your own insta
 
 ### Browse log volumes by type
 
-Grafana Logs Drilldown proactively visualizes your log volume data per detected pattern, broken down in various ways. At a glance you can immediately spot spikes or other changes.
+Logs Drilldown proactively visualizes your log volume data per detected pattern, broken down in various ways. At a glance you can immediately spot spikes or other changes.
 
 For example, if your HTTP service is suffering from a DDoS attack, the relevant graphs will clearly show the spikes. From here you can drill down to discover enough details about the attack to counter it.
 

--- a/docs/sources/shared/troubleshoot-logs-drilldown.md
+++ b/docs/sources/shared/troubleshoot-logs-drilldown.md
@@ -18,13 +18,13 @@ This page addresses common issues when getting started and using Grafana Logs Dr
 
 Grafana Explore Logs is installed by default in Grafana versions v11.3.0 through v11.5.
 
-Grafana Logs Drilldown is installed by default in Grafana versions v11.6.11 and later.
+Logs Drilldown is installed by default in Grafana versions v11.6.11 and later.
 
 In Grafana v12 and later, the **Drilldown** menu includes all Drilldown apps by default.
 
 For more information about the name change for this feature, see this [blog post](https://grafana.com/blog/2025/02/20/grafana-drilldown-apps-the-improved-queryless-experience-formerly-known-as-the-explore-apps/).
 
-If you do not see Logs Drilldown under either name, then check to make sure you have the [Grafana Logs Drilldown plugin](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/) installed and configured.
+If you do not see Logs Drilldown under either name, then check to make sure you have the [Logs Drilldown plugin](https://grafana.com/grafana/plugins/grafana-lokiexplore-app/) installed and configured.
 
 {{< admonition type="note" >}}
 Your instance needs internet connection in order to download the Logs Drilldown plugin. If you are working in an offline environment, you can download the Logs Drilldown plugin separately and add it to your Grafana `/plugins` repository.
@@ -34,7 +34,7 @@ Check with your Grafana administrator. All the Grafana Drilldown apps require th
 
 ## Ensure Loki is properly configured
 
-To use Grafana Logs Drilldown, you need to have Loki properly configured. You can find full instructions in [Access or install Grafana Logs Drilldown](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/access/).
+To use Logs Drilldown, you need to have Loki properly configured. You can find full instructions in [Access or install Grafana Logs Drilldown](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/access/).
 
 ## Service selection errors
 
@@ -42,7 +42,7 @@ This section covers errors on the service selection page.
 
 ### There are no services
 
-If everything is presented as an `unknown_service` when you access Grafana Logs Drilldown, you can try the following fixes:
+If everything is presented as an `unknown_service` when you access Logs Drilldown, you can try the following fixes:
 
 1. Ensure the Volume API is enabled by setting the [`volume_enabled` configuration value](https://grafana.com/docs/loki/latest/configure/#:~:text=volume_enabled) in Loki. Enabled by default in Loki 3.1 and later.
 1. Specify the label to use to identify services by setting the [`discover_service_name` configuration value](https://grafana.com/docs/loki/latest/configure/#:~:text=discover_service_name) in Loki.
@@ -82,7 +82,7 @@ Try the following fixes:
 
 ## There are no detected levels
 
-If you do not see `detected_level` values in Grafana Logs Drilldown, you can try the following fixes:
+If you do not see `detected_level` values in Logs Drilldown, you can try the following fixes:
 
 1. Ensure level detection is enabled by setting the [`discover_log_levels` configuration value](https://grafana.com/docs/loki/latest/configure/#:~:text=discover_log_levels). Enabled by default in Loki 3.1 and later.
 
@@ -92,7 +92,7 @@ This section covers errors related to labels and fields in Logs Drilldown.
 
 ### There are no labels
 
-If you do not see any labels in Grafana Logs Drilldown, you can try the following fixes:
+If you do not see any labels in Logs Drilldown, you can try the following fixes:
 
 1. Ensure your collector is properly configured to attach them.
 

--- a/docs/sources/view-logs/_index.md
+++ b/docs/sources/view-logs/_index.md
@@ -8,38 +8,64 @@ weight: 500
 
 The logs visualization in Grafana Logs Drilldown displays log lines from your Loki data source with filtering options and controls to customize how data is displayed.
 
+A line filter search field appears at the top of the page. Enter text to filter your logs to lines that contain, or exclude, that text.
+
+## Visualization types
+
+On the **Logs** tab, use the radio buttons in the panel header to switch how your logs are displayed:
+
+- **Logs**: The default log line list, with the [log controls](#log-controls) and [log details](#log-details).
+- **Table**: Displays logs in a table with a column for each displayed field. You can add or remove columns, sort by a column, resize columns, and wrap text. Your column selection and sizes are remembered.
+- **JSON**: Opens the dedicated JSON viewer for logs formatted as JSON. For more information, refer to [Logs Drilldown JSON viewer](../viewing-json-logs/).
+
+{{< docs/public-preview product="the native logs table" featureFlag="logsTablePanelNG" >}}
+
+When the `logsTablePanelNG` feature flag is enabled, the **Table** view renders your logs using Grafana's native logs table panel.
+
 ## Log controls
 
 The controls component provides options to interact with and customize the log list. You can jump to the top or bottom, change sort order, filter by string or level, use deduplication, and choose display options such as timestamp format or color highlighting.
 
 From top to bottom, the log controls include:
 
-* **Expand/collapse controls**: Show or hide the full controls toolbar.
-* **Scroll to the bottom**: Jump to the last log line in the view.
-* **Sort direction**: Toggle between ascending (oldest logs first) or descending (newest logs first) order.
-* **Client-side string search**: Click to open or close client-side string search for displayed results.
-* **Deduplication**: Hide duplicate log lines using a few different deduplication algorithms.
-  * **None**: Disables deduplication.
-  * **Exact**: Matches on the whole line except for date fields.
-  * **Numbers**: Matches after stripping out numbers such as durations, IP addresses, and so on.
-  * **Signature**: The most aggressive deduplication as it strips all letters and numbers and matches on the remaining whitespace and punctuation.
-* **Filter logs by log level**: Filter logs by level, such as All levels, Info, Warn, and Error.
-* **Set timestamp format**: Hide timestamps, show millisecond timestamps, or show nanosecond timestamps.
-* **Line wrapping control**:
-  * **Disabled**: Log lines are truncated.
-  * **Enabled**: Log lines wrap to multiple lines.
-  * **Enabled with JSON formatting**: Pretty-prints JSON log lines.
-* **Logs highlighting**: Toggle between plain text and color highlighting.
-* **Font size control**: Toggle between small (default) and large font.
-* **Unescape newlines**: Displayed when logs contain escaped new lines. Click to render escaped new lines as new lines.
-* **Download logs**: Download in plain text (txt), JavaScript Object Notation (JSON), or Comma-separated values (CSV) format.
-* **Scroll to the top**: Jump to the first log line in the view.
+- **Expand/collapse controls**: Show or hide the full controls toolbar.
+- **Scroll to the bottom**: Jump to the last log line in the view.
+- **Sort direction**: Toggle between ascending (oldest logs first) or descending (newest logs first) order.
+- **Client-side string search**: Click to open or close client-side string search for displayed results.
+- **Deduplication**: Hide duplicate log lines using a few different deduplication algorithms.
+  - **None**: Disables deduplication.
+  - **Exact**: Matches on the whole line except for date fields.
+  - **Numbers**: Matches after stripping out numbers such as durations, IP addresses, and so on.
+  - **Signature**: The most aggressive deduplication as it strips all letters and numbers and matches on the remaining whitespace and punctuation.
+- **Filter logs by log level**: Filter logs by level, such as All levels, Info, Warn, and Error.
+- **Set timestamp format**: Hide timestamps, show millisecond timestamps, or show nanosecond timestamps.
+- **Line wrapping control**:
+  - **Disabled**: Log lines are truncated.
+  - **Enabled**: Log lines wrap to multiple lines.
+  - **Enabled with JSON formatting**: Pretty-prints JSON log lines.
+- **Logs highlighting**: Toggle between plain text and color highlighting.
+- **Font size control**: Toggle between small (default) and large font.
+- **Unescape newlines**: Displayed when logs contain escaped new lines. Click to render escaped new lines as new lines.
+- **Download logs**: Download in plain text (txt), JavaScript Object Notation (JSON), or Comma-separated values (CSV) format.
+- **Scroll to the top**: Jump to the first log line in the view.
 
 {{< admonition type="note" >}}
 When you are in [JSON view](../viewing-json-logs/), these controls are not available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
 {{< /admonition >}}
 
-## Log Details
+## Panel menu
+
+Most panels in Logs Drilldown have a menu that you open by clicking the menu icon (three vertical dots) in the panel header. The available options depend on the panel and your Grafana configuration:
+
+- **Explore**: Opens Grafana Explore with a query based on your current selections.
+- **Add to Dashboard**: Adds the panel to a new or existing dashboard.
+- **Create alert**: Creates an alert rule from the panel's query.
+- **Expand logs view** or **Condense logs view**: On the logs panel, toggles the logs list between fitting the available height and expanding to fill the screen.
+- **Explain in Assistant**: Sends the panel's query to Grafana Assistant for an explanation.
+
+Some options, such as **Add to Dashboard**, **Create alert**, and **Explain in Assistant**, appear only when the corresponding Grafana feature is available.
+
+## Log details
 
 The **Log details** component is displayed when you click a log line. It shows additional information from that log line in collapsible sections, including fields (usually key-value pairs) and links (derived fields, correlations, and more).
 
@@ -47,8 +73,8 @@ The **Log details** component is displayed when you click a log line. It shows a
 
 Within the Log details view, you have the ability to filter the displayed fields in two ways:
 
-* **Positive filter**: Focuses on a specific field
-* **Negative filter**: Excludes certain fields
+- **Positive filter**: Focuses on a specific field
+- **Negative filter**: Excludes certain fields
 
 These filters modify the corresponding query that generated the log line, incorporating equality and inequality expressions accordingly.
 
@@ -66,7 +92,7 @@ Grafana provides data links or correlations, allowing you to convert any part of
 
 ### Log details modes
 
-There are two modes available to view log details: 
+There are two modes available to view log details:
 
 - **Inline log details** display the log details below the log line within the log list.
 
@@ -77,6 +103,8 @@ No matter which display mode you are currently viewing, you can change it by cli
 ## Highlighting
 
 The logs visualization implements a predefined set of rules to apply subtle colors to the log lines, to help with readability and help with identifying important information faster. This is an optional feature that can be disabled in the controls or in the panel options.
+
+Log levels are also color-coded to help you scan for errors and warnings. For example, `debug` lines use a neutral gray and `info` lines use a neutral blue.
 
 ## Log Context
 

--- a/docs/sources/viewing-json-logs/_index.md
+++ b/docs/sources/viewing-json-logs/_index.md
@@ -12,7 +12,7 @@ weight: 800
 
 # Logs Drilldown JSON viewer
 
-You can easily view and interact with your JSON formatted logs using the Logs Drilldown JSON viewer. This view will help you read your JSON style logs, and filter through them to make your related visualizations more relevant and focused.
+You can easily view and interact with your JSON formatted logs using the Grafana Logs Drilldown JSON viewer. This view will help you read your JSON style logs, and filter through them to make your related visualizations more relevant and focused.
 
 {{< admonition type="note" >}}
 To use this feature, you must be running Loki 3.5.0 or later.


### PR DESCRIPTION
Updates the Logs Drilldown docs for user-facing changes shipped since the last docs update, plus a product-name cleanup.

- Document visualization types and the Table view, the panel menu, expand/condense logs view, Overview log-line actions, the Fields "Extract fields from logs" toggle, and Default fields regex matching. The native logs table is noted as public preview (`logsTablePanelNG`).
- Standardize product naming: full "Grafana Logs Drilldown" on first mention per page, short "Logs Drilldown" after.

**Documents these changes:**

- Table / native logs table visualization: #1752
- Logs panel fit-to-height / full screen: #1895, moved to panel menu in #1932
- Overview service-selection log-line actions and permalinks: #1940
- Line filter moved to the top: #1860
- Fields "Extract fields from logs" (optional parsers): #1975
- Default fields regex matching for multiple label values: #1997
- Refreshed level colors: #1990, #2021

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/logs-drilldown/blob/main/docs/genai.md))
