### PR TITLE
fix(counts): keep logs count displays in sync and drop stale cached counts

### DIFF
--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -16,11 +16,13 @@ import { PageSlugs, TabNames, ValueSlugs } from 'services/enums';
 import { formatLogsCount, getDisplayedLogsCount } from 'services/logsCount';
 import { narrowPageSlug } from 'services/narrowing';
 import { getDrillDownTabLink } from 'services/navigate';
+import { LINE_LIMIT } from 'services/query';
 import { getDrilldownSlug, getDrilldownValueSlug } from 'services/routing';
 import { getMaxLines } from 'services/store';
 
 export interface ActionBarSceneState extends SceneObjectState {
   loadSearchScene?: LoadSearchScene;
+  maxLines?: number;
   shareButtonScene?: ShareButtonScene;
 }
 
@@ -32,6 +34,9 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
   }
 
   onActivate() {
+    // Snapshot at activation: getMaxLines parses the route and throws off-route, so never call it in render
+    this.setState({ maxLines: getMaxLines(this) });
+
     if (!this.state.shareButtonScene) {
       this.setState({
         shareButtonScene: new ShareButtonScene({}),
@@ -80,8 +85,8 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
     }
 
     const { $data, loading, logsCount, totalLogsCount, ...state } = serviceScene.useState();
-    // Read the line limit fresh on every render; a snapshot goes stale when the user changes it
-    const displayedLogsCount = getDisplayedLogsCount(totalLogsCount, logsCount, getMaxLines(model));
+    const { maxLines } = model.useState();
+    const displayedLogsCount = getDisplayedLogsCount(totalLogsCount, logsCount, maxLines ?? LINE_LIMIT);
 
     const loadingStates = state.loadingStates;
 

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css, cx } from '@emotion/css';
 
-import { getValueFormat, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 
@@ -13,15 +13,14 @@ import { LoadSearchScene } from 'Components/SavedSearches/LoadSearchScene';
 import { SaveSearchButton } from 'Components/SavedSearches/SaveSearchButton';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { PageSlugs, TabNames, ValueSlugs } from 'services/enums';
+import { formatLogsCount, getDisplayedLogsCount } from 'services/logsCount';
 import { narrowPageSlug } from 'services/narrowing';
 import { getDrillDownTabLink } from 'services/navigate';
-import { LINE_LIMIT } from 'services/query';
 import { getDrilldownSlug, getDrilldownValueSlug } from 'services/routing';
 import { getMaxLines } from 'services/store';
 
 export interface ActionBarSceneState extends SceneObjectState {
   loadSearchScene?: LoadSearchScene;
-  maxLines?: number;
   shareButtonScene?: ShareButtonScene;
 }
 
@@ -33,10 +32,6 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
   }
 
   onActivate() {
-    this.setState({
-      maxLines: getMaxLines(this),
-    });
-
     if (!this.state.shareButtonScene) {
       this.setState({
         shareButtonScene: new ShareButtonScene({}),
@@ -85,7 +80,8 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
     }
 
     const { $data, loading, logsCount, totalLogsCount, ...state } = serviceScene.useState();
-    const { maxLines } = model.useState();
+    // Read the line limit fresh on every render; a snapshot goes stale when the user changes it
+    const displayedLogsCount = getDisplayedLogsCount(totalLogsCount, logsCount, getMaxLines(model));
 
     const loadingStates = state.loadingStates;
 
@@ -118,7 +114,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
                   counter={loadingStates[tab.displayName] ? undefined : getCounter(tab, state)}
                   suffix={
                     tab.displayName === TabNames.logs
-                      ? ({ className }) => LogsCount(className, totalLogsCount, logsCount, maxLines ?? LINE_LIMIT)
+                      ? ({ className }) => LogsCount(className, displayedLogsCount)
                       : undefined
                   }
                   icon={loadingStates[tab.displayName] ? 'spinner' : undefined}
@@ -181,35 +177,14 @@ function getStyles(theme: GrafanaTheme2) {
   };
 }
 
-function LogsCount(
-  className: string | undefined,
-  totalCount: number | undefined,
-  logsCount: number | undefined,
-  maxLines: number
-) {
+function LogsCount(className: string | undefined, count: number | undefined) {
   const styles = useStyles2(getLogsCountStyles);
-  const valueFormatter = getValueFormat('short');
 
-  // The instant query (totalCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
-  if (totalCount === undefined && logsCount !== undefined && logsCount < maxLines) {
-    const formattedCount = valueFormatter(logsCount, 0);
-    return (
-      <span className={cx(className, styles.logsCountStyles)}>
-        {formattedCount.text}
-        {formattedCount.suffix?.trim()}
-      </span>
-    );
-  } else if (totalCount !== undefined) {
-    const formattedTotalCount = valueFormatter(totalCount, 0);
-    return (
-      <span className={cx(className, styles.logsCountStyles)}>
-        {formattedTotalCount.text}
-        {formattedTotalCount.suffix?.trim()}
-      </span>
-    );
+  if (count === undefined) {
+    return <span className={cx(className, styles.emptyCountStyles)}></span>;
   }
 
-  return <span className={cx(className, styles.emptyCountStyles)}></span>;
+  return <span className={cx(className, styles.logsCountStyles)}>{formatLogsCount(count)}</span>;
 }
 
 function getLogsCountStyles(theme: GrafanaTheme2) {

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent } from 'react';
 
-import { DataFrame, getValueFormat, LogRowModel, shallowCompare } from '@grafana/data';
+import { DataFrame, LogRowModel, shallowCompare } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import {
@@ -34,6 +34,7 @@ import { getVariableForLabel } from 'services/fields';
 import { LineFilterCaseSensitive, LineFilterOp } from 'services/filterTypes';
 import { isDedupStrategy, isLogsSortOrder } from 'services/guards';
 import { logger } from 'services/logger';
+import { formatLogsCount } from 'services/logsCount';
 import { narrowLogsSortOrder } from 'services/narrowing';
 import { logsControlsSupported } from 'services/panel';
 import { runSceneQueries } from 'services/query';
@@ -300,9 +301,7 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   }
 
   private getTitle(logsCount: number | undefined) {
-    const valueFormatter = getValueFormat('short');
-    const formattedCount = logsCount !== undefined ? valueFormatter(logsCount, 0) : undefined;
-    return formattedCount !== undefined ? `Logs (${formattedCount.text}${formattedCount.suffix?.trim()})` : 'Logs';
+    return logsCount === undefined ? 'Logs' : `Logs (${formatLogsCount(logsCount)})`;
   }
 
   private getLogsPanel = () => {

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import {
-  FieldConfig,
-  FieldConfigSource,
-  getValueFormat,
-  GrafanaTheme2,
-  LogsSortOrder,
-  shallowCompare,
-} from '@grafana/data';
+import { FieldConfig, FieldConfigSource, GrafanaTheme2, LogsSortOrder, shallowCompare } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   DeepPartial,
@@ -42,6 +35,7 @@ import { areArraysEqual } from 'services/comparison';
 import { getVariableForLabel, isLogsIdField } from 'services/fields';
 import { FilterOp } from 'services/filterTypes';
 import { logger } from 'services/logger';
+import { formatLogsCount } from 'services/logsCount';
 import { DATAPLANE_BODY_NAME_LEGACY, DATAPLANE_LINE_NAME } from 'services/logsFrame';
 import { setTableFieldOverrides, storeTableFieldConfig } from 'services/logsTable';
 import { narrowLogsSortOrder, unknownToStrings } from 'services/narrowing';
@@ -246,9 +240,7 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
   }
 
   private getTitle(logsCount: number | undefined) {
-    const valueFormatter = getValueFormat('short');
-    const formattedCount = logsCount !== undefined ? valueFormatter(logsCount, 0) : undefined;
-    return formattedCount !== undefined ? `Logs (${formattedCount.text}${formattedCount.suffix?.trim()})` : 'Logs';
+    return logsCount === undefined ? 'Logs' : `Logs (${formatLogsCount(logsCount)})`;
   }
 
   onLoadSyncDisplayedFieldsWithUrlColumns = () => {

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DataFrame, getValueFormat, LoadingState } from '@grafana/data';
+import { DataFrame, LoadingState } from '@grafana/data';
 import {
   PanelBuilders,
   SceneComponentProps,
@@ -19,7 +19,6 @@ import {
   useStyles2,
 } from '@grafana/ui';
 
-import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { LevelsVariableScene } from 'Components/IndexScene/LevelsVariableScene';
 import { getPanelWrapperStyles, PanelMenu } from 'Components/Panels/PanelMenu';
 import { AddFilterEvent } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
@@ -29,11 +28,12 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'se
 import { areArraysEqual } from 'services/comparison';
 import { getTimeSeriesExpr } from 'services/expressions';
 import { toggleLevelFromFilter } from 'services/levels';
+import { formatLogsCount, getDisplayedLogsCount } from 'services/logsCount';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
-import { buildDataQuery, LINE_LIMIT } from 'services/query';
+import { buildDataQuery } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
-import { getLogsVolumeOption, setLogsVolumeOption } from 'services/store';
+import { getLogsVolumeOption, getMaxLines, setLogsVolumeOption } from 'services/store';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
@@ -102,20 +102,8 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getTitle(totalLogsCount: number | undefined, logsCount: number | undefined) {
-    const indexScene = sceneGraph.getAncestor(this, IndexScene);
-    const maxLines = indexScene.state.ds?.maxLines ?? LINE_LIMIT;
-    const valueFormatter = getValueFormat('short');
-    const formattedTotalCount = totalLogsCount !== undefined ? valueFormatter(totalLogsCount, 0) : undefined;
-    // The instant query (totalLogsCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
-    if (totalLogsCount === undefined && logsCount !== undefined && logsCount < maxLines) {
-      const formattedCount = valueFormatter(logsCount, 0);
-      return formattedCount !== undefined
-        ? `Log volume (${formattedCount.text}${formattedCount.suffix?.trim()})`
-        : 'Log volume';
-    }
-    return formattedTotalCount !== undefined
-      ? `Log volume (${formattedTotalCount.text}${formattedTotalCount.suffix?.trim()})`
-      : 'Log volume';
+    const count = getDisplayedLogsCount(totalLogsCount, logsCount, getMaxLines(this));
+    return count === undefined ? 'Log volume' : `Log volume (${formatLogsCount(count)})`;
   }
 
   private setCollapsed(collapsed: boolean | undefined, panel: VizPanel) {
@@ -200,7 +188,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
     this._subs.add(
       serviceScene.subscribeToState((newState, prevState) => {
-        if (newState.totalLogsCount !== prevState.totalLogsCount || newState.logsCount !== undefined) {
+        if (newState.totalLogsCount !== prevState.totalLogsCount || newState.logsCount !== prevState.logsCount) {
           if (!this.state.panel) {
             this.setState({
               panel: this.getVizPanel(),

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -31,13 +31,14 @@ import { toggleLevelFromFilter } from 'services/levels';
 import { formatLogsCount, getDisplayedLogsCount } from 'services/logsCount';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
-import { buildDataQuery } from 'services/query';
+import { buildDataQuery, LINE_LIMIT } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
 import { getLogsVolumeOption, getMaxLines, setLogsVolumeOption } from 'services/store';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
+  maxLines?: number;
   panel?: VizPanel;
 }
 
@@ -54,6 +55,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private onActivate() {
+    // Snapshot at activation: getMaxLines parses the route and throws off-route, so never call it in subscriptions
+    this.setState({ maxLines: getMaxLines(this) });
+
     if (!this.state.panel) {
       const panel = this.getVizPanel();
       this.setState({
@@ -102,7 +106,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getTitle(totalLogsCount: number | undefined, logsCount: number | undefined) {
-    const count = getDisplayedLogsCount(totalLogsCount, logsCount, getMaxLines(this));
+    const count = getDisplayedLogsCount(totalLogsCount, logsCount, this.state.maxLines ?? LINE_LIMIT);
     return count === undefined ? 'Log volume' : `Log volume (${formatLogsCount(count)})`;
   }
 

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -59,7 +59,7 @@ import { clearJSONParserFields } from 'services/fields';
 import { filterUnusedJSONFilters } from 'services/filters';
 import { logger } from 'services/logger';
 import { LokiQueryDirection } from 'services/lokiQuery';
-import { getMetadataService } from 'services/metadata';
+import { getMetadataService, getRawTimeRange } from 'services/metadata';
 import { migrateLineFilterV1 } from 'services/migrations';
 import { narrowPageOrValueSlug, narrowPageSlug, narrowValueSlug } from 'services/narrowing';
 import { navigateToDrilldownPage, navigateToIndex, navigateToValueBreakdown } from 'services/navigate';
@@ -410,7 +410,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         patternsCount: undefined,
         totalLogsCount: undefined,
       });
-      getMetadataService().setServiceSceneState(this.state);
+      getMetadataService().setServiceSceneState(this.state, getRawTimeRange(this));
       this._subs.unsubscribe();
 
       // Redirect to root with updated params, which will trigger history push back to index route, preventing empty page or empty service query bugs
@@ -442,11 +442,20 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     const metadataService = getMetadataService();
     const state = metadataService.getServiceSceneState();
 
-    if (state) {
-      this.setState({
-        ...state,
-      });
+    if (!state) {
+      return;
     }
+
+    const countsRange = metadataService.getCountsTimeRange();
+    const currentRange = sceneGraph.getTimeRange(this).state;
+    if (countsRange && countsRange.from === currentRange.from && countsRange.to === currentRange.to) {
+      this.setState({ ...state });
+      return;
+    }
+
+    // Counts were computed for a different time range; restore everything else and let the gated queries re-run
+    const { fieldsCount, labelsCount, logsCount, patternsCount, totalLogsCount, ...rest } = state;
+    this.setState({ ...rest });
   }
 
   getUrlState() {
@@ -629,7 +638,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       patternsCount: undefined,
     });
 
-    getMetadataService().setServiceSceneState(this.state);
+    getMetadataService().setServiceSceneState(this.state, getRawTimeRange(this));
   }
 
   private subscribeToFieldsVariable() {
@@ -702,7 +711,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       this.setState({
         patternsCount,
       });
-      getMetadataService().setPatternsCount(patternsCount);
+      getMetadataService().setPatternsCount(patternsCount, getRawTimeRange(this));
     });
   }
 
@@ -724,9 +733,8 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     if (slug === PageSlugs.fields || parentSlug === ValueSlugs.field || this.state.fieldsCount === undefined) {
       this.state.$detectedFieldsData?.runQueries();
     }
-    if (this.state.logsCount === undefined) {
-      this.state.$logsCount?.runQueries();
-    }
+    // Always refresh: counts restored from metadata can belong to an older time range (#2049)
+    this.state.$logsCount?.runQueries();
   }
 
   private subscribeToPatternsQuery() {
@@ -737,7 +745,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         this.setState({
           patternsCount,
         });
-        getMetadataService().setPatternsCount(patternsCount);
+        getMetadataService().setPatternsCount(patternsCount, getRawTimeRange(this));
       }
     });
   }
@@ -757,7 +765,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
           this.setState({
             labelsCount: removeSpecialFields.length + 1, // Add one for detected_level
           });
-          getMetadataService().setLabelsCount(detectedLabelsFields.length);
+          getMetadataService().setLabelsCount(detectedLabelsFields.length, getRawTimeRange(this));
         }
       }
     });
@@ -780,7 +788,12 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
           this.setState({
             logsCount: resultCount,
           });
+          getMetadataService().setLogsCount(resultCount, getRawTimeRange(this));
         }
+      } else if (newState.data?.state === LoadingState.Loading && this.state.logsCount !== undefined) {
+        // Clear instead of showing the previous range's count while the query re-runs (#2049)
+        this.setState({ logsCount: undefined });
+        getMetadataService().setLogsCount(undefined, getRawTimeRange(this));
       }
 
       onQuery(newState, this);
@@ -795,7 +808,11 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
         this.setState({
           totalLogsCount: value,
         });
-        getMetadataService().setTotalLogsCount(value ?? 0);
+        getMetadataService().setTotalLogsCount(value, getRawTimeRange(this));
+      } else if (newState.data?.state === LoadingState.Loading && this.state.totalLogsCount !== undefined) {
+        // Clear instead of showing the previous range's count while the query re-runs (#2049)
+        this.setState({ totalLogsCount: undefined });
+        getMetadataService().setTotalLogsCount(undefined, getRawTimeRange(this));
       }
     });
   }
