### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ overrides:
   webpack: 5.108.1
   websocket-driver@<0.7.5: 0.7.5
   postcss@<8.5.18: 8.5.23
-  nanoid: 3.3.17
+  nanoid: 3.3.18
 
 importers:
   .:
@@ -6149,9 +6149,9 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.17:
+  nanoid@3.3.18:
     resolution:
-      { integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g== }
+      { integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w== }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
@@ -14052,7 +14052,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.6
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -14343,7 +14343,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,4 +74,4 @@ overrides:
   webpack: 5.108.1
   'websocket-driver@<0.7.5': 0.7.5
   'postcss@<8.5.18': 8.5.23
-  nanoid: 3.3.17
+  nanoid: 3.3.18


### PR DESCRIPTION
## Summary
Updates pnpm overrides in `pnpm-workspace.yaml` to resolve `pnpm audit` findings. Most CVE overrides had already landed on `main`; this PR bumps the one remaining fixable finding.

- **nanoid**: `3.3.17` → `3.3.18` (GHSA-2v37-7h3g-55p8, high — custom generators can loop indefinitely when size is zero)

`pnpm-lock.yaml` is regenerated; `react-router-dom` resolves to the already-pinned `7.18.2`.

## Test plan
- [x] `pnpm install --no-frozen-lockfile` succeeds; lockfile passes supply-chain policies (no protections disabled)
- [x] `pnpm audit`: high/critical count is 0; nanoid resolved. 2 moderate remain — see Known remaining
- [x] `pnpm run typecheck` (`tsc --noEmit`) passes

## Known remaining
No installable patch is available for these, so they are intentionally left flagged:

- **react-router** GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg (`>=6.0.0 <7.18.0`, moderate). All 11 paths come solely via `@grafana/ui > react-router-dom-v5-compat > react-router@6.30.4`. The react-router 6.x line dead-ends at `6.30.4` (no 6.x patch published), and `react-router-dom-v5-compat` imports `UNSAFE_useRoutesImpl`, `UNSAFE_useRouteId` and `UNSAFE_logV6DeprecationWarnings`, which react-router 7 no longer exports — so a bare `react-router` override would collapse both majors onto 7.x and break `@grafana/ui` at runtime. This needs an upstream `@grafana/ui` bump off `react-router-dom-v5-compat`, not an override here. (This rationale is already documented inline in `pnpm-workspace.yaml`.)