### PR TITLE
fix(panels): add mapping for trace color

### DIFF
--- a/src/services/levels.ts
+++ b/src/services/levels.ts
@@ -1,7 +1,7 @@
 import { DataFrame, FieldType, GrafanaTheme2, MappingType, ValueMap } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
-import { SeriesVisibilityChangeMode } from '@grafana/ui';
+import { colors, SeriesVisibilityChangeMode } from '@grafana/ui';
 
 import { isOperatorExclusive, isOperatorInclusive } from './operatorHelpers';
 import { UNKNOWN_LEVEL_LOGS } from './panel';
@@ -96,7 +96,7 @@ export const LEVEL_COLORS = {
   debug: config.theme2.isDark ? '#9e9e9e' : 'dimgray',
   error: 'semi-dark-red',
   info: 'semi-dark-blue',
-  trace: 'light-blue',
+  trace: colors[2],
   // matches LogLevelColor for unknown in grafana core logsModel.ts
   unknown: config.theme2.isDark ? '#8e8e8e' : '#bdc4cd',
   warn: 'semi-dark-orange',

--- a/src/services/panel.test.ts
+++ b/src/services/panel.test.ts
@@ -11,6 +11,7 @@ import {
   sortLevelTransformation,
   UNKNOWN_LEVEL_FIELD_NAME_REGEX,
   WARNING_LEVEL_FIELD_NAME_REGEX,
+  TRACE_LEVEL_FIELD_NAME_REGEX,
 } from './panel';
 
 describe('setLevelColorOverrides', () => {
@@ -25,8 +26,8 @@ describe('setLevelColorOverrides', () => {
     setLevelColorOverrides(overrides);
 
     // Ensure the correct number of calls
-    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledTimes(6);
-    expect(overrideColorMock).toHaveBeenCalledTimes(6);
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledTimes(7);
+    expect(overrideColorMock).toHaveBeenCalledTimes(7);
 
     // Check that regex is called correctly for each field
     expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(INFO_LEVEL_FIELD_NAME_REGEX).toString());
@@ -34,6 +35,7 @@ describe('setLevelColorOverrides', () => {
     expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(WARNING_LEVEL_FIELD_NAME_REGEX).toString());
     expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(ERROR_LEVEL_FIELD_NAME_REGEX).toString());
     expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(CRITICAL_LEVEL_FIELD_NAME_REGEX).toString());
+    expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(TRACE_LEVEL_FIELD_NAME_REGEX).toString());
     expect(matchFieldsWithNameByRegexMock).toHaveBeenCalledWith(new RegExp(UNKNOWN_LEVEL_FIELD_NAME_REGEX).toString());
   });
 });

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -41,6 +41,7 @@ export const DEBUG_LEVEL_FIELD_NAME_REGEX = /^debug$/i;
 export const WARNING_LEVEL_FIELD_NAME_REGEX = /^(warn|warning)$/i;
 export const ERROR_LEVEL_FIELD_NAME_REGEX = /^(error|errors)$/i;
 export const CRITICAL_LEVEL_FIELD_NAME_REGEX = /^(crit|critical|fatal|severe)$/i;
+export const TRACE_LEVEL_FIELD_NAME_REGEX = /^trace$/i;
 export const UNKNOWN_LEVEL_FIELD_NAME_REGEX = /^(logs|unknown)$/i;
 
 export const logsLabelLevelsMatches: Record<string, RegExp> = {
@@ -71,6 +72,10 @@ export function setLevelColorOverrides(overrides: FieldConfigOverridesBuilder<Fi
   });
   overrides.matchFieldsWithNameByRegex(CRITICAL_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({
     fixedColor: LEVEL_COLORS.critical,
+    mode: 'fixed',
+  });
+  overrides.matchFieldsWithNameByRegex(TRACE_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({
+    fixedColor: LEVEL_COLORS.trace,
     mode: 'fixed',
   });
   overrides.matchFieldsWithNameByRegex(UNKNOWN_LEVEL_FIELD_NAME_REGEX.toString()).overrideColor({


### PR DESCRIPTION
Color mapping for the trace level has been missing since the beginning. Adding in this PR.

<img width="360" height="531" alt="Trace" src="https://github.com/user-attachments/assets/5392f065-d7a8-4044-937f-3bc43e667a7c" />
