### PR TITLE
fix(LogList): show the exact log count in volume and logs panels

### DIFF
--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css, cx } from '@emotion/css';
 
-import { getValueFormat, GrafanaTheme2 } from '@grafana/data';
+import { formattedValueToString, getValueFormat, GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 
@@ -188,25 +188,15 @@ function LogsCount(
   maxLines: number
 ) {
   const styles = useStyles2(getLogsCountStyles);
-  const valueFormatter = getValueFormat('short');
+  const valueFormatter = getValueFormat('locale');
 
   // The instant query (totalCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
   if (totalCount === undefined && logsCount !== undefined && logsCount < maxLines) {
     const formattedCount = valueFormatter(logsCount, 0);
-    return (
-      <span className={cx(className, styles.logsCountStyles)}>
-        {formattedCount.text}
-        {formattedCount.suffix?.trim()}
-      </span>
-    );
+    return <span className={cx(className, styles.logsCountStyles)}>{formattedValueToString(formattedCount)}</span>;
   } else if (totalCount !== undefined) {
     const formattedTotalCount = valueFormatter(totalCount, 0);
-    return (
-      <span className={cx(className, styles.logsCountStyles)}>
-        {formattedTotalCount.text}
-        {formattedTotalCount.suffix?.trim()}
-      </span>
-    );
+    return <span className={cx(className, styles.logsCountStyles)}>{formattedValueToString(formattedTotalCount)}</span>;
   }
 
   return <span className={cx(className, styles.emptyCountStyles)}></span>;

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css, cx } from '@emotion/css';
 
-import { formattedValueToString, getValueFormat, GrafanaTheme2 } from '@grafana/data';
+import { getValueFormat, GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 
@@ -188,15 +188,25 @@ function LogsCount(
   maxLines: number
 ) {
   const styles = useStyles2(getLogsCountStyles);
-  const valueFormatter = getValueFormat('locale');
+  const valueFormatter = getValueFormat('short');
 
   // The instant query (totalCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
   if (totalCount === undefined && logsCount !== undefined && logsCount < maxLines) {
     const formattedCount = valueFormatter(logsCount, 0);
-    return <span className={cx(className, styles.logsCountStyles)}>{formattedValueToString(formattedCount)}</span>;
+    return (
+      <span className={cx(className, styles.logsCountStyles)}>
+        {formattedCount.text}
+        {formattedCount.suffix?.trim()}
+      </span>
+    );
   } else if (totalCount !== undefined) {
     const formattedTotalCount = valueFormatter(totalCount, 0);
-    return <span className={cx(className, styles.logsCountStyles)}>{formattedValueToString(formattedTotalCount)}</span>;
+    return (
+      <span className={cx(className, styles.logsCountStyles)}>
+        {formattedTotalCount.text}
+        {formattedTotalCount.suffix?.trim()}
+      </span>
+    );
   }
 
   return <span className={cx(className, styles.emptyCountStyles)}></span>;

--- a/src/Components/ServiceScene/LogsPanelScene.tsx
+++ b/src/Components/ServiceScene/LogsPanelScene.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent } from 'react';
 
-import { DataFrame, getValueFormat, LogRowModel, shallowCompare } from '@grafana/data';
+import { DataFrame, formattedValueToString, getValueFormat, LogRowModel, shallowCompare } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import {
@@ -300,9 +300,9 @@ export class LogsPanelScene extends SceneObjectBase<LogsPanelSceneState> {
   }
 
   private getTitle(logsCount: number | undefined) {
-    const valueFormatter = getValueFormat('short');
+    const valueFormatter = getValueFormat('locale');
     const formattedCount = logsCount !== undefined ? valueFormatter(logsCount, 0) : undefined;
-    return formattedCount !== undefined ? `Logs (${formattedCount.text}${formattedCount.suffix?.trim()})` : 'Logs';
+    return formattedCount !== undefined ? `Logs (${formattedValueToString(formattedCount)})` : 'Logs';
   }
 
   private getLogsPanel = () => {

--- a/src/Components/ServiceScene/LogsTablePanelScene.tsx
+++ b/src/Components/ServiceScene/LogsTablePanelScene.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/css';
 import {
   FieldConfig,
   FieldConfigSource,
+  formattedValueToString,
   getValueFormat,
   GrafanaTheme2,
   LogsSortOrder,
@@ -246,9 +247,9 @@ export class LogsTablePanelScene extends SceneObjectBase<LogsTablePanelSceneStat
   }
 
   private getTitle(logsCount: number | undefined) {
-    const valueFormatter = getValueFormat('short');
+    const valueFormatter = getValueFormat('locale');
     const formattedCount = logsCount !== undefined ? valueFormatter(logsCount, 0) : undefined;
-    return formattedCount !== undefined ? `Logs (${formattedCount.text}${formattedCount.suffix?.trim()})` : 'Logs';
+    return formattedCount !== undefined ? `Logs (${formattedValueToString(formattedCount)})` : 'Logs';
   }
 
   onLoadSyncDisplayedFieldsWithUrlColumns = () => {

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DataFrame, getValueFormat, LoadingState } from '@grafana/data';
+import { DataFrame, formattedValueToString, getValueFormat, LoadingState } from '@grafana/data';
 import {
   PanelBuilders,
   SceneComponentProps,
@@ -104,17 +104,15 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private getTitle(totalLogsCount: number | undefined, logsCount: number | undefined) {
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
     const maxLines = indexScene.state.ds?.maxLines ?? LINE_LIMIT;
-    const valueFormatter = getValueFormat('short');
+    const valueFormatter = getValueFormat('locale');
     const formattedTotalCount = totalLogsCount !== undefined ? valueFormatter(totalLogsCount, 0) : undefined;
     // The instant query (totalLogsCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
     if (totalLogsCount === undefined && logsCount !== undefined && logsCount < maxLines) {
       const formattedCount = valueFormatter(logsCount, 0);
-      return formattedCount !== undefined
-        ? `Log volume (${formattedCount.text}${formattedCount.suffix?.trim()})`
-        : 'Log volume';
+      return formattedCount !== undefined ? `Log volume (${formattedValueToString(formattedCount)})` : 'Log volume';
     }
     return formattedTotalCount !== undefined
-      ? `Log volume (${formattedTotalCount.text}${formattedTotalCount.suffix?.trim()})`
+      ? `Log volume (${formattedValueToString(formattedTotalCount)})`
       : 'Log volume';
   }
 


### PR DESCRIPTION
Before:

<img width="216" height="376" alt="imagen" src="https://github.com/user-attachments/assets/e2acf3ad-e53f-410b-b4c2-107ba901beac" />

After:

<img width="262" height="367" alt="imagen" src="https://github.com/user-attachments/assets/83eb43e3-420d-449c-bea1-c08f14cdfd2e" />

The tab remains using the short number to prevent it from growing too much for very high volume. The correct count can be found in Logs Volume.