@@ -811,7 +828,7 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
           this.setState({
             fieldsCount: detectedFieldsFrame.length,
           });
-          getMetadataService().setFieldsCount(detectedFieldsFrame.length);
+          getMetadataService().setFieldsCount(detectedFieldsFrame.length, getRawTimeRange(this));
         }
       }
     });
@@ -819,6 +836,15 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
 
   private subscribeToTimeRange() {
     return sceneGraph.getTimeRange(this).subscribeToState(() => {
+      // Every count is about to be recomputed; clear them so a mid-flight navigation can't restore mixed-range values (#2049)
+      this.setState({
+        fieldsCount: undefined,
+        labelsCount: undefined,
+        logsCount: undefined,
+        patternsCount: undefined,
+        totalLogsCount: undefined,
+      });
+      getMetadataService().clearCounts();
       this.state.$patternsData?.runQueries();
       this.state.$detectedLabelsData?.runQueries();
       this.state.$detectedFieldsData?.runQueries();

--- a/src/services/logsCount.test.ts
+++ b/src/services/logsCount.test.ts
@@ -1,0 +1,31 @@
+import { getDisplayedLogsCount } from './logsCount';
+
+describe('getDisplayedLogsCount', () => {
+  it('prefers the exact logs count when under the line limit, even if a total exists', () => {
+    expect(getDisplayedLogsCount(72, 75, 1000)).toBe(75);
+  });
+
+  it('falls back to the total count when the line limit was hit', () => {
+    expect(getDisplayedLogsCount(150000, 1000, 1000)).toBe(150000);
+  });
+
+  it('falls back to the total count when the logs count exceeds the limit (infinite scroll)', () => {
+    expect(getDisplayedLogsCount(150000, 2000, 1000)).toBe(150000);
+  });
+
+  it('shows the exact logs count when no total is available yet', () => {
+    expect(getDisplayedLogsCount(undefined, 75, 1000)).toBe(75);
+  });
+
+  it('returns undefined when the limit was hit and no total is available', () => {
+    expect(getDisplayedLogsCount(undefined, 1000, 1000)).toBeUndefined();
+  });
+
+  it('returns undefined when neither count is available', () => {
+    expect(getDisplayedLogsCount(undefined, undefined, 1000)).toBeUndefined();
+  });
+
+  it('shows an exact zero instead of a stale total', () => {
+    expect(getDisplayedLogsCount(72, 0, 1000)).toBe(0);
+  });
+});

--- a/src/services/logsCount.ts
+++ b/src/services/logsCount.ts
@@ -1,0 +1,23 @@
+import { getValueFormat } from '@grafana/data';
+
+// Shared short-format for log counts, e.g. 1234 -> "1K", shown in tab badge and panel titles
+export function formatLogsCount(count: number): string {
+  const formatted = getValueFormat('short')(count, 0);
+  return `${formatted.text}${formatted.suffix?.trim() ?? ''}`;
+}
+
+/**
+ * Picks the logs count to display in the tab badge and log volume title.
+ * Prefers the exact returned-line count when under the line limit (the query returned everything);
+ * falls back to the instant count query total, which is approximate (see #2049).
+ */
+export function getDisplayedLogsCount(
+  totalLogsCount: number | undefined,
+  logsCount: number | undefined,
+  maxLines: number
+): number | undefined {
+  if (logsCount !== undefined && logsCount < maxLines) {
+    return logsCount;
+  }
+  return totalLogsCount;
+}

--- a/src/services/logsCount.ts
+++ b/src/services/logsCount.ts
@@ -6,11 +6,7 @@ export function formatLogsCount(count: number): string {
   return `${formatted.text}${formatted.suffix?.trim() ?? ''}`;
 }
 
-/**
- * Picks the logs count to display in the tab badge and log volume title.
- * Prefers the exact returned-line count when under the line limit (the query returned everything);
- * falls back to the instant count query total, which is approximate (see #2049).
- */
+// Count shown in tab badge and volume title: exact when under the line limit, else the approximate instant total (#2049)
 export function getDisplayedLogsCount(
   totalLogsCount: number | undefined,
   logsCount: number | undefined,

--- a/src/services/metadata.test.ts
+++ b/src/services/metadata.test.ts
@@ -8,6 +8,8 @@ const mockDefaultColumns = {
   records: [],
 } as unknown as LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords;
 
+const range = { from: 'now-1h', to: 'now' };
+
 describe('MetadataService', () => {
   let service: MetadataService;
 
@@ -21,12 +23,12 @@ describe('MetadataService', () => {
     });
 
     it('initializes state and sets patternsCount', () => {
-      service.setPatternsCount(5);
+      service.setPatternsCount(5, range);
       expect(service.getServiceSceneState()).toEqual({ patternsCount: 5 });
     });
 
     it('initializes state and sets labelsCount', () => {
-      service.setLabelsCount(3);
+      service.setLabelsCount(3, range);
       expect(service.getServiceSceneState()).toEqual({ labelsCount: 3 });
     });
 
@@ -36,18 +38,18 @@ describe('MetadataService', () => {
     });
 
     it('initializes state and sets fieldsCount', () => {
-      service.setFieldsCount(10);
+      service.setFieldsCount(10, range);
       expect(service.getServiceSceneState()).toEqual({ fieldsCount: 10 });
     });
 
     it('initializes state and sets totalLogsCount', () => {
-      service.setTotalLogsCount(100);
+      service.setTotalLogsCount(100, range);
       expect(service.getServiceSceneState()).toEqual({ totalLogsCount: 100 });
     });
 
     it('merges multiple setters into same state', () => {
-      service.setPatternsCount(2);
-      service.setLabelsCount(4);
+      service.setPatternsCount(2, range);
+      service.setLabelsCount(4, range);
       service.setEmbedded(false);
       expect(service.getServiceSceneState()).toEqual({
         patternsCount: 2,
@@ -56,16 +58,52 @@ describe('MetadataService', () => {
       });
     });
 
-    it('setServiceSceneState replaces state with full snapshot', () => {
-      service.setServiceSceneState({
+    it('count setters record the time range the counts were computed for', () => {
+      expect(service.getCountsTimeRange()).toBeUndefined();
+      service.setTotalLogsCount(100, range);
+      expect(service.getCountsTimeRange()).toEqual(range);
+      service.setLogsCount(50, { from: 'now-6h', to: 'now' });
+      expect(service.getCountsTimeRange()).toEqual({ from: 'now-6h', to: 'now' });
+    });
+
+    it('clearCounts drops every count but keeps non-count state', () => {
+      service.setServiceSceneState(
+        {
+          embedded: true,
+          fieldsCount: 1,
+          labelsCount: 2,
+          loading: false,
+          logsCount: 50,
+          patternsCount: 3,
+          totalLogsCount: 100,
+        },
+        range
+      );
+      service.clearCounts();
+      expect(service.getServiceSceneState()).toEqual({
         embedded: true,
-        fieldsCount: 1,
-        labelsCount: 2,
+        fieldsCount: undefined,
+        labelsCount: undefined,
         loading: false,
-        logsCount: 50,
-        patternsCount: 3,
-        totalLogsCount: 100,
+        logsCount: undefined,
+        patternsCount: undefined,
+        totalLogsCount: undefined,
       });
+    });
+
+    it('setServiceSceneState replaces state with full snapshot', () => {
+      service.setServiceSceneState(
+        {
+          embedded: true,
+          fieldsCount: 1,
+          labelsCount: 2,
+          loading: false,
+          logsCount: 50,
+          patternsCount: 3,
+          totalLogsCount: 100,
+        },
+        range
+      );
       expect(service.getServiceSceneState()).toEqual({
         embedded: true,
         fieldsCount: 1,
@@ -197,7 +235,7 @@ describe('initializeMetadataService', () => {
 
   it('force=true replaces existing service', () => {
     const first = getMetadataService();
-    first.setPatternsCount(42);
+    first.setPatternsCount(42, range);
     initializeMetadataService(true);
     const second = getMetadataService();
     expect(second).toBeInstanceOf(MetadataService);

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -1,8 +1,11 @@
 import { LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords } from '@grafana/api-clients/rtkq/logsdrilldown/v1beta1';
+import { sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { DefaultLabelsSettings } from './api';
 import { LokiConfig, LokiConfigNotSupported } from './datasourceTypes';
 import { ServiceSceneCustomState } from 'Components/ServiceScene/ServiceScene';
+
+export type CountsTimeRange = { from: string; to: string };
 
 let metadataService: MetadataService;
 
@@ -18,6 +21,8 @@ export function initializeMetadataService(force = false): void {
  */
 export class MetadataService {
   private serviceSceneState: ServiceSceneCustomState | undefined = undefined;
+  // The raw time range (e.g. `now-1h`/`now`) the stored counts were computed for, see #2049
+  private countsTimeRange: CountsTimeRange | undefined = undefined;
   private lokiConfig: LokiConfigState;
   private defaultColumns: Record<string, LogsDrilldownDefaultColumnsLogsDefaultColumnsRecords> = {};
   private defaultLabels: DefaultLabelsSettings | null = null;
@@ -26,20 +31,38 @@ export class MetadataService {
     return this.serviceSceneState;
   }
 
-  public setPatternsCount(count: number) {
+  public getCountsTimeRange() {
+    return this.countsTimeRange;
+  }
+
+  // Drop all counts, e.g. when the time range changes and every count is about to be recomputed
+  public clearCounts() {
+    if (!this.serviceSceneState) {
+      return;
+    }
+    this.serviceSceneState.fieldsCount = undefined;
+    this.serviceSceneState.labelsCount = undefined;
+    this.serviceSceneState.logsCount = undefined;
+    this.serviceSceneState.patternsCount = undefined;
+    this.serviceSceneState.totalLogsCount = undefined;
+  }
+
+  public setPatternsCount(count: number, range: CountsTimeRange) {
     if (!this.serviceSceneState) {
       this.serviceSceneState = {};
     }
 
     this.serviceSceneState.patternsCount = count;
+    this.countsTimeRange = range;
   }
 
-  public setLabelsCount(count: number) {
+  public setLabelsCount(count: number, range: CountsTimeRange) {
     if (!this.serviceSceneState) {
       this.serviceSceneState = {};
     }
 
     this.serviceSceneState.labelsCount = count;
+    this.countsTimeRange = range;
   }
 
   public setEmbedded(embedded: boolean) {
@@ -49,23 +72,34 @@ export class MetadataService {
     this.serviceSceneState.embedded = embedded;
   }
 
-  public setFieldsCount(count: number) {
+  public setFieldsCount(count: number, range: CountsTimeRange) {
     if (!this.serviceSceneState) {
       this.serviceSceneState = {};
     }
 
     this.serviceSceneState.fieldsCount = count;
+    this.countsTimeRange = range;
   }
 
-  public setTotalLogsCount(count: number) {
+  public setTotalLogsCount(count: number | undefined, range: CountsTimeRange) {
     if (!this.serviceSceneState) {
       this.serviceSceneState = {};
     }
 
     this.serviceSceneState.totalLogsCount = count;
+    this.countsTimeRange = range;
   }
 
-  public setServiceSceneState(state: ServiceSceneCustomState) {
+  public setLogsCount(count: number | undefined, range: CountsTimeRange) {
+    if (!this.serviceSceneState) {
+      this.serviceSceneState = {};
+    }
+
+    this.serviceSceneState.logsCount = count;
+    this.countsTimeRange = range;
+  }
+
+  public setServiceSceneState(state: ServiceSceneCustomState, range: CountsTimeRange) {
     this.serviceSceneState = {
       embedded: state.embedded,
       fieldsCount: state.fieldsCount,
@@ -75,6 +109,7 @@ export class MetadataService {
       patternsCount: state.patternsCount,
       totalLogsCount: state.totalLogsCount,
     };
+    this.countsTimeRange = range;
   }
 
   public setLokiConfig(lokiConfig: LokiConfig | LokiConfigNotSupported) {
@@ -118,4 +153,10 @@ export class MetadataService {
 
 export function getMetadataService(): MetadataService {
   return metadataService;
+}
+
+// The raw scene time range, passed with every count write so restores can detect counts from another range
+export function getRawTimeRange(sceneRef: SceneObject): CountsTimeRange {
+  const { from, to } = sceneGraph.getTimeRange(sceneRef).state;
+  return { from, to };
 }

--- a/src/services/navigate.test.ts
+++ b/src/services/navigate.test.ts
@@ -12,6 +12,7 @@ jest.mock('@grafana/scenes', () => ({
   ...jest.requireActual('@grafana/scenes'),
   sceneGraph: {
     getAncestor: () => mockIndexScene,
+    getTimeRange: () => ({ state: { from: 'now-1h', to: 'now' } }),
   },
 }));
 describe('navigate', () => {

--- a/src/services/navigate.ts
+++ b/src/services/navigate.ts
@@ -4,7 +4,7 @@ import { sceneGraph } from '@grafana/scenes';
 
 import { PageSlugs, ValueSlugs } from './enums';
 import { escapePrimaryLabel } from './extensions/links';
-import { getMetadataService } from './metadata';
+import { getMetadataService, getRawTimeRange } from './metadata';
 import { prefixRoute } from './plugin';
 import { buildServicesUrl, DRILLDOWN_URL_KEYS, ROUTES } from './routing';
 import { ALL_VARIABLE_VALUE } from './variables';
@@ -62,7 +62,7 @@ export function getValueBreakdownLink(newPath: ValueSlugs, label: string, servic
     // If we're going to navigate, we need to share the state between this instantiation of the service scene
     if (serviceScene) {
       const metadataService = getMetadataService();
-      metadataService.setServiceSceneState(serviceScene.state);
+      metadataService.setServiceSceneState(serviceScene.state, getRawTimeRange(serviceScene));
     }
 
     return fullUrl;
@@ -133,7 +133,7 @@ export function navigateToDrilldownPage(path: PageSlugs, serviceScene: ServiceSc
     // If we're going to navigate, we need to share the state between this instantiation of the service scene
     if (serviceScene) {
       const metadataService = getMetadataService();
-      metadataService.setServiceSceneState(serviceScene.state);
+      metadataService.setServiceSceneState(serviceScene.state, getRawTimeRange(serviceScene));
     }
 
     pushUrlHandler(drilldownLink);


### PR DESCRIPTION
## Summary 📝
 Took a 🔪 stab at this...I'm not sure I updated metadata correctly. Let me know what you think or feel free to close it.

- Fixes #2049 ([BUG]: Unexpected/potentially incorrect count in Logs volume/Logs list): the Logs tab badge, **Log volume (N)** title, and **Logs (N)** panel title now agree — they show the exact returned-line count while under the line limit, and fall back to the (approximate) instant count query total only when the limit is hit. Shared `getDisplayedLogsCount`/`formatLogsCount` helpers replace four hand-rolled copies.
- Stale counts no longer survive navigation: the count query re-runs on every `ServiceScene` activation, counts cached in `MetadataService` are stamped with the time range they were computed for and discarded on restore when it differs, and counts clear while their queries re-run instead of flashing the previous range's value.

## Test 🧪

- [x] `pnpm typecheck`, eslint, prettier, and the full jest suite pass (837 tests); new unit tests cover the display precedence (`logsCount.test.ts`) and the range stamp + `clearCounts` (`metadata.test.ts`).
- [x] Manually verified against local docker Loki and a cloud dev stack: zoom and navigate-away-and-back keep all three counts in sync; no previous-range count flash; over the line limit the badge/title switch to the instant total (traced the `logsCountQuery`/`logsPanelQuery` responses in devtools to confirm sources).


https://github.com/user-attachments/assets/8d7af701-b775-4fee-a077-b460d6ac0552



🤖 Generated with [Claude Code](https://claude.com/claude-code)