### PR TITLE
fix(LogsVolumePanel): improve accuracy of results in the panel title displayed count

### DIFF
--- a/src/Components/IndexScene/IndexScene.tsx
+++ b/src/Components/IndexScene/IndexScene.tsx
@@ -260,10 +260,6 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
     this._subs.add(unsub);
     this.addActivationHandler(this.onActivate.bind(this));
-
-    getLokiDatasource(this).then((ds) => {
-      this.setState({ ds });
-    });
   }
 
   static Component = ({ model }: SceneComponentProps<IndexScene>) => {
@@ -387,6 +383,7 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
 
     this._subs.add(this.subscribeToLokiConfigAPI());
     this._subs.add(this.subscribeToDataSourceChange());
+    this.updateDatasource();
 
     this.getDefaultColumnsFromAppPlatform();
     this.getDefaultLabelsAndSetContentScene();
@@ -498,9 +495,16 @@ export class IndexScene extends SceneObjectBase<IndexSceneState> {
     }
   }
 
+  private updateDatasource() {
+    getLokiDatasource(this).then((ds) => {
+      this.setState({ ds });
+    });
+  }
+
   private subscribeToDataSourceChange() {
     return getDataSourceVariable(this).subscribeToState((newState, prevState) => {
       if (newState.value !== prevState.value) {
+        this.updateDatasource();
         this.state.$lokiConfig.runQueries();
         this.getDefaultColumnsFromAppPlatform();
       }

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css, cx } from '@emotion/css';
 
-import { getValueFormat, GrafanaTheme2 } from '@grafana/data';
+import { formattedValueToString, getValueFormat, GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Box, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 
@@ -191,22 +191,12 @@ function LogsCount(
   const valueFormatter = getValueFormat('short');
 
   // The instant query (totalCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
-  if (totalCount === undefined && logsCount !== undefined && logsCount < maxLines) {
+  if (logsCount !== undefined && logsCount < maxLines) {
     const formattedCount = valueFormatter(logsCount, 0);
-    return (
-      <span className={cx(className, styles.logsCountStyles)}>
-        {formattedCount.text}
-        {formattedCount.suffix?.trim()}
-      </span>
-    );
+    return <span className={cx(className, styles.logsCountStyles)}>{formattedValueToString(formattedCount)}</span>;
   } else if (totalCount !== undefined) {
     const formattedTotalCount = valueFormatter(totalCount, 0);
-    return (
-      <span className={cx(className, styles.logsCountStyles)}>
-        {formattedTotalCount.text}
-        {formattedTotalCount.suffix?.trim()}
-      </span>
-    );
+    return <span className={cx(className, styles.logsCountStyles)}>{formattedValueToString(formattedTotalCount)}</span>;
   }
 
   return <span className={cx(className, styles.emptyCountStyles)}></span>;

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -30,6 +30,7 @@ import { areArraysEqual } from 'services/comparison';
 import { getTimeSeriesExpr } from 'services/expressions';
 import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
+import { sumLogsVolumeSeries } from 'services/logsVolume';
 import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
 import { buildDataQuery, LINE_LIMIT } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
@@ -101,13 +102,21 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     );
   }
 
-  private getTitle(totalLogsCount: number | undefined, logsCount: number | undefined) {
+  private getTitle() {
+    const isCollapsed = getLogsVolumeOption('collapsed');
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    // Instant query or logs volume count
+    const totalLogsCount = this.getVolumeOrInstantQueryCount();
+    // Logs Panel response count
+    const logsCount = serviceScene.state.logsCount;
+
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
     const maxLines = indexScene.state.ds?.maxLines ?? LINE_LIMIT;
-    const valueFormatter = getValueFormat('locale');
+    // The instant query can be inaccurate, so we show a short version of the number. A full-range logs volume query will return the correct count.
+    const valueFormatter = getValueFormat(isCollapsed ? 'short' : 'locale');
     const formattedTotalCount = totalLogsCount !== undefined ? valueFormatter(totalLogsCount, 0) : undefined;
     // The instant query (totalLogsCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
-    if (totalLogsCount === undefined && logsCount !== undefined && logsCount < maxLines) {
+    if (logsCount !== undefined && logsCount < maxLines) {
       const formattedCount = valueFormatter(logsCount, 0);
       return formattedCount !== undefined ? `Log volume (${formattedValueToString(formattedCount)})` : 'Log volume';
     }
@@ -115,6 +124,16 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       ? `Log volume (${formattedValueToString(formattedTotalCount)})`
       : 'Log volume';
   }
+
+  private getVolumeOrInstantQueryCount = () => {
+    const panelData = this.state.panel?.state.$data?.state.data;
+    if (panelData?.state === LoadingState.Done && panelData.series) {
+      return sumLogsVolumeSeries(panelData.series);
+    }
+
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    return serviceScene.state.totalLogsCount;
+  };
 
   private setCollapsed(collapsed: boolean | undefined, panel: VizPanel) {
     if (collapsed) {
@@ -141,7 +160,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     const isCollapsed = getLogsVolumeOption('collapsed');
     // Overrides are defined by setLogsVolumeFieldConfigOverrides, any overrides added here will be overwritten!
     const viz = PanelBuilders.timeseries()
-      .setTitle(this.getTitle(serviceScene.state.totalLogsCount, serviceScene.state.logsCount))
+      .setTitle(this.getTitle())
       .setOption('legend', {
         calcs: ['sum'],
         displayMode: LegendDisplayMode.List,
@@ -205,7 +224,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
             });
           } else {
             this.state.panel.setState({
-              title: this.getTitle(newState.totalLogsCount, newState.logsCount),
+              title: this.getTitle(),
             });
           }
         }
@@ -228,6 +247,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
           this.displayVisibleRange();
         }
         syncLevelsVisibleSeries(panel, newState.data.series, this);
+        panel.setState({
+          title: this.getTitle(),
+        });
       })
     );
   }

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -8,6 +8,7 @@ import {
   LoadingState,
   ValueFormatter,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import {
   PanelBuilders,
   SceneComponentProps,
@@ -120,9 +121,11 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
     const maxLines = indexScene.state.ds?.maxLines ?? LINE_LIMIT;
 
+    const title = t('components.service-scene.logs-volume.logs-volume-panel.title', 'Log volume');
+
     // Potentially inaccurate, wait for logsCount
     if (totalLogsCount !== undefined && totalLogsCount < maxLines && logsCount === undefined) {
-      return 'Log volume';
+      return title;
     }
 
     let valueFormatter: ValueFormatter;
@@ -138,7 +141,15 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       formattedCount = valueFormatter(totalLogsCount, 0);
     }
 
-    return formattedCount !== undefined ? `Log volume (${formattedValueToString(formattedCount)})` : 'Log volume';
+    return formattedCount !== undefined
+      ? t(
+          'components.service-scene.logs-volume.logs-volume-panel.title-with-count',
+          'Log volume ({{formattedCount}})',
+          {
+            formattedCount: formattedValueToString(formattedCount),
+          }
+        )
+      : title;
   }
 
   private getVolumeOrInstantQueryCount = () => {

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -144,7 +144,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private getVolumeOrInstantQueryCount = () => {
     const panelData = this.state.panel?.state.$data?.state.data;
     if (panelData?.series) {
-      return sumLogsVolumeSeries(panelData.series);
+      return sumLogsVolumeSeries(panelData.series, this);
     }
 
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
@@ -244,6 +244,17 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
             });
           }
         }
