### PR TITLE
docs(table): add logs table and update logs panel docs with images

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -38,7 +38,7 @@ cards:
       description: Find solutions to common issues you might encounter when using Grafana Logs Drilldown.
       height: 24
     - title: Engage with your JSON log lines
-      href: ./viewing-json-logs/
+      href: ./view-logs/json/
       description: Drill down into your JSON log lines to better understand your log line data.
       height: 24
     - title: Give feedback

--- a/docs/sources/labels-and-fields/_index.md
+++ b/docs/sources/labels-and-fields/_index.md
@@ -31,7 +31,7 @@ Label visualizations are helpful for:
 You can click the **Select** button on a Label or Field graph to access a breakdown of its values, seeing the log volumes visualized along the way.
 This can be useful for understanding the traits of your system, and for spotting spikes or other changes.
 
-Click individual log lines to view the **Log Details** panel which displays fields and labels with filtering options. For more information about Log Details, refer to [View logs](../view-logs/).
+Click individual log lines to view the **Log Details** panel which displays fields and labels with filtering options. For more information about Log Details, refer to [View logs](../view-logs/#log-details).
 
 ## Labels tab user interface overview
 

--- a/docs/sources/patterns/_index.md
+++ b/docs/sources/patterns/_index.md
@@ -87,7 +87,7 @@ Patterns tab user interface:
 
 When you expand a pattern row to view log lines with that pattern, each row has a menu with the following options:
 
-- **Show/Hide log details**: Select from the menu for the individual log line to view the log line, index labels, parsed fields, and structured metadata. For more information, refer to [View logs](../view-logs/).
+- **Show/Hide log details**: Select from the menu for the individual log line to view the log line, index labels, parsed fields, and structured metadata. For more information, refer to [View logs](../view-logs/#log-details).
 - **Show context**: Select from the menu to view the log line in the context of the logs that occurred before and after that specific log.
 - **Copy log line**: Select from the menu to copy individual log lines to the clipboard.
 

--- a/docs/sources/view-logs/_index.md
+++ b/docs/sources/view-logs/_index.md
@@ -79,7 +79,9 @@ The menu includes the following options:
 
 ## Log details
 
-Log details show all the information attached to a single log line. To open log details, click a log line, or select **Show log details** from the log line menu.
+Log details show all the information attached to a single log line. 
+
+To open log details, lick a log line or select **Show log details** from the log line menu.
 
 {{< figure alt="The log details sidebar next to the log list, with the copy menu open and collapsible sections for the log line, links to tracing data sources, a trace, and indexed labels" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-logs-details-copy-menu.png" caption="Log details in sidebar mode" >}}
 

--- a/docs/sources/view-logs/_index.md
+++ b/docs/sources/view-logs/_index.md
@@ -14,13 +14,9 @@ A line filter search field appears at the top of the page. Enter text to filter 
 
 On the **Logs** tab, use the radio buttons in the panel header to switch how your logs are displayed:
 
-- **Logs**: The default log line list, with the [log controls](#log-controls) and [log details](#log-details).
-- **Table**: Displays logs in a table with a column for each displayed field. You can add or remove columns, sort by a column, resize columns, and wrap text. Your column selection and sizes are remembered.
-- **JSON**: Opens the dedicated JSON viewer for logs formatted as JSON. For more information, refer to [Logs Drilldown JSON viewer](../viewing-json-logs/).
-
-{{< docs/public-preview product="the native logs table" featureFlag="logsTablePanelNG" >}}
-
-When the `logsTablePanelNG` feature flag is enabled, the **Table** view renders your logs using Grafana's native logs table panel.
+- **Logs**: The default log line list, with the [log controls](#log-controls), the [log line menu](#log-line-menu), and [log details](#log-details), described on this page.
+- **Table**: Displays logs in a table with a column for each displayed field. You can add or remove columns, sort by a column, resize columns, and wrap text. For more information, refer to [Logs Drilldown table view](./table/).
+- **JSON**: Opens the dedicated JSON viewer for logs formatted as JSON. For more information, refer to [Logs Drilldown JSON viewer](./json/).
 
 ## Log controls
 
@@ -46,11 +42,11 @@ From top to bottom, the log controls include:
 - **Logs highlighting**: Toggle between plain text and color highlighting.
 - **Font size control**: Toggle between small (default) and large font.
 - **Unescape newlines**: Displayed when logs contain escaped new lines. Click to render escaped new lines as new lines.
-- **Download logs**: Download in plain text (txt), JavaScript Object Notation (JSON), or Comma-separated values (CSV) format.
+- **Download logs**: Download in plain text (`txt`), JavaScript Object Notation (JSON), or Comma-separated values (CSV) format.
 - **Scroll to the top**: Jump to the first log line in the view.
 
 {{< admonition type="note" >}}
-When you are in [JSON view](../viewing-json-logs/), these controls are not available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
+When you are in [JSON view](./json/), these controls are not available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
 {{< /admonition >}}
 
 ## Panel menu
@@ -65,40 +61,54 @@ Most panels in Logs Drilldown have a menu that you open by clicking the menu ico
 
 Some options, such as **Add to Dashboard**, **Create alert**, and **Explain in Assistant**, appear only when the corresponding Grafana feature is available.
 
+## Log line menu
+
+Click the menu icon (three vertical dots) at the start of a log line to open the log line menu.
+
+{{< figure alt="A log line menu open over the log list, showing the Show log details, Show context, and Pin log options, followed by copy options and Explain log line in Assistant" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-logs-ellipsis-menu.png" caption="The log line menu" >}}
+
+The menu includes the following options:
+
+- **Show log details**: Opens [log details](#log-details) for the log line. When details are already open, the option reads **Hide log details**.
+- **Show context**: Displays the log lines that arrived before and after the selected line. Refer to [Log context](#log-context) for more information.
+- **Pin log**: Keeps the log line pinned in the log list. To remove the pin, select **Unpin log**.
+- **Copy log line message**: Copies the log line text to your clipboard.
+- **Copy log line contents as JSON**: Copies the log line, including its fields, as a JSON object.
+- **Copy link to log line**: Copies a short link that opens Logs Drilldown focused on this log line, so you can share it.
+- **Explain log line in Assistant**: Sends the log line to Grafana Assistant for an explanation. This option only appears when Grafana Assistant is available.
+
 ## Log details
 
-The **Log details** component is displayed when you click a log line. It shows additional information from that log line in collapsible sections, including fields (usually key-value pairs) and links (derived fields, correlations, and more).
+Log details show all the information attached to a single log line. To open log details, click a log line, or select **Show log details** from the log line menu.
 
-### Fields
+{{< figure alt="The log details sidebar next to the log list, with the copy menu open and collapsible sections for the log line, links to tracing data sources, a trace, and indexed labels" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-logs-details-copy-menu.png" caption="Log details in sidebar mode" >}}
 
-Within the Log details view, you have the ability to filter the displayed fields in two ways:
+At the top of log details, use the **Search field names and values** field to narrow down what's displayed. The copy icon opens a menu with **Copy log line message** and **Copy log contents as JSON** options.
 
-- **Positive filter**: Focuses on a specific field
-- **Negative filter**: Excludes certain fields
+Log details organize the information in collapsible sections:
 
-These filters modify the corresponding query that generated the log line, incorporating equality and inequality expressions accordingly.
+- **Log line**: The raw log line.
+- **Links**: Data links and correlations, which turn parts of the log line into links to related data or external resources, for example a trace ID linking to your tracing data source.
+- **Trace**: A preview of the trace, when a trace link is detected in the log line.
+- Fields, grouped by type for data sources that support it. For Loki, the groups are **Indexed labels**, **Structured metadata**, and **Parsed fields**.
 
-For supported data sources like Loki and Elasticsearch, log details will verify whether the field is already included in the current query, indicating an active state for positive filters. This enables you to toggle it off from the query or convert the filter expression from positive to negative as necessary.
+### Work with fields
 
-Click the eye icon to select a subset of fields to visualize in the logs list instead of the complete log line.
+Each field row has icons to act on that field:
 
-Each field has a stats icon, which displays ad-hoc statistics in relation to all displayed logs.
-
-For data sources that support log types, such as Loki, instead of a single view containing all fields, different groups of fields will be displayed grouping them by their type: Indexed Labels, Structured Metadata, and Parsed fields.
-
-### Links
-
-Grafana provides data links or correlations, allowing you to convert any part of a log message into an internal or external link. These links enable you to navigate to related data or external resources, offering a seamless and convenient way to explore additional information.
+- **Filter for value** and **Filter out value**: Add the field to your query as an equality or inequality expression. When a filter is already active, you can toggle it off or flip it from positive to negative.
+- The eye icon: Shows the field in the log list instead of the complete log line, or hides it again.
+- **Ad-hoc statistics**: Displays how the field's values are distributed across the displayed logs.
+- The copy icon: Copies the field's value to your clipboard.
 
 ### Log details modes
 
-There are two modes available to view log details:
+There are two modes to view log details:
 
-- **Inline log details** display the log details below the log line within the log list.
+- **Inline** displays the log details below the log line within the log list.
+- **Sidebar** displays the log details in a panel to the side of the log list.
 
-- **Sidebar log details** display the log details in a panel to the side of the log list.
-
-No matter which display mode you are currently viewing, you can change it by clicking the mode control icon.
+To switch modes, use the mode icon in the log details header: **Anchor to the right** switches to the sidebar, and **Display inline** moves the details back into the list.
 
 ## Highlighting
 
@@ -116,4 +126,4 @@ Change the **Context time window** option to look for logs within a specific tim
 
 ## Infinite scroll
 
-When you reach the bottom of the list of logs, if you continue scrolling and the displayed logs are within the selected time interval, you can request to load more logs. When the sort order is "newest first" you will receive older logs, and when the sort order is "oldest first" you will get newer logs.
+When you reach the bottom of the list of logs, if you continue scrolling and the displayed logs are within the selected time interval, you can request to load more logs. When the sort order is "newest first" you receive older logs, and when the sort order is "oldest first" you get newer logs.

--- a/docs/sources/view-logs/_index.md
+++ b/docs/sources/view-logs/_index.md
@@ -6,13 +6,13 @@ weight: 500
 
 # View logs
 
-The logs visualization in Grafana Logs Drilldown displays log lines from your Loki data source with filtering options and controls to customize how data is displayed.
+The logs visualization in Grafana Logs Drilldown displays log lines from your Loki data source, with filtering options and controls to customize the display.
 
 A line filter search field appears at the top of the page. Enter text to filter your logs to lines that contain, or exclude, that text.
 
 ## Visualization types
 
-On the **Logs** tab, use the radio buttons in the panel header to switch how your logs are displayed:
+On the **Logs** tab, use the radio buttons in the panel header to switch how Logs Drilldown displays your logs:
 
 - **Logs**: The default log line list, with the [log controls](#log-controls), the [log line menu](#log-line-menu), and [log details](#log-details), described on this page.
 - **Table**: Displays logs in a table with a column for each displayed field. You can add or remove columns, sort by a column, resize columns, and wrap text. For more information, refer to [Logs Drilldown table view](./table/).
@@ -46,7 +46,7 @@ From top to bottom, the log controls include:
 - **Scroll to the top**: Jump to the first log line in the view.
 
 {{< admonition type="note" >}}
-When you are in [JSON view](../json/), these controls are not available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
+When you're in [JSON view](./json/), these controls aren't available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
 {{< /admonition >}}
 
 ## Panel menu
@@ -79,9 +79,9 @@ The menu includes the following options:
 
 ## Log details
 
-Log details show all the information attached to a single log line. 
+Log details show all the information attached to a single log line.
 
-To open log details, lick a log line or select **Show log details** from the log line menu.
+To open log details, click a log line or select **Show log details** from the log line menu.
 
 {{< figure alt="The log details sidebar next to the log list, with the copy menu open and collapsible sections for the log line, links to tracing data sources, a trace, and indexed labels" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-logs-details-copy-menu.png" caption="Log details in sidebar mode" >}}
 
@@ -91,7 +91,7 @@ Log details organize the information in collapsible sections:
 
 - **Log line**: The raw log line.
 - **Links**: Data links and correlations, which turn parts of the log line into links to related data or external resources, for example a trace ID linking to your tracing data source.
-- **Trace**: A preview of the trace, when a trace link is detected in the log line.
+- **Trace**: A preview of the trace, when the log line contains a trace link.
 - Fields, grouped by type for data sources that support it. For Loki, the groups are **Indexed labels**, **Structured metadata**, and **Parsed fields**.
 
 ### Work with fields
@@ -114,7 +114,7 @@ To switch modes, use the mode icon in the log details header: **Anchor to the ri
 
 ## Highlighting
 
-The logs visualization implements a predefined set of rules to apply subtle colors to the log lines, to help with readability and help with identifying important information faster. This is an optional feature that can be disabled in the controls or in the panel options.
+The logs visualization implements a predefined set of rules to apply subtle colors to the log lines, to help with readability and help with identifying important information faster. You can disable this optional feature in the controls or in the panel options.
 
 Log levels are also color-coded to help you scan for errors and warnings. For example, `debug` lines use a neutral gray and `info` lines use a neutral blue.
 

--- a/docs/sources/view-logs/_index.md
+++ b/docs/sources/view-logs/_index.md
@@ -46,7 +46,7 @@ From top to bottom, the log controls include:
 - **Scroll to the top**: Jump to the first log line in the view.
 
 {{< admonition type="note" >}}
-When you are in [JSON view](./json/), these controls are not available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
+When you are in [JSON view](../json/), these controls are not available: client-side string search, deduplication, filter by log level, timestamp format, font size control, and download logs. JSON view includes additional toggles for showing structured metadata and labels.
 {{< /admonition >}}
 
 ## Panel menu

--- a/docs/sources/view-logs/json/_index.md
+++ b/docs/sources/view-logs/json/_index.md
@@ -26,7 +26,7 @@ To interact with the JSON view, select **Show logs** for your service in Logs Dr
 
 {{< figure alt="Logs Drilldown service panel with Show logs highlighted" caption="Show logs button" width="500px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-show-logs.png" >}}
 
-On the **Logs** tab, select the **JSON** radio button in the panel header (next to **Logs** and **Table**) to switch to the JSON viewer. Your logs are displayed in a structured, collapsible tree view, enabling you to browse, expand, and collapse JSON fields.
+On the **Logs** tab, select the **JSON** radio button in the panel header (next to **Logs** and **Table**) to switch to the JSON viewer. The JSON viewer displays your logs in a structured, collapsible tree view, so you can browse, expand, and collapse JSON fields.
 
 {{< figure alt="Logs Drilldown JSON viewer with structured log rows" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-json-viewer.png" caption="The JSON viewer" >}}
 
@@ -48,4 +48,4 @@ To include filtered log data again, remove the excluded data from the **Fields**
 
 Log lines entirely formatted as JSON are supported.
 
-Log lines with only certain fields or metadata structured as JSON are not currently supported.
+Log lines with only certain fields or metadata structured as JSON aren't currently supported.

--- a/docs/sources/view-logs/json/_index.md
+++ b/docs/sources/view-logs/json/_index.md
@@ -1,13 +1,15 @@
 ---
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/viewing-json-logs/
+aliases:
+  - ../../viewing-json-logs/ # old URL before this page moved under view-logs/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/view-logs/json/
 description: Learn how to view JSON formatted logs in Logs Drilldown.
 keywords:
   - Logs
   - JSON
   - Formatting
-menuTitle: Viewing JSON logs
+menuTitle: JSON
 title: Logs Drilldown JSON viewer
-weight: 800
+weight: 300
 ---
 
 # Logs Drilldown JSON viewer
@@ -28,7 +30,7 @@ On the **Logs** tab, select the **JSON** radio button in the panel header (next 
 
 {{< figure alt="Logs Drilldown JSON viewer with structured log rows" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-json-viewer.png" caption="The JSON viewer" >}}
 
-The **Line wrapping** control in the log controls panel also offers an **Enabled with JSON formatting** option. This pretty-prints JSON within the standard Logs view but does not open the dedicated JSON viewer. For more information about line wrapping, refer to [View logs](../view-logs/).
+The **Line wrapping** control in the log controls panel also offers an **Enabled with JSON formatting** option. This pretty-prints JSON within the standard Logs view but does not open the dedicated JSON viewer. For more information about line wrapping, refer to [View logs](../).
 
 ## Filtering log lines with the JSON view
 

--- a/docs/sources/view-logs/json/_index.md
+++ b/docs/sources/view-logs/json/_index.md
@@ -30,7 +30,7 @@ On the **Logs** tab, select the **JSON** radio button in the panel header (next 
 
 {{< figure alt="Logs Drilldown JSON viewer with structured log rows" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-json-viewer.png" caption="The JSON viewer" >}}
 
-The **Line wrapping** control in the log controls panel also offers an **Enabled with JSON formatting** option. This pretty-prints JSON within the standard Logs view but does not open the dedicated JSON viewer. For more information about line wrapping, refer to [View logs](../).
+The **Line wrapping** control in the log controls panel also offers an **Enabled with JSON formatting** option. This pretty-prints JSON within the standard Logs view but doesn't open the dedicated JSON viewer. For more information about line wrapping, refer to [View logs](../view-logs/).
 
 ## Filtering log lines with the JSON view
 

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -34,7 +34,7 @@ The sidebar on the left of the table controls which fields appear as columns:
 
 To give the table more room, collapse the sidebar with the **Collapse sidebar** icon. You can also resize the sidebar, the columns, and the log details sidebar by dragging their edges. Your column selection and sizes are remembered.
 
-## Log details
+## View log details
 
 Each row has a **Show details** eye icon at the start of the line.
 

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -65,7 +65,7 @@ Click a column header to sort by that column, and click again to flip the direct
 
 ### Wrap text
 
-The wrap control in the rail toggles text wrapping for long log lines and cell values.
+Select the wrap control in the rail to toggle text wrapping for long log lines and cell values.
 
 ### Download
 

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -89,7 +89,7 @@ The export includes the columns you've selected. In dashboards, the download con
 
 If you're coming from the previous table view in Logs Drilldown or Grafana Explore, here's where features moved in the Logs table visualization:
 
-| Task                  | Previous table view                                                                 | Logs Table visualization                                                                       |
+| Task                  | Previous table view                                                                 | Logs table visualization                                                                       |
 | --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Inspect a log line    | The **View log line** eye icon opened an **Inspect value** dialog with the raw line | The **Show details** eye icon opens the full [log details sidebar](#view-log-details)          |
 | Add or remove columns | Fields sidebar with checkboxes                                                      | Same sidebar, unchanged                                                                        |

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -14,25 +14,35 @@ weight: 200
 
 The **Table** view in Grafana Logs Drilldown displays your logs in a table with a column for each displayed field, so you can scan structured logs the way you'd read a spreadsheet.
 
+Use the table view when you want to scan, compare, and sort log data. For example, you can sort by duration to find the slowest requests, compare status codes or Pod names across many log lines.
+
 To open the table view, select **Show logs** for your service in Logs Drilldown, then select the **Table** radio button in the panel header, next to **Logs** and **JSON**.
 
 ## The Logs Table visualization
 
 {{< docs/public-preview product="The Logs Table visualization" featureFlag="logsTablePanelNG" >}}
 
-When the feature toggle is enabled, the **Table** view renders your logs with Grafana's native Logs Table visualization, described on this page.
+When you enable the feature toggle, the **Table** view renders your logs with the native Grafana Logs Table visualization, described on this page.
 
 ## Select and organize columns
 
-The sidebar on the left of the table controls which fields appear as columns:
+Use the sidebar on the left of the table to choose which fields appear as columns. For example, to build a table with only the fields you care about:
 
-- Use the **Search fields by name** field to find a field.
-- Select a field's checkbox to add it as a column, or clear the checkbox to remove it.
-- **Selected fields** lists the current columns. Drag fields in this list to reorder the columns.
-- **Suggested** offers likely useful fields, and **Fields** lists everything else. The percentage next to a field shows how many of the displayed log lines contain it.
-- Select **Reset** to restore the default columns: the time, level, and log line fields.
+1. Select the **Table** view in the panel header.
+1. Click **Search fields by name** and enter a full or partial field name.
+1. Select the field's checkbox to add it as a column, and clear the checkboxes of any columns you don't need.
 
-To give the table more room, collapse the sidebar with the **Collapse sidebar** icon. You can also resize the sidebar, the columns, and the log details sidebar by dragging their edges. Your column selection and sizes are remembered.
+The sidebar offers the following controls:
+
+| Action                  | UI element                   | Description                                                                                                                                                           |
+| ----------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Find a field            | **Search fields by name**    | Type a field name to filter the list of available fields.                                                                                                             |
+| Add or remove a column  | Field checkbox               | Select a field's checkbox to add it as a column, or clear the checkbox to remove it.                                                                                  |
+| Reorder columns         | **Selected fields**          | Lists the current columns. Drag fields in this list to reorder the columns.                                                                                           |
+| Browse available fields | **Suggested** and **Fields** | **Suggested** offers likely useful fields, and **Fields** lists everything else. The percentage next to a field shows how many of the displayed log lines contain it. |
+| Restore defaults        | **Reset**                    | Restores the default columns: the time, level, and log line fields.                                                                                                   |
+
+To give the table more room, collapse the sidebar with the **Collapse sidebar** icon. You can also resize the sidebar, the columns, and the log details sidebar by dragging their edges. Logs Drilldown remembers your column selection and sizes.
 
 ## View log details
 
@@ -57,7 +67,7 @@ The table view uses the columns themselves for filtering, plus a controls rail o
 
 Every column header has a **Filter** icon, which opens a list of that column's values to filter by. To filter by log level, use the **Filter** icon on the level column, for example `detected_level`.
 
-You can also hover over any cell and use **Filter for value** or **Filter out value** to add that value to your query, or filter from within [log details](#log-details). The **Log levels** filter in the Logs Drilldown toolbar applies to the table view as well.
+You can also hover over any cell and use **Filter for value** or **Filter out value** to add that value to your query, or filter from within [log details](#view-log-details). The **Log levels** filter in the Logs Drilldown toolbar applies to the table view as well.
 
 ### Sort
 
@@ -69,9 +79,9 @@ Select the wrap control in the rail to toggle text wrapping for long log lines a
 
 ### Download
 
-Use the **Download logs** control in the rail to export the displayed logs as `txt`, `json`, or `csv`. 
+Use the **Download logs** control in the rail to export the displayed logs as `txt`, `json`, or `csv`.
 
-The export includes the columns you've selected. In dashboards, the download control appears when the **Display download control** panel option is enabled.
+The export includes the columns you've selected. In dashboards, the download control appears when you enable the **Display download control** panel option.
 
 ## Where features moved
 
@@ -79,7 +89,7 @@ If you're coming from the previous table view in Logs Drilldown or Grafana Explo
 
 | Task                  | Previous table view                                                                 | Logs Table visualization                                                                       |
 | --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Inspect a log line    | The **View log line** eye icon opened an **Inspect value** dialog with the raw line | The **Show details** eye icon opens the full [log details sidebar](#log-details)               |
+| Inspect a log line    | The **View log line** eye icon opened an **Inspect value** dialog with the raw line | The **Show details** eye icon opens the full [log details sidebar](#view-log-details)          |
 | Add or remove columns | Fields sidebar with checkboxes                                                      | Same sidebar, unchanged                                                                        |
 | Reorder columns       | Column menu with **Move left** and **Move right** (Logs Drilldown)                  | Drag fields in the **Selected fields** list                                                    |
 | Remove a column       | **Remove column** in the column menu (Logs Drilldown)                               | Clear the field's checkbox in the sidebar                                                      |

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -69,7 +69,9 @@ Select the wrap control in the rail to toggle text wrapping for long log lines a
 
 ### Download
 
-The **Download logs** control in the rail exports the displayed logs as `txt`, `json`, or `csv`. The export includes the columns you've selected. In dashboards, the download control appears when the **Display download control** panel option is enabled.
+Use the **Download logs** control in the rail to export the displayed logs as `txt`, `json`, or `csv`. 
+
+The export includes the columns you've selected. In dashboards, the download control appears when the **Display download control** panel option is enabled.
 
 ## Where features moved
 

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -50,7 +50,9 @@ Each row has a **Show details** eye icon at the start of the line.
 
 {{< figure alt="The table view with the Show details icon highlighted on a row and the log details sidebar open, showing the copy menu, the raw log line, and its fields" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-table-show-details-copy-menu.png" caption="Log details in the table view" >}}
 
-Select **Show details** to open the log details sidebar, where you can search fields, copy the log line, filter for or out field values, and view field statistics. Refer to [View logs](../#log-details) for everything log details can do. In the table view:
+Select **Show details** to open the log details sidebar, where you can search fields, copy the log line, filter for or out field values, and view field statistics. Refer to [View logs](../#log-details) for explanations. 
+
+In the table view:
 
 - Log details always open as a sidebar on the right, which you can resize or close with the **Close log details sidebar** icon or the Escape key.
 - The copy icon at the top of the sidebar opens a menu with **Copy log line message** and **Copy log contents as JSON** options, as shown in the previous image.

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -75,7 +75,7 @@ The export includes the columns you've selected. In dashboards, the download con
 
 ## Where features moved
 
-If you're coming from the previous table view in Logs Drilldown or Grafana Explore, here's where familiar features live in the Logs Table visualization:
+If you're coming from the previous table view in Logs Drilldown or Grafana Explore, here's where features moved in the Logs table visualization:
 
 | Task                  | Previous table view                                                                 | Logs Table visualization                                                                       |
 | --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |

--- a/docs/sources/view-logs/table/_index.md
+++ b/docs/sources/view-logs/table/_index.md
@@ -1,0 +1,88 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/logs/view-logs/table/
+description: Learn how to view logs in a table, organize columns, and inspect log details in Grafana Logs Drilldown.
+keywords:
+  - Logs
+  - Table
+  - Columns
+menuTitle: Table
+title: Logs Drilldown table view
+weight: 200
+---
+
+# Logs Drilldown table view
+
+The **Table** view in Grafana Logs Drilldown displays your logs in a table with a column for each displayed field, so you can scan structured logs the way you'd read a spreadsheet.
+
+To open the table view, select **Show logs** for your service in Logs Drilldown, then select the **Table** radio button in the panel header, next to **Logs** and **JSON**.
+
+## The Logs Table visualization
+
+{{< docs/public-preview product="The Logs Table visualization" featureFlag="logsTablePanelNG" >}}
+
+When the feature toggle is enabled, the **Table** view renders your logs with Grafana's native Logs Table visualization, described on this page.
+
+## Select and organize columns
+
+The sidebar on the left of the table controls which fields appear as columns:
+
+- Use the **Search fields by name** field to find a field.
+- Select a field's checkbox to add it as a column, or clear the checkbox to remove it.
+- **Selected fields** lists the current columns. Drag fields in this list to reorder the columns.
+- **Suggested** offers likely useful fields, and **Fields** lists everything else. The percentage next to a field shows how many of the displayed log lines contain it.
+- Select **Reset** to restore the default columns: the time, level, and log line fields.
+
+To give the table more room, collapse the sidebar with the **Collapse sidebar** icon. You can also resize the sidebar, the columns, and the log details sidebar by dragging their edges. Your column selection and sizes are remembered.
+
+## Log details
+
+Each row has a **Show details** eye icon at the start of the line.
+
+{{< figure alt="The table view with the Show details icon highlighted on a row and the log details sidebar open, showing the copy menu, the raw log line, and its fields" width="900px" align="center" src="/media/docs/explore-logs/v2/logs-drilldown-table-show-details-copy-menu.png" caption="Log details in the table view" >}}
+
+Select **Show details** to open the log details sidebar, where you can search fields, copy the log line, filter for or out field values, and view field statistics. Refer to [View logs](../#log-details) for everything log details can do. In the table view:
+
+- Log details always open as a sidebar on the right, which you can resize or close with the **Close log details sidebar** icon or the Escape key.
+- The copy icon at the top of the sidebar opens a menu with **Copy log line message** and **Copy log contents as JSON** options, as shown in the previous image.
+- Opening details for several rows creates a tab for each log line, so you can compare them.
+- Use the up and down arrow keys to move the details view to the previous or next log line.
+
+Rows also have a **Copy link to log line** icon that copies a short link to that log line to your clipboard.
+
+## Filter, sort, wrap, and download
+
+The table view uses the columns themselves for filtering, plus a controls rail on the right edge of the panel.
+
+### Filter by level and by value
+
+Every column header has a **Filter** icon, which opens a list of that column's values to filter by. To filter by log level, use the **Filter** icon on the level column, for example `detected_level`.
+
+You can also hover over any cell and use **Filter for value** or **Filter out value** to add that value to your query, or filter from within [log details](#log-details). The **Log levels** filter in the Logs Drilldown toolbar applies to the table view as well.
+
+### Sort
+
+Click a column header to sort by that column, and click again to flip the direction. The sort order control in the rail switches between newest and oldest logs first, and stays in sync with the time column.
+
+### Wrap text
+
+The wrap control in the rail toggles text wrapping for long log lines and cell values.
+
+### Download
+
+The **Download logs** control in the rail exports the displayed logs as `txt`, `json`, or `csv`. The export includes the columns you've selected. In dashboards, the download control appears when the **Display download control** panel option is enabled.
+
+## Where features moved
+
+If you're coming from the previous table view in Logs Drilldown or Grafana Explore, here's where familiar features live in the Logs Table visualization:
+
+| Task                  | Previous table view                                                                 | Logs Table visualization                                                                       |
+| --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Inspect a log line    | The **View log line** eye icon opened an **Inspect value** dialog with the raw line | The **Show details** eye icon opens the full [log details sidebar](#log-details)               |
+| Add or remove columns | Fields sidebar with checkboxes                                                      | Same sidebar, unchanged                                                                        |
+| Reorder columns       | Column menu with **Move left** and **Move right** (Logs Drilldown)                  | Drag fields in the **Selected fields** list                                                    |
+| Remove a column       | **Remove column** in the column menu (Logs Drilldown)                               | Clear the field's checkbox in the sidebar                                                      |
+| Filter by a value     | Icons on cell hover                                                                 | Cell hover icons, plus a **Filter** icon in every column header                                |
+| Filter by level       | Cell filters on the level column                                                    | **Filter** icon in the level column header, cell filters, or the **Log levels** toolbar filter |
+| Wrap long lines       | Not available; cells scrolled horizontally                                          | Wrap control in the rail, or the **Wrap text** column option                                   |
+| Download logs         | **Download logs** control                                                           | Same control, same `txt`, `json`, and `csv` formats                                            |
+| Share a log line      | **Copy link to log line** icon                                                      | Same icon, unchanged                                                                           |


### PR DESCRIPTION
## Summary 📝
Thanks @knylander-grafana for explaining how to update docs! Let me know if I've made it more confusing, happy to change it.

Documents the Logs Table visualization (public preview, `logsTablePanelNG`) and expands the logs panel docs with new screenshots, addressing the docs gap tracked in grafana/grafana#130308.

- **New page — [Logs Drilldown table view](https://github.com/grafana/logs-drilldown/blob/l2d22/docs-add-images-description-logs-table-panel/docs/sources/view-logs/table/_index.md)** (`view-logs/table/`): how to enable the feature toggle, selecting and organizing columns, log details from the **Show details** icon, level filters, sorting, text wrap, download/export, and a "Where features moved" table mapping the previous table view to the new visualization.
- **Expanded [View logs](https://github.com/grafana/logs-drilldown/blob/l2d22/docs-add-images-description-logs-table-panel/docs/sources/view-logs/_index.md)**: new **Log line menu** and full **Log details** sections (search field, copy menu, field groups, per-field actions, inline/sidebar modes) with screenshots.
- **Navigation restructure**: **View logs** is now a parent page with **Table** and **JSON** subpages. The JSON viewer moved from `viewing-json-logs/` to `view-logs/json/` (git rename) with an `aliases` entry so the published URL keeps redirecting.
- Three new screenshots uploaded to `/media/docs/explore-logs/v2/`.
- All UI strings verified against the source: this repo and Grafana core (`public/app/plugins/panel/logstable/`, `LogLineMenu.tsx`, `LogLineDetailsHeader.tsx`).

<img width="1248" height="964" alt="Screenshot 2026-08-12 at 11 41 41 AM" src="https://github.com/user-attachments/assets/ddbc8f06-749f-48b2-b0b3-4760231c6dbd" />


## Test 🧪

- `make docs` renders locally: nav shows View logs → Table/JSON, all three images load, the public-preview admonition and figures render, breadcrumbs correct.
- Old JSON viewer URL renders Hugo's alias redirect stub after a clean build.
- Vale (`grafana/vale`) passes with zero errors/warnings on all changed files (remaining warnings are pre-existing prose in untouched files).
- Inbound links from `patterns`, `labels-and-fields`, `get-started`, and the landing-page card retargeted; grep confirms no stale references to the old paths.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/logs-drilldown/blob/main/docs/genai.md))

🤖 Generated with [Claude Code](https://claude.com/claude-code)