### PR TITLE
chore(faro): ignore benign ResizeObserver loop errors like core

### DIFF
--- a/src/faro/faroInit.ts
+++ b/src/faro/faroInit.ts
@@ -44,9 +44,7 @@ export const initFaro = async () => {
           new TracingInstrumentation(),
         ],
         isolate: true,
-        // Benign browser noise, filtered by Grafana core's own faro config as well
-        // (GrafanaJavascriptAgentBackend): the ResizeObserver messages fire when a resize
-        // callback changes layout and delivery rolls to the next frame — no user impact.
+        // Benign browser noise; Grafana core's faro config ignores the same messages
         ignoreErrors: ['ResizeObserver loop limit exceeded', 'ResizeObserver loop completed'],
         beforeSend: (event) => {
           if ((event.meta.page?.url ?? '').includes(PLUGIN_BASE_URL)) {

--- a/src/faro/faroInit.ts
+++ b/src/faro/faroInit.ts
@@ -44,6 +44,10 @@ export const initFaro = async () => {
           new TracingInstrumentation(),
         ],
         isolate: true,
+        // Benign browser noise, filtered by Grafana core's own faro config as well
+        // (GrafanaJavascriptAgentBackend): the ResizeObserver messages fire when a resize
+        // callback changes layout and delivery rolls to the next frame — no user impact.
+        ignoreErrors: ['ResizeObserver loop limit exceeded', 'ResizeObserver loop completed'],
         beforeSend: (event) => {
           if ((event.meta.page?.url ?? '').includes(PLUGIN_BASE_URL)) {
             return event;


### PR DESCRIPTION
## Summary 📝

The plugin's Faro apps record the benign browser message "ResizeObserver loop completed with undelivered notifications" as an error (~28 events per 30 min in prod, 0 affected users). Add the same `ignoreErrors` entries Grafana core uses ([GrafanaJavascriptAgentBackend.ts](https://github.com/grafana/grafana/blob/main/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts)) so we stop tracking noise core deliberately filters.

## Test 🧪

- `pnpm typecheck` and `pnpm jest src/faro` pass.
- After release, the [Kowalski error group](https://ops.grafana-ops.net/a/grafana-kowalski-app/apps/60/errors/7346614118153079013) should flatline for versions ≥ this release.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/logs-drilldown/blob/main/docs/genai.md))

🤖 Generated with [Claude Code](https://claude.com/claude-code)