+      })
+    );
+
+    this._subs.add(
+      getLevelsVariable(this).subscribeToState((newState, prevState) => {
+        if (areArraysEqual(newState.filters, prevState.filters) || !this.state.panel) {
+          return;
+        }
+        this.state.panel.setState({
+          title: this.getTitle(),
+        });
       })
     );
 

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-import { DataFrame, formattedValueToString, getValueFormat, LoadingState } from '@grafana/data';
+import {
+  DataFrame,
+  FormattedValue,
+  formattedValueToString,
+  getValueFormat,
+  LoadingState,
+  ValueFormatter,
+} from '@grafana/data';
 import {
   PanelBuilders,
   SceneComponentProps,
@@ -112,22 +119,31 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
     const indexScene = sceneGraph.getAncestor(this, IndexScene);
     const maxLines = indexScene.state.ds?.maxLines ?? LINE_LIMIT;
-    // The instant query can be inaccurate, so we show a short version of the number. A full-range logs volume query will return the correct count.
-    const valueFormatter = getValueFormat(isCollapsed ? 'short' : 'locale');
-    const formattedTotalCount = totalLogsCount !== undefined ? valueFormatter(totalLogsCount, 0) : undefined;
+
+    // Potentially inaccurate, wait for logsCount
+    if (totalLogsCount !== undefined && totalLogsCount < maxLines && logsCount === undefined) {
+      return 'Log volume';
+    }
+
+    let valueFormatter: ValueFormatter;
+    let formattedCount: FormattedValue | undefined = undefined;
+
     // The instant query (totalLogsCount) doesn't return good results for small result sets, if we're below the max number of lines, use the logs query result instead.
     if (logsCount !== undefined && logsCount < maxLines) {
-      const formattedCount = valueFormatter(logsCount, 0);
-      return formattedCount !== undefined ? `Log volume (${formattedValueToString(formattedCount)})` : 'Log volume';
+      valueFormatter = getValueFormat('locale');
+      formattedCount = valueFormatter(logsCount, 0);
+    } else if (totalLogsCount !== undefined) {
+      // The instant query can be inaccurate, so we show a short version of the number. A full-range logs volume query will return the correct count.
+      valueFormatter = getValueFormat(isCollapsed ? 'short' : 'locale');
+      formattedCount = valueFormatter(totalLogsCount, 0);
     }
-    return formattedTotalCount !== undefined
-      ? `Log volume (${formattedValueToString(formattedTotalCount)})`
-      : 'Log volume';
+
+    return formattedCount !== undefined ? `Log volume (${formattedValueToString(formattedCount)})` : 'Log volume';
   }
 
   private getVolumeOrInstantQueryCount = () => {
     const panelData = this.state.panel?.state.$data?.state.data;
-    if (panelData?.state === LoadingState.Done && panelData.series) {
+    if (panelData?.series) {
       return sumLogsVolumeSeries(panelData.series);
     }
 

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -725,6 +725,12 @@
         },
         "text-loading": "Loading..."
       },
+      "logs-volume": {
+        "logs-volume-panel": {
+          "title": "Log volume",
+          "title-with-count": "Log volume ({{formattedCount}})"
+        }
+      },
       "text-loading": "Loading..."
     },
     "service-selection-scene": {

--- a/src/services/logsVolume.test.ts
+++ b/src/services/logsVolume.test.ts
@@ -1,7 +1,7 @@
 import { FieldType, LoadingState, toDataFrame } from '@grafana/data';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 
-import { readLevelsFromCompletedLogsVolumePanel, getLevelsFromLogsVolume } from './logsVolume';
+import { readLevelsFromCompletedLogsVolumePanel, getLevelsFromLogsVolume, sumLogsVolumeSeries } from './logsVolume';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
 
 describe('readLevelsFromCompletedLogsVolumePanel', () => {
@@ -91,5 +91,58 @@ describe('getLevelsFromLogsVolume', () => {
   it('returns null when no logs volume panel exists in the scene', () => {
     jest.spyOn(sceneGraph, 'findObject').mockReturnValue(null);
     expect(getLevelsFromLogsVolume({} as SceneObject, '')).toBeNull();
+  });
+});
+
+describe('sumLogsVolumeSeries', () => {
+  it('sums numeric values across all series', () => {
+    const series = [
+      toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [0, 1] },
+          {
+            labels: { detected_level: 'error' },
+            name: 'Value',
+            type: FieldType.number,
+            values: [1, 2],
+          },
+        ],
+      }),
+      toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [0, 1] },
+          {
+            labels: { detected_level: 'warn' },
+            name: 'Value',
+            type: FieldType.number,
+            values: [3, 4],
+          },
+        ],
+      }),
+    ];
+    expect(sumLogsVolumeSeries(series)).toBe(10);
+  });
+
+  it('ignores non-finite values and frames without a number field', () => {
+    const series = [
+      toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [0, 1, 2] },
+          {
+            name: 'Value',
+            type: FieldType.number,
+            values: [5, Number.NaN, Number.POSITIVE_INFINITY],
+          },
+        ],
+      }),
+      toDataFrame({
+        fields: [{ name: 'Time', type: FieldType.time, values: [0, 1] }],
+      }),
+    ];
+    expect(sumLogsVolumeSeries(series)).toBe(5);
+  });
+
+  it('returns 0 for empty series', () => {
+    expect(sumLogsVolumeSeries([])).toBe(0);
   });
 });

--- a/src/services/logsVolume.test.ts
+++ b/src/services/logsVolume.test.ts
@@ -1,8 +1,13 @@
-import { FieldType, LoadingState, toDataFrame } from '@grafana/data';
-import { sceneGraph, SceneObject } from '@grafana/scenes';
+import { AdHocVariableFilter, FieldType, LoadingState, toDataFrame } from '@grafana/data';
+import { AdHocFiltersVariable, sceneGraph, SceneObject } from '@grafana/scenes';
 
+import { FilterOp } from './filterTypes';
 import { readLevelsFromCompletedLogsVolumePanel, getLevelsFromLogsVolume, sumLogsVolumeSeries } from './logsVolume';
+import { getLevelsVariable } from './variableGetters';
+import { VAR_LEVELS } from './variables';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
+
+jest.mock('./variableGetters');
 
 describe('readLevelsFromCompletedLogsVolumePanel', () => {
   it('returns null when the panel is collapsed', () => {
@@ -95,36 +100,71 @@ describe('getLevelsFromLogsVolume', () => {
 });
 
 describe('sumLogsVolumeSeries', () => {
-  it('sums numeric values across all series', () => {
-    const series = [
-      toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [0, 1] },
-          {
-            labels: { detected_level: 'error' },
-            name: 'Value',
-            type: FieldType.number,
-            values: [1, 2],
-          },
-        ],
-      }),
-      toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [0, 1] },
-          {
-            labels: { detected_level: 'warn' },
-            name: 'Value',
-            type: FieldType.number,
-            values: [3, 4],
-          },
-        ],
-      }),
-    ];
-    expect(sumLogsVolumeSeries(series)).toBe(10);
+  const scene = {} as SceneObject;
+
+  function setup(filters: AdHocVariableFilter[]) {
+    const levelsVariable = new AdHocFiltersVariable({
+      filters,
+      name: VAR_LEVELS,
+    });
+    jest.mocked(getLevelsVariable).mockReturnValue(levelsVariable);
+  }
+
+  const series = [
+    toDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [0, 1] },
+        {
+          labels: { detected_level: 'error' },
+          name: 'Value',
+          type: FieldType.number,
+          values: [1, 2],
+        },
+      ],
+    }),
+    toDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [0, 1] },
+        {
+          labels: { detected_level: 'warn' },
+          name: 'Value',
+          type: FieldType.number,
+          values: [3, 4],
+        },
+      ],
+    }),
+  ];
+
+  it('sums numeric values across all series when there are no level filters', () => {
+    setup([]);
+    expect(sumLogsVolumeSeries(series, scene)).toBe(10);
+  });
+
+  it('sums only series that match inclusive level filters', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.Equal,
+        value: 'error',
+      },
+    ]);
+    expect(sumLogsVolumeSeries(series, scene)).toBe(3);
+  });
+
+  it('excludes series that match exclusive level filters', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.NotEqual,
+        value: 'error',
+      },
+    ]);
+    expect(sumLogsVolumeSeries(series, scene)).toBe(7);
   });
 
   it('ignores non-finite values and frames without a number field', () => {
-    const series = [
+    setup([]);
+    const mixedSeries = [
       toDataFrame({
         fields: [
           { name: 'Time', type: FieldType.time, values: [0, 1, 2] },
@@ -139,10 +179,11 @@ describe('sumLogsVolumeSeries', () => {
         fields: [{ name: 'Time', type: FieldType.time, values: [0, 1] }],
       }),
     ];
-    expect(sumLogsVolumeSeries(series)).toBe(5);
+    expect(sumLogsVolumeSeries(mixedSeries, scene)).toBe(5);
   });
 
   it('returns 0 for empty series', () => {
-    expect(sumLogsVolumeSeries([])).toBe(0);
+    setup([]);
+    expect(sumLogsVolumeSeries([], scene)).toBe(0);
   });
 });

--- a/src/services/logsVolume.ts
+++ b/src/services/logsVolume.ts
@@ -1,8 +1,27 @@
-import { LoadingState } from '@grafana/data';
+import { DataFrame, FieldType, LoadingState } from '@grafana/data';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { getLevelLabelsFromSeries } from './levels';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
+
+/**
+ * Sums every numeric sample across logs volume range series (all levels / buckets).
+ */
+export function sumLogsVolumeSeries(series: DataFrame[]): number {
+  let total = 0;
+  for (const frame of series) {
+    const valueField = frame.fields.find((field) => field.type === FieldType.number);
+    if (!valueField) {
+      continue;
+    }
+    for (const value of valueField.values) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        total += value;
+      }
+    }
+  }
+  return total;
+}
 
 /**
  * Reads distinct detected_level names from a completed logs volume (range) query.

--- a/src/services/logsVolume.ts
+++ b/src/services/logsVolume.ts
@@ -1,15 +1,23 @@
 import { DataFrame, FieldType, LoadingState } from '@grafana/data';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 
-import { getLevelLabelsFromSeries } from './levels';
+import { getLevelLabelsFromSeries, getVisibleLevels } from './levels';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
 
 /**
- * Sums every numeric sample across logs volume range series (all levels / buckets).
+ * Sums volume samples for series that match active level filters.
  */
-export function sumLogsVolumeSeries(series: DataFrame[]): number {
+export function sumLogsVolumeSeries(series: DataFrame[], sceneRef: SceneObject): number {
+  const levelsByFrame = getLevelLabelsFromSeries(series);
+  const visibleLevels = new Set(getVisibleLevels(levelsByFrame, sceneRef));
+
   let total = 0;
-  for (const frame of series) {
+  for (let i = 0; i < series.length; i++) {
+    const frame = series[i];
+    const level = levelsByFrame[i];
+    if (frame == null || level == null || !visibleLevels.has(level)) {
+      continue;
+    }
     const valueField = frame.fields.find((field) => field.type === FieldType.number);
     if (!valueField) {
       continue;


### PR DESCRIPTION
Follow up to https://github.com/grafana/logs-drilldown/pull/2056

As there are scenarios where the instant query can return inaccurate numbers, we're further updating the Logs Volume count to:

- If collapsed, show the instant query result in short format (matching the tab)

<img width="1451" height="143" alt="Collapsed" src="https://github.com/user-attachments/assets/81a53311-1694-4633-bb95-86c9195bc9bc" />

- If expanded, use the count from the Logs Volume metric query response, which will be accurate (and match the visualization)

<img width="1444" height="320" alt="Expanded" src="https://github.com/user-attachments/assets/29ff9e9f-60b4-4d25-bb3a-6b0654b0f34a" />

- If the logs result is below the line limit (matching a few logs), use the count from the Logs response

<img width="1449" height="370" alt="Small numbers" src="https://github.com/user-attachments/assets/541849b4-35cc-4af3-9ca0-b30c538e14ea" />

Additionally:

- When the short version is used in the Tab or Panel title, it uses Grafana's value formatter which adds a space before the unit, matching the format from the series legends.
- Fixes a bug where the ds instance held by IndexScene was out of date, affecting maxLines.

### How to test

- Select a label to go to the service details
- If there are 1493 logs and the line limit is 1000:
  - The Logs tab should show a short version (e.g. 1.4 K)
  - Logs volume show 1493, which should match the count of every log level
  - The logs visualization should show 1000 and have 1000 logs in the panel.
- Change the line limit, zoom in or out using Logs Volume, these counts should be consistent.

Get logs using Graft or in Core Grafana with `make devenv sources=loki`
