### PR TITLE
feat(LosgVolume): Support aggregation by other log fields

### DIFF
--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -79,6 +79,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
     }
 
     const { $data, loading, logsCount, totalLogsCount, ...state } = serviceScene.useState();
+    const { loadSearchScene, shareButtonScene } = model.useState();
     const maxLines = getMaxLines(model);
 
     const loadingStates = state.loadingStates;
@@ -87,13 +88,9 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
       <Box paddingY={0}>
         <div className={styles.actions}>
           <Stack gap={1}>
-            {model.state.shareButtonScene && (
-              <model.state.shareButtonScene.Component model={model.state.shareButtonScene} />
-            )}
+            {shareButtonScene && <shareButtonScene.Component model={shareButtonScene} />}
             <SaveSearchButton sceneRef={model} />
-            {model.state.loadSearchScene && (
-              <model.state.loadSearchScene.Component model={model.state.loadSearchScene} />
-            )}
+            {loadSearchScene && <loadSearchScene.Component model={loadSearchScene} />}
           </Stack>
         </div>
 

--- a/src/Components/ServiceScene/ActionBarScene.tsx
+++ b/src/Components/ServiceScene/ActionBarScene.tsx
@@ -15,13 +15,11 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'se
 import { PageSlugs, TabNames, ValueSlugs } from 'services/enums';
 import { narrowPageSlug } from 'services/narrowing';
 import { getDrillDownTabLink } from 'services/navigate';
-import { LINE_LIMIT } from 'services/query';
 import { getDrilldownSlug, getDrilldownValueSlug } from 'services/routing';
 import { getMaxLines } from 'services/store';
 
 export interface ActionBarSceneState extends SceneObjectState {
   loadSearchScene?: LoadSearchScene;
-  maxLines?: number;
   shareButtonScene?: ShareButtonScene;
 }
 
@@ -33,10 +31,6 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
   }
 
   onActivate() {
-    this.setState({
-      maxLines: getMaxLines(this),
-    });
-
     if (!this.state.shareButtonScene) {
       this.setState({
         shareButtonScene: new ShareButtonScene({}),
@@ -85,7 +79,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
     }
 
     const { $data, loading, logsCount, totalLogsCount, ...state } = serviceScene.useState();
-    const { maxLines } = model.useState();
+    const maxLines = getMaxLines(model);
 
     const loadingStates = state.loadingStates;
 
@@ -118,7 +112,7 @@ export class ActionBarScene extends SceneObjectBase<ActionBarSceneState> {
                   counter={loadingStates[tab.displayName] ? undefined : getCounter(tab, state)}
                   suffix={
                     tab.displayName === TabNames.logs
-                      ? ({ className }) => LogsCount(className, totalLogsCount, logsCount, maxLines ?? LINE_LIMIT)
+                      ? ({ className }) => LogsCount(className, totalLogsCount, logsCount, maxLines)
                       : undefined
                   }
                   icon={loadingStates[tab.displayName] ? 'spinner' : undefined}

--- a/src/Components/ServiceScene/JSONLogsScene.tsx
+++ b/src/Components/ServiceScene/JSONLogsScene.tsx
@@ -166,8 +166,6 @@ export class JSONLogsScene extends SceneObjectBase<JSONLogsSceneState> {
       } else {
         this.setVizFlags(detectedFieldFrame);
       }
-    } else if (serviceScene.state?.$detectedFieldsData?.state.data?.state === undefined) {
-      serviceScene.state?.$detectedFieldsData?.runQueries();
     }
 
     // Subscribe to detected fields

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.test.ts
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.test.ts
@@ -2,9 +2,14 @@ import { sceneGraph, VizPanel } from '@grafana/scenes';
 
 import { LogsVolumePanel } from './LogsVolumePanel';
 import { LogsVolumeActions } from 'Components/ServiceScene/LogsVolumeActions';
+import { getFeatureFlag } from 'featureFlags/openFeature';
 import { getQueryRunnerFromProvider } from 'services/panel';
 import { setLogsVolumeAggregateBy } from 'services/store';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
+
+jest.mock('featureFlags/openFeature', () => ({
+  getFeatureFlag: jest.fn(() => true),
+}));
 
 jest.mock('services/expressions', () => ({
   getLogsVolumeQuery: jest.fn(
@@ -42,6 +47,7 @@ function createPanel(aggregateBy: string) {
 describe('LogsVolumePanel.setAggregateBy', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getFeatureFlag).mockReturnValue(true);
     jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue({
       state: { $data: undefined },
     } as never);
@@ -67,6 +73,21 @@ describe('LogsVolumePanel.setAggregateBy', () => {
     const query = queryRunner.state.queries[0];
     expect(query.legendFormat).toBe('{{pod}}');
     expect(query.expr).toContain('by (pod)');
+  });
+
+  it('does not change aggregation when the feature flag is disabled', () => {
+    jest.mocked(getFeatureFlag).mockReturnValue(false);
+    const volume = new LogsVolumePanel({});
+    const { actions, panel } = createPanel(LEVEL_VARIABLE_VALUE);
+    volume.setState({ panel });
+    const dataBefore = panel.state.$data;
+
+    volume.setAggregateBy('pod');
+
+    expect(volume.state.aggregateBy).toBe(LEVEL_VARIABLE_VALUE);
+    expect(actions.state.aggregateBy).toBe(LEVEL_VARIABLE_VALUE);
+    expect(panel.state.$data).toBe(dataBefore);
+    expect(setLogsVolumeAggregateBy).not.toHaveBeenCalled();
   });
 
   it('does not replace the panel when the field is unchanged', () => {

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.test.ts
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.test.ts
@@ -1,0 +1,84 @@
+import { sceneGraph, VizPanel } from '@grafana/scenes';
+
+import { LogsVolumePanel } from './LogsVolumePanel';
+import { LogsVolumeActions } from 'Components/ServiceScene/LogsVolumeActions';
+import { getQueryRunnerFromProvider } from 'services/panel';
+import { setLogsVolumeAggregateBy } from 'services/store';
+import { LEVEL_VARIABLE_VALUE } from 'services/variables';
+
+jest.mock('services/expressions', () => ({
+  getLogsVolumeQuery: jest.fn(
+    (_scene: unknown, field: string) => `sum(count_over_time({job="app"}[$__auto])) by (${field})`
+  ),
+  excludeAggregateByFromLogsVolumeQuery: jest.fn((expr: string) => expr),
+}));
+
+jest.mock('services/store', () => ({
+  getLogsVolumeAggregateBy: jest.fn(),
+  getLogsVolumeOption: jest.fn(),
+  getMaxLines: jest.fn(() => 1000),
+  setLogsVolumeAggregateBy: jest.fn(),
+  setLogsVolumeOption: jest.fn(),
+}));
+
+function createPanel(aggregateBy: string) {
+  const actions = new LogsVolumeActions({
+    aggregateBy,
+    onAggregateByChange: () => {},
+  });
+  const panel = {
+    state: {
+      $data: { subscribeToState: jest.fn() },
+      collapsed: false,
+      headerActions: actions,
+    },
+    setState(this: { state: Record<string, unknown> }, state: Record<string, unknown>) {
+      this.state = { ...this.state, ...state };
+    },
+  };
+  return { actions, panel: panel as unknown as VizPanel };
+}
+
+describe('LogsVolumePanel.setAggregateBy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(sceneGraph, 'getAncestor').mockReturnValue({
+      state: { $data: undefined },
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the panel and updates the query and header actions', () => {
+    const volume = new LogsVolumePanel({});
+    const { actions, panel } = createPanel(LEVEL_VARIABLE_VALUE);
+    volume.setState({ panel });
+
+    volume.setAggregateBy('pod');
+
+    expect(volume.state.panel).toBe(panel);
+    expect(volume.state.aggregateBy).toBe('pod');
+    expect(actions.state.aggregateBy).toBe('pod');
+    expect(setLogsVolumeAggregateBy).toHaveBeenCalledWith(volume, 'pod');
+
+    const queryRunner = getQueryRunnerFromProvider(panel.state.$data!);
+    const query = queryRunner.state.queries[0];
+    expect(query.legendFormat).toBe('{{pod}}');
+    expect(query.expr).toContain('by (pod)');
+  });
+
+  it('does not replace the panel when the field is unchanged', () => {
+    const volume = new LogsVolumePanel({});
+    const { panel } = createPanel(LEVEL_VARIABLE_VALUE);
+    volume.setState({ panel });
+    const dataBefore = panel.state.$data;
+
+    volume.setAggregateBy(LEVEL_VARIABLE_VALUE);
+
+    expect(volume.state.panel).toBe(panel);
+    expect(panel.state.$data).toBe(dataBefore);
+    expect(setLogsVolumeAggregateBy).not.toHaveBeenCalled();
+  });
+});

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -233,7 +233,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setCollapsed(isCollapsed)
       .setHeaderActions(
         new LogsVolumeActions({
-          aggregateBy: this.state.aggregateBy,
+          aggregateBy: this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE,
           onAggregateByChange: (field) => this.setAggregateBy(field),
         })
       )

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Unsubscribable } from 'rxjs';
+
 import {
   DataFrame,
   FormattedValue,
@@ -68,6 +70,7 @@ export const logsVolumePanelKey = 'logs-volume-panel';
 
 export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private updatedLogSeries: DataFrame[] | null = null;
+  private visibleRangeSub?: Unsubscribable;
   constructor(state: Omit<LogsVolumePanelState, 'aggregateBy'>) {
     super({
       ...state,
@@ -89,7 +92,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     const previousField = this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE;
     setLogsVolumeAggregateBy(this, field === LEVEL_VARIABLE_VALUE ? undefined : field);
     this.setState({ aggregateBy: field });
-    this.setState({ panel: this.getVizPanel() });
+    this.updateVolumeQuery();
     reportAppInteraction(
       USER_EVENTS_PAGES.service_details,
       USER_EVENTS_ACTIONS.service_details.logs_volume_aggregate_by_changed,
@@ -98,6 +101,21 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         previousField,
       }
     );
+  }
+
+  private updateVolumeQuery() {
+    const panel = this.state.panel;
+    if (!panel) {
+      return;
+    }
+
+    const actions = panel.state.headerActions;
+    if (actions instanceof LogsVolumeActions) {
+      actions.setState({ aggregateBy: this.state.aggregateBy });
+    }
+
+    panel.setState({ $data: getQueryRunner([this.getVolumeQuery()]) });
+    this.subscribeToVisibleRange(panel);
   }
 
   private restoreAggregateBy() {
@@ -123,13 +141,23 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
   private onActivate() {
     this.restoreAggregateBy();
+    this._subs.add(() => this.visibleRangeSub?.unsubscribe());
 
-    if (!this.state.panel) {
-      const panel = this.getVizPanel();
-      this.setState({
-        panel,
-      });
-      this.updateContainerHeight(panel);
+    // No need to wait for detectedFields.
+    if (this.state.aggregateBy === LEVEL_VARIABLE_VALUE) {
+      this.setPanel();
+    }
+
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    const detectedFieldsData = serviceScene.state.$detectedFieldsData;
+    if (detectedFieldsData) {
+      this._subs.add(
+        detectedFieldsData.subscribeToState((state) => {
+          if (!this.state.panel && state.data?.state === LoadingState.Done) {
+            this.setPanel();
+          }
+        })
+      );
     }
 
     const labels = getLabelsVariable(this);
@@ -184,7 +212,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       })
     );
 
-    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this._subs.add(
       serviceScene.state.$data?.subscribeToState((newState) => {
         if (newState.data?.state === LoadingState.Done) {
@@ -213,6 +240,14 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         });
       })
     );
+  }
+
+  private setPanel() {
+    const panel = this.getVizPanel();
+    this.setState({
+      panel,
+    });
+    this.updateContainerHeight(panel);
   }
 
   private getTitle() {
@@ -268,11 +303,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
   private setCollapsed(collapsed: boolean | undefined) {
     setLogsVolumeOption('collapsed', collapsed ? 'true' : undefined);
-
-    const panel = this.getVizPanel();
-    this.setState({ panel });
-    this.updateContainerHeight(panel);
-
+    this.setPanel();
     syncLogsListPanelHeightFromScene(sceneGraph.getAncestor(this, ServiceScene));
   }
 
@@ -329,23 +360,22 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private subscribeToVisibleRange(panel: VizPanel) {
+    this.visibleRangeSub?.unsubscribe();
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
-    this._subs.add(
-      panel.state.$data?.subscribeToState((newState) => {
-        if (newState.data?.state !== LoadingState.Done) {
-          return;
-        }
-        if (serviceScene.state.$data?.state.data?.state === LoadingState.Done && !newState.data.annotations?.length) {
-          this.updateVisibleRange(serviceScene.state.$data?.state.data?.series);
-        } else {
-          this.displayVisibleRange();
-        }
-        this.syncVisibleSeries(panel, newState.data.series);
-        panel.setState({
-          title: this.getTitle(),
-        });
-      })
-    );
+    this.visibleRangeSub = panel.state.$data?.subscribeToState((newState) => {
+      if (newState.data?.state !== LoadingState.Done) {
+        return;
+      }
+      if (serviceScene.state.$data?.state.data?.state === LoadingState.Done && !newState.data.annotations?.length) {
+        this.updateVisibleRange(serviceScene.state.$data?.state.data?.series);
+      } else {
+        this.displayVisibleRange();
+      }
+      this.syncVisibleSeries(panel, newState.data.series);
+      panel.setState({
+        title: this.getTitle(),
+      });
+    });
   }
 
   public updateContainerHeight(panel: VizPanel) {
@@ -454,10 +484,10 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
 
   public static Component = ({ model }: SceneComponentProps<LogsVolumePanel>) => {
     const { panel } = model.useState();
+    const styles = useStyles2(getPanelWrapperStyles);
     if (!panel) {
       return;
     }
-    const styles = useStyles2(getPanelWrapperStyles);
 
     return (
       <div className={styles.panelWrapper}>

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -40,32 +40,28 @@ import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { sumLogsVolumeSeries } from 'services/logsVolume';
 import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
-import { getParserEnabled } from 'services/parserToggle';
 import { buildDataQuery, LINE_LIMIT } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
-import { getLogsVolumeAggregateBy, getLogsVolumeOption, setLogsVolumeOption } from 'services/store';
+import {
+  getLogsVolumeAggregateBy,
+  getLogsVolumeOption,
+  setLogsVolumeAggregateBy,
+  setLogsVolumeOption,
+} from 'services/store';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
-  aggregateBy: string;
+  aggregateBy?: string;
   panel?: VizPanel;
 }
 
 export const logsVolumePanelKey = 'logs-volume-panel';
 
-function getStoredAggregateBy() {
-  if (!getParserEnabled()) {
-    return LEVEL_VARIABLE_VALUE;
-  }
-  return getLogsVolumeAggregateBy() || LEVEL_VARIABLE_VALUE;
-}
-
 export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private updatedLogSeries: DataFrame[] | null = null;
   constructor(state: Omit<LogsVolumePanelState, 'aggregateBy'>) {
     super({
-      aggregateBy: getStoredAggregateBy(),
       ...state,
       key: logsVolumePanelKey,
     });
@@ -81,23 +77,27 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (field === this.state.aggregateBy) {
       return;
     }
-    setLogsVolumeOption('aggregateBy', field === LEVEL_VARIABLE_VALUE ? undefined : field);
+    setLogsVolumeAggregateBy(this, field === LEVEL_VARIABLE_VALUE ? undefined : field);
     this.setState({ aggregateBy: field });
     this.setState({ panel: this.getVizPanel() });
   }
 
+  private restoreAggregateBy() {
+    const aggregateBy = getLogsVolumeAggregateBy(this) ?? LEVEL_VARIABLE_VALUE;
+    if (aggregateBy !== this.state.aggregateBy) {
+      this.setState({ aggregateBy });
+    }
+  }
+
   private getVolumeQuery() {
-    const aggregateBy = this.state.aggregateBy;
+    const aggregateBy = this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE;
     return buildDataQuery(getTimeSeriesExpr(this, aggregateBy, false), {
       legendFormat: `{{${aggregateBy}}}`,
     });
   }
 
   private onActivate() {
-    if (!getParserEnabled()) {
-      setLogsVolumeOption('aggregateBy', undefined);
-      this.setAggregateBy(LEVEL_VARIABLE_VALUE);
-    }
+    this.restoreAggregateBy();
 
     if (!this.state.panel) {
       const panel = this.getVizPanel();

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -31,6 +31,7 @@ import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { LevelsVariableScene } from 'Components/IndexScene/LevelsVariableScene';
 import { getPanelWrapperStyles, PanelMenu } from 'Components/Panels/PanelMenu';
 import { AddFilterEvent } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
+import { MAX_NUMBER_OF_TIME_SERIES } from 'Components/ServiceScene/Breakdowns/TimeSeriesLimit';
 import { LogsVolumeActions } from 'Components/ServiceScene/LogsVolumeActions';
 import { ServiceScene } from 'Components/ServiceScene/ServiceScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
@@ -276,6 +277,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         })
       )
       .setShowMenuAlways(true)
+      .setSeriesLimit(MAX_NUMBER_OF_TIME_SERIES)
       .setData(isCollapsed ? undefined : getQueryRunner([this.getVolumeQuery()]));
 
     setLogsVolumeFieldConfigOverrides(viz);

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -70,7 +70,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   public isAggregatingByLevel() {
-    return this.state.aggregateBy === LEVEL_VARIABLE_VALUE;
+    return this.state.aggregateBy == null || this.state.aggregateBy === LEVEL_VARIABLE_VALUE;
   }
 
   public setAggregateBy(field: string) {

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -52,7 +52,7 @@ import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'service
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
-  aggregateBy?: string;
+  aggregateBy: string;
   panel?: VizPanel;
 }
 
@@ -63,6 +63,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   constructor(state: Omit<LogsVolumePanelState, 'aggregateBy'>) {
     super({
       ...state,
+      aggregateBy: LEVEL_VARIABLE_VALUE,
       key: logsVolumePanelKey,
     });
 
@@ -70,7 +71,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   public isAggregatingByLevel() {
-    return this.state.aggregateBy == null || this.state.aggregateBy === LEVEL_VARIABLE_VALUE;
+    return this.state.aggregateBy === LEVEL_VARIABLE_VALUE;
   }
 
   public setAggregateBy(field: string) {
@@ -90,9 +91,8 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getVolumeQuery() {
-    const aggregateBy = this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE;
-    return buildDataQuery(getTimeSeriesExpr(this, aggregateBy, false), {
-      legendFormat: `{{${aggregateBy}}}`,
+    return buildDataQuery(getTimeSeriesExpr(this, this.state.aggregateBy, false), {
+      legendFormat: `{{${this.state.aggregateBy}}}`,
     });
   }
 
@@ -233,7 +233,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setCollapsed(isCollapsed)
       .setHeaderActions(
         new LogsVolumeActions({
-          aggregateBy: this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE,
+          aggregateBy: this.state.aggregateBy,
           onAggregateByChange: (field) => this.setAggregateBy(field),
         })
       )

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -35,11 +35,18 @@ import { LogsVolumeActions } from 'Components/ServiceScene/LogsVolumeActions';
 import { ServiceScene } from 'Components/ServiceScene/ServiceScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { areArraysEqual } from 'services/comparison';
-import { getLogsVolumeQuery } from 'services/expressions';
+import { excludeAggregateByFromLogsVolumeQuery, getLogsVolumeQuery } from 'services/expressions';
+import { getParserForField } from 'services/fields';
+import { toggleFieldFromFilter } from 'services/labels';
 import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { sumLogsVolumeSeries } from 'services/logsVolume';
-import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
+import {
+  getQueryRunner,
+  setLogsVolumeFieldConfigOverrides,
+  syncLevelsVisibleSeries,
+  syncLogsVolumeVisibleSeries,
+} from 'services/panel';
 import { buildDataQuery, LINE_LIMIT } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
 import {
@@ -48,7 +55,7 @@ import {
   setLogsVolumeAggregateBy,
   setLogsVolumeOption,
 } from 'services/store';
-import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'services/variableGetters';
+import { getFieldsVariable, getLabelsVariable, getLevelsVariable, getMetadataVariable } from 'services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
@@ -100,9 +107,17 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getVolumeQuery() {
-    return buildDataQuery(getLogsVolumeQuery(this, this.state.aggregateBy), {
+    return buildDataQuery(this.getVolumeQueryExpr(), {
       legendFormat: `{{${this.state.aggregateBy}}}`,
     });
+  }
+
+  private getVolumeQueryExpr() {
+    return excludeAggregateByFromLogsVolumeQuery(
+      getLogsVolumeQuery(this, this.state.aggregateBy),
+      this.state.aggregateBy,
+      this
+    );
   }
 
   private onActivate() {
@@ -130,10 +145,24 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       })
     );
 
-    // Set Panel on fields variable filter update
+    // Recreate the panel when other field filters change; the grouped-by field is focused instead.
     this._subs.add(
       fields.subscribeToState((newState, prevState) => {
-        if (!areArraysEqual(newState.filters, prevState.filters)) {
+        if (this.filtersChangedExcept(newState.filters, prevState.filters, this.state.aggregateBy)) {
+          this.setState({
+            panel: this.getVizPanel(),
+          });
+        }
+      })
+    );
+
+    // Recreate when other metadata filters change; the grouped-by field is excluded from the query.
+    this._subs.add(
+      getMetadataVariable(this).subscribeToState((newState, prevState) => {
+        if (this.isAggregatingByLevel() || getParserForField(this.state.aggregateBy, this) !== 'structuredMetadata') {
+          return;
+        }
+        if (this.filtersChangedExcept(newState.filters, prevState.filters, this.state.aggregateBy)) {
           this.setState({
             panel: this.getVizPanel(),
           });
@@ -316,9 +345,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         } else {
           this.displayVisibleRange();
         }
-        if (this.isAggregatingByLevel()) {
-          syncLevelsVisibleSeries(panel, newState.data.series, this);
-        }
+        this.syncVisibleSeries(panel, newState.data.series);
         panel.setState({
           title: this.getTitle(),
         });
@@ -361,34 +388,70 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     });
   }
 
-  private extendTimeSeriesLegendBus = (context: PanelContext) => {
-    const levelFilter = getLevelsVariable(this);
-    this._subs.add(
-      levelFilter?.subscribeToState(() => {
-        const panel = this.state.panel;
-        if (!panel?.state.$data?.state.data?.series) {
-          return;
-        }
-
-        if (this.isAggregatingByLevel()) {
-          syncLevelsVisibleSeries(panel, panel?.state.$data?.state.data?.series, this);
-        }
-      })
+  private filtersChangedExcept(
+    newFilters: Array<{ key: string }>,
+    prevFilters: Array<{ key: string }>,
+    exceptKey: string
+  ) {
+    return !areArraysEqual(
+      newFilters.filter((filter) => filter.key !== exceptKey),
+      prevFilters.filter((filter) => filter.key !== exceptKey)
     );
+  }
 
-    context.onToggleSeriesVisibility = (label: string | string[] | null, mode: SeriesVisibilityChangeMode) => {
-      if (label == null || Array.isArray(label) || !this.isAggregatingByLevel()) {
+  private syncVisibleSeries(panel: VizPanel, series: DataFrame[]) {
+    if (this.isAggregatingByLevel()) {
+      syncLevelsVisibleSeries(panel, series, this);
+      return;
+    }
+    syncLogsVolumeVisibleSeries(this.state.aggregateBy, panel, series, this);
+  }
+
+  private extendTimeSeriesLegendBus = (context: PanelContext) => {
+    const syncFromFilters = () => {
+      const panel = this.state.panel;
+      const series = panel?.state.$data?.state.data?.series;
+      if (!panel || !series) {
         return;
       }
-      const action = toggleLevelFromFilter(label, this);
-      this.publishEvent(new AddFilterEvent('legend', 'include', LEVEL_VARIABLE_VALUE, label), true);
+      this.syncVisibleSeries(panel, series);
+    };
+
+    this._subs.add(getLevelsVariable(this)?.subscribeToState(syncFromFilters));
+    this._subs.add(getFieldsVariable(this)?.subscribeToState(syncFromFilters));
+    this._subs.add(getMetadataVariable(this)?.subscribeToState(syncFromFilters));
+
+    context.onToggleSeriesVisibility = (label: string | string[] | null, mode: SeriesVisibilityChangeMode) => {
+      if (label == null || Array.isArray(label)) {
+        return;
+      }
+
+      if (this.isAggregatingByLevel()) {
+        const action = toggleLevelFromFilter(label, this);
+        this.publishEvent(new AddFilterEvent('legend', 'include', LEVEL_VARIABLE_VALUE, label), true);
+
+        reportAppInteraction(
+          USER_EVENTS_PAGES.service_details,
+          USER_EVENTS_ACTIONS.service_details.level_in_logs_volume_clicked,
+          {
+            action,
+            level: label,
+          }
+        );
+        return;
+      }
+
+      const field = this.state.aggregateBy;
+      const action = toggleFieldFromFilter(field, label, this);
+      this.publishEvent(new AddFilterEvent('legend', 'include', field, label), true);
 
       reportAppInteraction(
         USER_EVENTS_PAGES.service_details,
         USER_EVENTS_ACTIONS.service_details.level_in_logs_volume_clicked,
         {
           action,
-          level: label,
+          field,
+          value: label,
         }
       );
     };

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -40,9 +40,10 @@ import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { sumLogsVolumeSeries } from 'services/logsVolume';
 import { getQueryRunner, setLogsVolumeFieldConfigOverrides, syncLevelsVisibleSeries } from 'services/panel';
+import { getParserEnabled } from 'services/parserToggle';
 import { buildDataQuery, LINE_LIMIT } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
-import { getLogsVolumeOption, setLogsVolumeOption } from 'services/store';
+import { getLogsVolumeAggregateBy, getLogsVolumeOption, setLogsVolumeOption } from 'services/store';
 import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'services/variableGetters';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
@@ -52,11 +53,19 @@ export interface LogsVolumePanelState extends SceneObjectState {
 }
 
 export const logsVolumePanelKey = 'logs-volume-panel';
+
+function getStoredAggregateBy() {
+  if (!getParserEnabled()) {
+    return LEVEL_VARIABLE_VALUE;
+  }
+  return getLogsVolumeAggregateBy() || LEVEL_VARIABLE_VALUE;
+}
+
 export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private updatedLogSeries: DataFrame[] | null = null;
   constructor(state: Omit<LogsVolumePanelState, 'aggregateBy'>) {
     super({
-      aggregateBy: LEVEL_VARIABLE_VALUE,
+      aggregateBy: getStoredAggregateBy(),
       ...state,
       key: logsVolumePanelKey,
     });
@@ -72,6 +81,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (field === this.state.aggregateBy) {
       return;
     }
+    setLogsVolumeOption('aggregateBy', field === LEVEL_VARIABLE_VALUE ? undefined : field);
     this.setState({ aggregateBy: field });
     this.setState({ panel: this.getVizPanel() });
   }
@@ -84,6 +94,11 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private onActivate() {
+    if (!getParserEnabled()) {
+      setLogsVolumeOption('aggregateBy', undefined);
+      this.setAggregateBy(LEVEL_VARIABLE_VALUE);
+    }
+
     if (!this.state.panel) {
       const panel = this.getVizPanel();
       this.setState({

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -42,7 +42,7 @@ import { getParserForField } from 'services/fields';
 import { toggleFieldFromFilter } from 'services/labels';
 import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
-import { sumLogsVolumeSeries } from 'services/logsVolume';
+import { isLogsVolumeByFieldEnabled, sumLogsVolumeSeries } from 'services/logsVolume';
 import {
   getQueryRunner,
   setLogsVolumeFieldConfigOverrides,
@@ -86,7 +86,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   public setAggregateBy(field: string) {
-    if (field === this.state.aggregateBy) {
+    if (!isLogsVolumeByFieldEnabled() || field === this.state.aggregateBy) {
       return;
     }
     const previousField = this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE;
@@ -119,6 +119,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private restoreAggregateBy() {
+    if (!isLogsVolumeByFieldEnabled()) {
+      return;
+    }
     const aggregateBy = getLogsVolumeAggregateBy(this) ?? LEVEL_VARIABLE_VALUE;
     if (aggregateBy !== this.state.aggregateBy) {
       this.setState({ aggregateBy });

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -35,7 +35,7 @@ import { LogsVolumeActions } from 'Components/ServiceScene/LogsVolumeActions';
 import { ServiceScene } from 'Components/ServiceScene/ServiceScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'services/analytics';
 import { areArraysEqual } from 'services/comparison';
-import { getTimeSeriesExpr } from 'services/expressions';
+import { getLogsVolumeQuery } from 'services/expressions';
 import { toggleLevelFromFilter } from 'services/levels';
 import { getSeriesVisibleRange, getVisibleRangeFrame } from 'services/logsFrame';
 import { sumLogsVolumeSeries } from 'services/logsVolume';
@@ -78,9 +78,18 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     if (field === this.state.aggregateBy) {
       return;
     }
+    const previousField = this.state.aggregateBy ?? LEVEL_VARIABLE_VALUE;
     setLogsVolumeAggregateBy(this, field === LEVEL_VARIABLE_VALUE ? undefined : field);
     this.setState({ aggregateBy: field });
     this.setState({ panel: this.getVizPanel() });
+    reportAppInteraction(
+      USER_EVENTS_PAGES.service_details,
+      USER_EVENTS_ACTIONS.service_details.logs_volume_aggregate_by_changed,
+      {
+        field,
+        previousField,
+      }
+    );
   }
 
   private restoreAggregateBy() {
@@ -91,7 +100,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getVolumeQuery() {
-    return buildDataQuery(getTimeSeriesExpr(this, this.state.aggregateBy, false), {
+    return buildDataQuery(getLogsVolumeQuery(this, this.state.aggregateBy, false), {
       legendFormat: `{{${this.state.aggregateBy}}}`,
     });
   }

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -27,7 +27,6 @@ import {
   useStyles2,
 } from '@grafana/ui';
 
-import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { LevelsVariableScene } from 'Components/IndexScene/LevelsVariableScene';
 import { getPanelWrapperStyles, PanelMenu } from 'Components/Panels/PanelMenu';
 import { AddFilterEvent } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
@@ -48,11 +47,12 @@ import {
   syncLevelsVisibleSeries,
   syncLogsVolumeVisibleSeries,
 } from 'services/panel';
-import { buildDataQuery, LINE_LIMIT } from 'services/query';
+import { buildDataQuery } from 'services/query';
 import { syncLogsListPanelHeightFromScene } from 'services/scenes';
 import {
   getLogsVolumeAggregateBy,
   getLogsVolumeOption,
+  getMaxLines,
   setLogsVolumeAggregateBy,
   setLogsVolumeOption,
 } from 'services/store';
@@ -223,8 +223,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     // Logs Panel response count
     const logsCount = serviceScene.state.logsCount;
 
-    const indexScene = sceneGraph.getAncestor(this, IndexScene);
-    const maxLines = indexScene.state.ds?.maxLines ?? LINE_LIMIT;
+    const maxLines = getMaxLines(this);
 
     const title = t('components.service-scene.logs-volume.logs-volume-panel.title', 'Log volume');
 

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -47,19 +47,40 @@ import { getFieldsVariable, getLabelsVariable, getLevelsVariable } from 'service
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 export interface LogsVolumePanelState extends SceneObjectState {
+  aggregateBy: string;
   panel?: VizPanel;
 }
 
 export const logsVolumePanelKey = 'logs-volume-panel';
 export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   private updatedLogSeries: DataFrame[] | null = null;
-  constructor(state: LogsVolumePanelState) {
+  constructor(state: Omit<LogsVolumePanelState, 'aggregateBy'>) {
     super({
+      aggregateBy: LEVEL_VARIABLE_VALUE,
       ...state,
       key: logsVolumePanelKey,
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  public isAggregatingByLevel() {
+    return this.state.aggregateBy === LEVEL_VARIABLE_VALUE;
+  }
+
+  public setAggregateBy(field: string) {
+    if (field === this.state.aggregateBy) {
+      return;
+    }
+    this.setState({ aggregateBy: field });
+    this.setState({ panel: this.getVizPanel() });
+  }
+
+  private getVolumeQuery() {
+    const aggregateBy = this.state.aggregateBy;
+    return buildDataQuery(getTimeSeriesExpr(this, aggregateBy, false), {
+      legendFormat: `{{${aggregateBy}}}`,
+    });
   }
 
   private onActivate() {
@@ -162,23 +183,13 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     return serviceScene.state.totalLogsCount;
   };
 
-  private setCollapsed(collapsed: boolean | undefined, panel: VizPanel) {
-    if (collapsed) {
-      panel.setState({
-        $data: undefined,
-      });
-    } else {
-      panel.setState({
-        $data: getQueryRunner([
-          buildDataQuery(getTimeSeriesExpr(this, LEVEL_VARIABLE_VALUE, false), {
-            legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
-          }),
-        ]),
-      });
-      this.subscribeToVisibleRange(panel);
-    }
-    this.updateContainerHeight(panel);
+  private setCollapsed(collapsed: boolean | undefined) {
     setLogsVolumeOption('collapsed', collapsed ? 'true' : undefined);
+
+    const panel = this.getVizPanel();
+    this.setState({ panel });
+    this.updateContainerHeight(panel);
+
     syncLogsListPanelHeightFromScene(sceneGraph.getAncestor(this, ServiceScene));
   }
 
@@ -205,17 +216,14 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
       .setMenu(new PanelMenu({}))
       .setCollapsible(true)
       .setCollapsed(isCollapsed)
-      .setHeaderActions(new LogsVolumeActions({}))
+      .setHeaderActions(
+        new LogsVolumeActions({
+          aggregateBy: this.state.aggregateBy,
+          onAggregateByChange: (field) => this.setAggregateBy(field),
+        })
+      )
       .setShowMenuAlways(true)
-      .setData(
-        isCollapsed
-          ? undefined
-          : getQueryRunner([
-              buildDataQuery(getTimeSeriesExpr(this, LEVEL_VARIABLE_VALUE, false), {
-                legendFormat: `{{${LEVEL_VARIABLE_VALUE}}}`,
-              }),
-            ])
-      );
+      .setData(isCollapsed ? undefined : getQueryRunner([this.getVolumeQuery()]));
 
     setLogsVolumeFieldConfigOverrides(viz);
 
@@ -227,7 +235,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     this._subs.add(
       panel.subscribeToState((newState, prevState) => {
         if (newState.collapsed !== prevState.collapsed) {
-          this.setCollapsed(newState.collapsed, panel);
+          this.setCollapsed(newState.collapsed);
         }
       })
     );
@@ -284,7 +292,9 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         } else {
           this.displayVisibleRange();
         }
-        syncLevelsVisibleSeries(panel, newState.data.series, this);
+        if (this.isAggregatingByLevel()) {
+          syncLevelsVisibleSeries(panel, newState.data.series, this);
+        }
         panel.setState({
           title: this.getTitle(),
         });
@@ -336,12 +346,14 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
           return;
         }
 
-        syncLevelsVisibleSeries(panel, panel?.state.$data?.state.data?.series, this);
+        if (this.isAggregatingByLevel()) {
+          syncLevelsVisibleSeries(panel, panel?.state.$data?.state.data?.series, this);
+        }
       })
     );
 
     context.onToggleSeriesVisibility = (label: string | string[] | null, mode: SeriesVisibilityChangeMode) => {
-      if (label == null || Array.isArray(label)) {
+      if (label == null || Array.isArray(label) || !this.isAggregatingByLevel()) {
         return;
       }
       const action = toggleLevelFromFilter(label, this);

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -100,7 +100,7 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getVolumeQuery() {
-    return buildDataQuery(getLogsVolumeQuery(this, this.state.aggregateBy, false), {
+    return buildDataQuery(getLogsVolumeQuery(this, this.state.aggregateBy), {
       legendFormat: `{{${this.state.aggregateBy}}}`,
     });
   }

--- a/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
+++ b/src/Components/ServiceScene/LogsVolume/LogsVolumePanel.tsx
@@ -183,6 +183,36 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
         }
       })
     );
+
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    this._subs.add(
+      serviceScene.state.$data?.subscribeToState((newState) => {
+        if (newState.data?.state === LoadingState.Done) {
+          this.updateVisibleRange(newState.data.series);
+        }
+      })
+    );
+
+    this._subs.add(
+      serviceScene.subscribeToState((newState, prevState) => {
+        if (newState.totalLogsCount !== prevState.totalLogsCount || newState.logsCount !== undefined) {
+          this.state.panel?.setState({
+            title: this.getTitle(),
+          });
+        }
+      })
+    );
+
+    this._subs.add(
+      getLevelsVariable(this).subscribeToState((newState, prevState) => {
+        if (areArraysEqual(newState.filters, prevState.filters) || !this.state.panel) {
+          return;
+        }
+        this.state.panel.setState({
+          title: this.getTitle(),
+        });
+      })
+    );
   }
 
   private getTitle() {
@@ -248,7 +278,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
   }
 
   private getVizPanel() {
-    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     const isCollapsed = getLogsVolumeOption('collapsed');
     // Overrides are defined by setLogsVolumeFieldConfigOverrides, any overrides added here will be overwritten!
     const viz = PanelBuilders.timeseries()
@@ -296,41 +325,6 @@ export class LogsVolumePanel extends SceneObjectBase<LogsVolumePanelState> {
     );
 
     this.subscribeToVisibleRange(panel);
-
-    this._subs.add(
-      serviceScene.state.$data?.subscribeToState((newState) => {
-        if (newState.data?.state === LoadingState.Done) {
-          this.updateVisibleRange(newState.data.series);
-        }
-      })
-    );
-
-    this._subs.add(
-      serviceScene.subscribeToState((newState, prevState) => {
-        if (newState.totalLogsCount !== prevState.totalLogsCount || newState.logsCount !== undefined) {
-          if (!this.state.panel) {
-            this.setState({
-              panel: this.getVizPanel(),
-            });
-          } else {
-            this.state.panel.setState({
-              title: this.getTitle(),
-            });
-          }
-        }
-      })
-    );
-
-    this._subs.add(
-      getLevelsVariable(this).subscribeToState((newState, prevState) => {
-        if (areArraysEqual(newState.filters, prevState.filters) || !this.state.panel) {
-          return;
-        }
-        this.state.panel.setState({
-          title: this.getTitle(),
-        });
-      })
-    );
 
     return panel;
   }

--- a/src/Components/ServiceScene/LogsVolumeActions.test.ts
+++ b/src/Components/ServiceScene/LogsVolumeActions.test.ts
@@ -1,18 +1,24 @@
 import { createDataFrame, Field, FieldType } from '@grafana/data';
+import { sceneGraph } from '@grafana/scenes';
 
-import { getAggregateByOptions } from './LogsVolumeActions';
+import { LogsVolumeActions, getAggregateByOptions } from './LogsVolumeActions';
 import {
   DETECTED_FIELDS_CARDINALITY_NAME,
   DETECTED_FIELDS_NAME_FIELD,
   DETECTED_FIELDS_PARSER_NAME,
   DETECTED_FIELDS_TYPE_NAME,
 } from 'services/datasource';
+import { isLogsVolumeByFieldEnabled } from 'services/logsVolume';
 import { getParserEnabled } from 'services/parserToggle';
 import { LEVEL_VARIABLE_VALUE } from 'services/variables';
 
 jest.mock('services/parserToggle', () => ({
   ...jest.requireActual('services/parserToggle'),
   getParserEnabled: jest.fn(() => true),
+}));
+
+jest.mock('services/logsVolume', () => ({
+  isLogsVolumeByFieldEnabled: jest.fn(() => true),
 }));
 
 const getParserEnabledMock = jest.mocked(getParserEnabled);
@@ -58,6 +64,26 @@ const mixedFields = detectedFieldsFrame([
   { name: 'cluster', parser: '', type: 'string' },
   { name: 'level', parser: '', type: 'string' },
 ]);
+
+describe('LogsVolumeActions', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not load aggregate-by options when the feature flag is disabled', () => {
+    jest.mocked(isLogsVolumeByFieldEnabled).mockReturnValue(false);
+    const getAncestor = jest.spyOn(sceneGraph, 'getAncestor');
+    const actions = new LogsVolumeActions({
+      aggregateBy: LEVEL_VARIABLE_VALUE,
+      onAggregateByChange: () => {},
+    });
+
+    actions.activate();
+
+    expect(getAncestor).not.toHaveBeenCalled();
+    expect(actions.state.options).toEqual([]);
+  });
+});
 
 describe('getAggregateByOptions', () => {
   beforeEach(() => {

--- a/src/Components/ServiceScene/LogsVolumeActions.test.ts
+++ b/src/Components/ServiceScene/LogsVolumeActions.test.ts
@@ -1,0 +1,101 @@
+import { createDataFrame, Field, FieldType } from '@grafana/data';
+
+import { getAggregateByOptions } from './LogsVolumeActions';
+import {
+  DETECTED_FIELDS_CARDINALITY_NAME,
+  DETECTED_FIELDS_NAME_FIELD,
+  DETECTED_FIELDS_PARSER_NAME,
+  DETECTED_FIELDS_TYPE_NAME,
+} from 'services/datasource';
+import { getParserEnabled } from 'services/parserToggle';
+import { LEVEL_VARIABLE_VALUE } from 'services/variables';
+
+jest.mock('services/parserToggle', () => ({
+  ...jest.requireActual('services/parserToggle'),
+  getParserEnabled: jest.fn(() => true),
+}));
+
+const getParserEnabledMock = jest.mocked(getParserEnabled);
+
+function detectedFieldsFrame(fields: Array<{ name: string; parser: string; type: string }>) {
+  const nameField: Field = {
+    config: {},
+    name: DETECTED_FIELDS_NAME_FIELD,
+    type: FieldType.string,
+    values: fields.map((field) => field.name),
+  };
+  const cardinalityField: Field = {
+    config: {},
+    name: DETECTED_FIELDS_CARDINALITY_NAME,
+    type: FieldType.number,
+    values: fields.map(() => 4),
+  };
+  const parserField: Field = {
+    config: {},
+    name: DETECTED_FIELDS_PARSER_NAME,
+    type: FieldType.string,
+    values: fields.map((field) => field.parser),
+  };
+  const typeField: Field = {
+    config: {},
+    name: DETECTED_FIELDS_TYPE_NAME,
+    type: FieldType.string,
+    values: fields.map((field) => field.type),
+  };
+
+  return createDataFrame({
+    fields: [nameField, cardinalityField, parserField, typeField],
+  });
+}
+
+const mixedFields = detectedFieldsFrame([
+  { name: 'caller', parser: 'logfmt', type: 'string' },
+  { name: 'ok', parser: 'logfmt', type: 'boolean' },
+  { name: 'status', parser: 'json', type: 'int' },
+  { name: 'latency', parser: 'logfmt', type: 'duration' },
+  { name: 'ratio', parser: 'json', type: 'float' },
+  { name: 'size', parser: 'logfmt', type: 'bytes' },
+  { name: 'cluster', parser: '', type: 'string' },
+  { name: 'level', parser: '', type: 'string' },
+]);
+
+describe('getAggregateByOptions', () => {
+  beforeEach(() => {
+    getParserEnabledMock.mockReturnValue(true);
+  });
+
+  it('keeps categorical fields and always includes detected_level', () => {
+    const options = getAggregateByOptions(mixedFields, LEVEL_VARIABLE_VALUE);
+
+    expect(options.map((option) => option.value)).toEqual([LEVEL_VARIABLE_VALUE, 'caller', 'cluster', 'ok', 'status']);
+  });
+
+  it('drops float, duration, and bytes fields', () => {
+    const values = getAggregateByOptions(mixedFields, LEVEL_VARIABLE_VALUE).map((option) => option.value);
+
+    expect(values).not.toContain('latency');
+    expect(values).not.toContain('ratio');
+    expect(values).not.toContain('size');
+  });
+
+  it('drops parsed fields when parsers are disabled', () => {
+    getParserEnabledMock.mockReturnValue(false);
+
+    expect(getAggregateByOptions(mixedFields, LEVEL_VARIABLE_VALUE).map((option) => option.value)).toEqual([
+      LEVEL_VARIABLE_VALUE,
+      'cluster',
+    ]);
+  });
+
+  it('prepends a selected field that is not already in the list', () => {
+    const options = getAggregateByOptions(mixedFields, 'namespace');
+
+    expect(options[0]).toEqual({ label: 'namespace', value: 'namespace' });
+  });
+
+  it('does not prepend a selected avg field', () => {
+    const values = getAggregateByOptions(mixedFields, 'latency').map((option) => option.value);
+
+    expect(values).not.toContain('latency');
+  });
+});

--- a/src/Components/ServiceScene/LogsVolumeActions.tsx
+++ b/src/Components/ServiceScene/LogsVolumeActions.tsx
@@ -92,11 +92,11 @@ function Component({ model }: SceneComponentProps<LogsVolumeActions>) {
 
   const dataSourceUid = getDataSource(model);
 
-  const lostVolumeCollapsed = getLogsVolumeOption('collapsed');
+  const logsVolumeCollapsed = getLogsVolumeOption('collapsed');
 
   return (
     <Stack alignItems="center" gap={1}>
-      {!lostVolumeCollapsed && (
+      {!logsVolumeCollapsed && (
         <InlineField
           className={styles.aggregateByField}
           transparent

--- a/src/Components/ServiceScene/LogsVolumeActions.tsx
+++ b/src/Components/ServiceScene/LogsVolumeActions.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { css } from '@emotion/css';
 
-import { AdHocVariableFilter } from '@grafana/data';
+import { AdHocVariableFilter, DataFrame } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { usePluginComponent } from '@grafana/runtime';
-import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Combobox, ComboboxOption, InlineField, Stack, useStyles2 } from '@grafana/ui';
 
 import { getDetectedFieldsFrame, ServiceScene } from 'Components/ServiceScene/ServiceScene';
@@ -57,7 +57,7 @@ export class LogsVolumeActions extends SceneObjectBase<LogsVolumeActionsState> {
   }
 
   private updateOptions() {
-    this.setState({ options: getAggregateByOptions(this, this.state.aggregateBy) });
+    this.setState({ options: getAggregateByOptions(getDetectedFieldsFrame(this), this.state.aggregateBy) });
   }
 
   public onChange = (option: ComboboxOption<string> | null) => {
@@ -126,8 +126,10 @@ function Component({ model }: SceneComponentProps<LogsVolumeActions>) {
   );
 }
 
-function getAggregateByOptions(sceneRef: SceneObject, selected: string): Array<ComboboxOption<string>> {
-  const detectedFieldsFrame = getDetectedFieldsFrame(sceneRef);
+export function getAggregateByOptions(
+  detectedFieldsFrame: DataFrame | undefined,
+  selected: string
+): Array<ComboboxOption<string>> {
   const namesField = getDetectedFieldsNamesField(detectedFieldsFrame);
   const parserField = getDetectedFieldsParserField(detectedFieldsFrame);
   const typesField = getDetectedFieldsTypeField(detectedFieldsFrame);

--- a/src/Components/ServiceScene/LogsVolumeActions.tsx
+++ b/src/Components/ServiceScene/LogsVolumeActions.tsx
@@ -1,17 +1,64 @@
 import React from 'react';
 
+import { css } from '@emotion/css';
+
 import { AdHocVariableFilter } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { usePluginComponent } from '@grafana/runtime';
-import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { Combobox, ComboboxOption, InlineField, Stack, useStyles2 } from '@grafana/ui';
 
+import { getDetectedFieldsFrame, ServiceScene } from 'Components/ServiceScene/ServiceScene';
+import { extractParserFromString, getDetectedFieldsNamesField, getDetectedFieldsParserField } from 'services/fields';
+import { FIELDS_TO_REMOVE } from 'services/filters';
+import { getParserEnabled } from 'services/parserToggle';
 import { getDataSource } from 'services/scenes';
+import { getLogsVolumeOption } from 'services/store';
 import { getAdHocFiltersVariable } from 'services/variableGetters';
-import { VAR_LABELS } from 'services/variables';
+import { LEVEL_VARIABLE_VALUE, VAR_LABELS } from 'services/variables';
 
-interface LogsVolumeActionsState extends SceneObjectState {}
+interface LogsVolumeActionsState extends SceneObjectState {
+  aggregateBy: string;
+  onAggregateByChange: (field: string) => void;
+  options: Array<ComboboxOption<string>>;
+}
 
 export class LogsVolumeActions extends SceneObjectBase<LogsVolumeActionsState> {
   static Component = Component;
+
+  constructor(state: Omit<LogsVolumeActionsState, 'options'> & { options?: Array<ComboboxOption<string>> }) {
+    super({
+      ...state,
+      options: state.options ?? [],
+    });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  private onActivate() {
+    const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
+    this.updateOptions();
+    const detectedFieldsData = serviceScene.state.$detectedFieldsData;
+    if (detectedFieldsData) {
+      this._subs.add(
+        detectedFieldsData.subscribeToState((state) => {
+          console.log(state);
+          this.updateOptions();
+        })
+      );
+    }
+  }
+
+  private updateOptions() {
+    this.setState({ options: getAggregateByOptions(this, this.state.aggregateBy) });
+  }
+
+  public onChange = (option: ComboboxOption<string> | null) => {
+    if (option == null) {
+      return;
+    }
+    this.state.onAggregateByChange(option.value);
+  };
 }
 
 type StreamSelector = Pick<AdHocVariableFilter, 'key' | 'operator' | 'value'>;
@@ -26,6 +73,8 @@ type TemporaryExemptionsProps = {
 };
 
 function Component({ model }: SceneComponentProps<LogsVolumeActions>) {
+  const { aggregateBy, options } = model.useState();
+  const styles = useStyles2(getStyles);
   const { component: TemporaryExemptionsButton, isLoading } = usePluginComponent<TemporaryExemptionsProps>(
     'grafana-adaptivelogs-app/temporary-exemptions/v1'
   );
@@ -36,15 +85,77 @@ function Component({ model }: SceneComponentProps<LogsVolumeActions>) {
 
   const dataSourceUid = getDataSource(model);
 
-  if (isLoading || !TemporaryExemptionsButton) {
-    return null;
-  }
+  const lostVolumeCollapsed = getLogsVolumeOption('collapsed');
 
   return (
-    <TemporaryExemptionsButton
-      dataSourceUid={dataSourceUid}
-      streamSelector={streamSelector}
-      contextHints={['explorelogs', 'logvolumepanel', 'headeraction']}
-    />
+    <Stack alignItems="center" gap={1}>
+      {!lostVolumeCollapsed && (
+        <InlineField
+          className={styles.aggregateByField}
+          transparent
+          label={t('components.service-scene.logs-volume.logs-volume-actions.label-group-by', 'Group by')}
+        >
+          <Combobox<string>
+            aria-label={t(
+              'components.service-scene.logs-volume.logs-volume-actions.aria-label-group-by',
+              'Group log volume by field'
+            )}
+            minWidth={16}
+            onChange={model.onChange}
+            options={options}
+            value={aggregateBy}
+            width="auto"
+          />
+        </InlineField>
+      )}
+      {!isLoading && TemporaryExemptionsButton && (
+        <TemporaryExemptionsButton
+          dataSourceUid={dataSourceUid}
+          streamSelector={streamSelector}
+          contextHints={['explorelogs', 'logvolumepanel', 'headeraction']}
+        />
+      )}
+    </Stack>
   );
 }
+
+function getAggregateByOptions(sceneRef: SceneObject, selected: string): Array<ComboboxOption<string>> {
+  const detectedFieldsFrame = getDetectedFieldsFrame(sceneRef);
+  const namesField = getDetectedFieldsNamesField(detectedFieldsFrame);
+  const parserField = getDetectedFieldsParserField(detectedFieldsFrame);
+  const parserEnabled = getParserEnabled();
+  const names = new Set<string>();
+
+  namesField?.values.forEach((name, index) => {
+    const fieldName = String(name);
+    if (!fieldName || FIELDS_TO_REMOVE.includes(fieldName)) {
+      return;
+    }
+    if (!parserEnabled) {
+      const parser = extractParserFromString(parserField?.values?.[index] ?? '');
+      if (parser !== 'structuredMetadata') {
+        return;
+      }
+    }
+    names.add(fieldName);
+  });
+
+  const options: Array<ComboboxOption<string>> = [
+    { label: LEVEL_VARIABLE_VALUE, value: LEVEL_VARIABLE_VALUE },
+    ...[...names].sort().map((name) => ({ label: name, value: name })),
+  ];
+
+  if (selected && !options.some((option) => option.value === selected)) {
+    options.unshift({ label: selected, value: selected });
+  }
+
+  return options;
+}
+
+const getStyles = () => ({
+  aggregateByField: css({
+    label: 'logs-volume-aggregate-by',
+    marginBottom: 0,
+    marginRight: 0,
+  }),
+});

--- a/src/Components/ServiceScene/LogsVolumeActions.tsx
+++ b/src/Components/ServiceScene/LogsVolumeActions.tsx
@@ -19,6 +19,7 @@ import {
   isAvgField,
 } from 'services/fields';
 import { FIELDS_TO_REMOVE } from 'services/filters';
+import { isLogsVolumeByFieldEnabled } from 'services/logsVolume';
 import { getParserEnabled } from 'services/parserToggle';
 import { getDataSource } from 'services/scenes';
 import { getLogsVolumeOption } from 'services/store';
@@ -44,6 +45,9 @@ export class LogsVolumeActions extends SceneObjectBase<LogsVolumeActionsState> {
   }
 
   private onActivate() {
+    if (!isLogsVolumeByFieldEnabled()) {
+      return;
+    }
     const serviceScene = sceneGraph.getAncestor(this, ServiceScene);
     this.updateOptions();
     const detectedFieldsData = serviceScene.state.$detectedFieldsData;
@@ -93,10 +97,11 @@ function Component({ model }: SceneComponentProps<LogsVolumeActions>) {
   const dataSourceUid = getDataSource(model);
 
   const logsVolumeCollapsed = getLogsVolumeOption('collapsed');
+  const logsVolumeByField = isLogsVolumeByFieldEnabled();
 
   return (
     <Stack alignItems="center" gap={1}>
-      {!logsVolumeCollapsed && (
+      {logsVolumeByField && !logsVolumeCollapsed && (
         <InlineField
           className={styles.aggregateByField}
           transparent

--- a/src/Components/ServiceScene/LogsVolumeActions.tsx
+++ b/src/Components/ServiceScene/LogsVolumeActions.tsx
@@ -9,7 +9,15 @@ import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObj
 import { Combobox, ComboboxOption, InlineField, Stack, useStyles2 } from '@grafana/ui';
 
 import { getDetectedFieldsFrame, ServiceScene } from 'Components/ServiceScene/ServiceScene';
-import { extractParserFromString, getDetectedFieldsNamesField, getDetectedFieldsParserField } from 'services/fields';
+import {
+  extractFieldTypeFromString,
+  extractParserFromString,
+  getDetectedFieldType,
+  getDetectedFieldsNamesField,
+  getDetectedFieldsParserField,
+  getDetectedFieldsTypeField,
+  isAvgField,
+} from 'services/fields';
 import { FIELDS_TO_REMOVE } from 'services/filters';
 import { getParserEnabled } from 'services/parserToggle';
 import { getDataSource } from 'services/scenes';
@@ -42,7 +50,6 @@ export class LogsVolumeActions extends SceneObjectBase<LogsVolumeActionsState> {
     if (detectedFieldsData) {
       this._subs.add(
         detectedFieldsData.subscribeToState((state) => {
-          console.log(state);
           this.updateOptions();
         })
       );
@@ -123,12 +130,16 @@ function getAggregateByOptions(sceneRef: SceneObject, selected: string): Array<C
   const detectedFieldsFrame = getDetectedFieldsFrame(sceneRef);
   const namesField = getDetectedFieldsNamesField(detectedFieldsFrame);
   const parserField = getDetectedFieldsParserField(detectedFieldsFrame);
+  const typesField = getDetectedFieldsTypeField(detectedFieldsFrame);
   const parserEnabled = getParserEnabled();
   const names = new Set<string>();
 
   namesField?.values.forEach((name, index) => {
     const fieldName = String(name);
     if (!fieldName || FIELDS_TO_REMOVE.includes(fieldName)) {
+      return;
+    }
+    if (isAvgField(extractFieldTypeFromString(typesField?.values?.[index]))) {
       return;
     }
     if (!parserEnabled) {
@@ -146,7 +157,9 @@ function getAggregateByOptions(sceneRef: SceneObject, selected: string): Array<C
   ];
 
   if (selected && !options.some((option) => option.value === selected)) {
-    options.unshift({ label: selected, value: selected });
+    if (!isAvgField(getDetectedFieldType(selected, detectedFieldsFrame))) {
+      options.unshift({ label: selected, value: selected });
+    }
   }
 
   return options;

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -720,8 +720,13 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       this.state.$detectedLabelsData?.runQueries();
     }
 
-    // If we don't have a detected fields count, or we are activating the fields scene, run the detected fields query
-    if (slug === PageSlugs.fields || parentSlug === ValueSlugs.field || this.state.fieldsCount === undefined) {
+    // Logs needs the series (not just fieldsCount); each route builds a new empty runner.
+    if (
+      slug === PageSlugs.fields ||
+      slug === PageSlugs.logs ||
+      parentSlug === ValueSlugs.field ||
+      this.state.fieldsCount === undefined
+    ) {
       this.state.$detectedFieldsData?.runQueries();
     }
     if (this.state.logsCount === undefined) {

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -720,12 +720,9 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
       this.state.$detectedLabelsData?.runQueries();
     }
 
-    // Logs needs the series (not just fieldsCount); each route builds a new empty runner.
     if (
-      slug === PageSlugs.fields ||
-      slug === PageSlugs.logs ||
-      parentSlug === ValueSlugs.field ||
-      this.state.fieldsCount === undefined
+      this.state.$detectedFieldsData?.state.data?.state !== LoadingState.Loading &&
+      this.state.$detectedFieldsData?.state.data?.state !== LoadingState.Done
     ) {
       this.state.$detectedFieldsData?.runQueries();
     }
@@ -1033,10 +1030,9 @@ function getDetectedLabelsQueryRunner() {
 }
 
 function getDetectedFieldsQueryRunner() {
-  return getResourceQueryRunner(
-    [buildResourceQuery(DETECTED_FIELD_VALUES_EXPR, 'detected_fields', { refId: DETECTED_FIELDS_QUERY_REFID })],
-    { runQueriesMode: 'manual' }
-  );
+  return getResourceQueryRunner([
+    buildResourceQuery(DETECTED_FIELD_VALUES_EXPR, 'detected_fields', { refId: DETECTED_FIELDS_QUERY_REFID }),
+  ]);
 }
 
 function getLogsQueryQueryRunner(sceneRef: SceneObject) {

--- a/src/Components/ServiceScene/ServiceScene.tsx
+++ b/src/Components/ServiceScene/ServiceScene.tsx
@@ -721,8 +721,10 @@ export class ServiceScene extends SceneObjectBase<ServiceSceneState> {
     }
 
     if (
-      this.state.$detectedFieldsData?.state.data?.state !== LoadingState.Loading &&
-      this.state.$detectedFieldsData?.state.data?.state !== LoadingState.Done
+      slug === PageSlugs.fields ||
+      slug === PageSlugs.logs ||
+      parentSlug === ValueSlugs.field ||
+      this.state.fieldsCount === undefined
     ) {
       this.state.$detectedFieldsData?.runQueries();
     }
@@ -1030,9 +1032,10 @@ function getDetectedLabelsQueryRunner() {
 }
 
 function getDetectedFieldsQueryRunner() {
-  return getResourceQueryRunner([
-    buildResourceQuery(DETECTED_FIELD_VALUES_EXPR, 'detected_fields', { refId: DETECTED_FIELDS_QUERY_REFID }),
-  ]);
+  return getResourceQueryRunner(
+    [buildResourceQuery(DETECTED_FIELD_VALUES_EXPR, 'detected_fields', { refId: DETECTED_FIELDS_QUERY_REFID })],
+    { runQueriesMode: 'manual' }
+  );
 }
 
 function getLogsQueryQueryRunner(sceneRef: SceneObject) {

--- a/src/featureFlags/openFeature.ts
+++ b/src/featureFlags/openFeature.ts
@@ -129,6 +129,12 @@ const goffFeatureFlags = {
     reason: 'static provider evaluation result',
     variant: 'default',
   },
+  'drilldown.logs.logsVolumeByField': {
+    valueType: 'boolean',
+    value: false,
+    reason: 'static provider evaluation result',
+    variant: 'default',
+  },
   logsTablePanelNG: {
     valueType: 'boolean',
     value: false,

--- a/src/locales/en-US/grafana-lokiexplore-app.json
+++ b/src/locales/en-US/grafana-lokiexplore-app.json
@@ -726,6 +726,10 @@
         "text-loading": "Loading..."
       },
       "logs-volume": {
+        "logs-volume-actions": {
+          "aria-label-group-by": "Group log volume by field",
+          "label-group-by": "Group by"
+        },
         "logs-volume-panel": {
           "title": "Log volume",
           "title-with-count": "Log volume ({{formattedCount}})"

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -76,6 +76,8 @@ export const USER_EVENTS_ACTIONS = {
     layout_type_changed: 'layout_type_changed',
     // Clicking on one of the levels in the Logs Volume panel
     level_in_logs_volume_clicked: 'level_in_logs_volume_clicked',
+    // Changing the logs volume group-by field. Props: field, previousField
+    logs_volume_aggregate_by_changed: 'logs_volume_aggregate_by_changed',
     // Clear all displayed fields (show original log line)
     logs_clear_displayed_fields: 'logs_clear_displayed_fields',
     // Show default (backend) columns

--- a/src/services/expressions.test.ts
+++ b/src/services/expressions.test.ts
@@ -1,31 +1,70 @@
 import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
 
-import { getTimeSeriesExpr } from './expressions';
-import { getParserFromFieldsFilters } from './fields';
+import { getFieldsTagValuesExpression, getLogsVolumeQuery } from './expressions';
+import { getParserForField, getParserFromFieldsFilters } from './fields';
+import { logger } from './logger';
 import { getParserEnabled } from './parserToggle';
 import { getFieldsVariable } from './variableGetters';
-import { JSON_FORMAT_EXPR, LEVEL_VARIABLE_VALUE, LOGS_FORMAT_EXPR, MIXED_FORMAT_EXPR } from './variables';
+import {
+  DETECTED_FIELD_AND_METADATA_VALUES_EXPR,
+  DETECTED_LEVELS_VALUES_EXPR,
+  JSON_FORMAT_EXPR,
+  LEVEL_VARIABLE_VALUE,
+  LOGS_FORMAT_EXPR,
+  MIXED_FORMAT_EXPR,
+  ParserType,
+  VAR_FIELDS_AND_METADATA,
+  VAR_FIELDS_EXPR,
+  VAR_LABELS_EXPR,
+  VAR_LEVELS,
+  VAR_LINE_FILTERS_EXPR,
+  VAR_LINE_FORMAT_EXPR,
+  VAR_METADATA_EXPR,
+  VAR_PATTERNS_EXPR,
+} from './variables';
+import { getDetectedFieldsFrame } from 'Components/ServiceScene/ServiceScene';
 
 jest.mock('./parserToggle');
 jest.mock('./fields');
 jest.mock('./variableGetters');
+jest.mock('./logger');
+jest.mock('Components/ServiceScene/ServiceScene', () => ({
+  getDetectedFieldsFrame: jest.fn(),
+}));
 
 const getParserEnabledMock = jest.mocked(getParserEnabled);
 const getParserFromFieldsFiltersMock = jest.mocked(getParserFromFieldsFilters);
+const getParserForFieldMock = jest.mocked(getParserForField);
 const getFieldsVariableMock = jest.mocked(getFieldsVariable);
+const getDetectedFieldsFrameMock = jest.mocked(getDetectedFieldsFrame);
+const loggerErrorMock = jest.mocked(logger.error);
 
 const sceneRef = {} as SceneObject;
+
+const baseQuery = (fieldName: string) =>
+  `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
+
+const queryWithParser = (fieldName: string, format: string) =>
+  `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${format} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
 
 /**
  * Configure the mocked dependencies for a single test case.
  */
 function setup(options: {
+  detectedFieldsAvailable?: boolean;
+  fieldParser?: ParserType;
   filterCount: number;
-  parser: 'json' | 'logfmt' | 'mixed' | 'structuredMetadata';
+  parser: ParserType;
   parserEnabled: boolean;
 }) {
   getParserEnabledMock.mockReturnValue(options.parserEnabled);
   getParserFromFieldsFiltersMock.mockReturnValue(options.parser);
+  getParserForFieldMock.mockReturnValue(options.fieldParser ?? options.parser);
+  getDetectedFieldsFrameMock.mockReturnValue(
+    options.detectedFieldsAvailable
+      ? ({ fields: [], length: 1 } as ReturnType<typeof getDetectedFieldsFrame>)
+      : undefined
+  );
   getFieldsVariableMock.mockReturnValue({
     state: {
       filters: new Array(options.filterCount).fill({}),
@@ -33,19 +72,20 @@ function setup(options: {
   } as unknown as AdHocFiltersVariable);
 }
 
-describe('getTimeSeriesExpr', () => {
+describe('getLogsVolumeQuery', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('when parsers are disabled', () => {
-    it.each(['json', 'logfmt', 'mixed'] as const)(
+    it.each(['json', 'logfmt', 'mixed', 'structuredMetadata'] as const)(
       'does not append the %s parser format even when field filters are present',
       (parser) => {
         setup({ filterCount: 2, parser, parserEnabled: false });
 
-        const expr = getTimeSeriesExpr(sceneRef, 'pod');
+        const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
+        expect(expr).toBe(baseQuery('pod'));
         expect(expr).not.toContain(JSON_FORMAT_EXPR);
         expect(expr).not.toContain(LOGS_FORMAT_EXPR);
         expect(expr).not.toContain(MIXED_FORMAT_EXPR);
@@ -54,54 +94,150 @@ describe('getTimeSeriesExpr', () => {
       }
     );
 
-    it('returns the base query without parser segments when field filters are present', () => {
-      setup({ filterCount: 3, parser: 'json', parserEnabled: false });
-
-      const expr = getTimeSeriesExpr(sceneRef, 'pod');
-
-      expect(expr).toBe(
-        'sum(count_over_time({${filters}}  ${metadata} ${patterns} ${lineFilters} ${fields} ${lineFormat} [$__auto])) by (pod)'
-      );
-    });
-
     it('produces the same query whether or not field filters exist', () => {
       setup({ filterCount: 0, parser: 'json', parserEnabled: false });
-      const exprWithoutFilters = getTimeSeriesExpr(sceneRef, 'pod');
+      const exprWithoutFilters = getLogsVolumeQuery(sceneRef, 'pod');
 
       setup({ filterCount: 5, parser: 'json', parserEnabled: false });
-      const exprWithFilters = getTimeSeriesExpr(sceneRef, 'pod');
+      const exprWithFilters = getLogsVolumeQuery(sceneRef, 'pod');
 
       expect(exprWithFilters).toBe(exprWithoutFilters);
+      expect(exprWithoutFilters).toBe(baseQuery('pod'));
     });
 
-    it('still appends the level metadata expression when excluding empty values for the level selector', () => {
+    it('does not append a parser format when aggregating by the level selector', () => {
       setup({ filterCount: 2, parser: 'json', parserEnabled: false });
 
-      const expr = getTimeSeriesExpr(sceneRef, LEVEL_VARIABLE_VALUE);
+      const expr = getLogsVolumeQuery(sceneRef, LEVEL_VARIABLE_VALUE);
 
-      expect(expr).toContain(`| ${LEVEL_VARIABLE_VALUE} != ""`);
-      expect(expr).not.toContain(JSON_FORMAT_EXPR);
-      expect(expr).toBe(
-        `sum(count_over_time({\${filters}} | ${LEVEL_VARIABLE_VALUE} != "" \${metadata} \${patterns} \${lineFilters} \${fields} \${lineFormat} [$__auto])) by (${LEVEL_VARIABLE_VALUE})`
-      );
+      expect(expr).toBe(baseQuery(LEVEL_VARIABLE_VALUE));
     });
   });
 
-  describe('when parsers are enabled', () => {
-    it('appends the json parser format when field filters are present', () => {
-      setup({ filterCount: 1, parser: 'json', parserEnabled: true });
+  describe('when parsers are enabled and field filters are present', () => {
+    it.each([
+      ['json', JSON_FORMAT_EXPR],
+      ['logfmt', LOGS_FORMAT_EXPR],
+      ['mixed', MIXED_FORMAT_EXPR],
+    ] as const)('appends the %s parser format', (parser, format) => {
+      setup({ filterCount: 1, parser, parserEnabled: true });
 
-      const expr = getTimeSeriesExpr(sceneRef, 'pod');
+      const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
-      expect(expr).toContain(JSON_FORMAT_EXPR);
+      expect(expr).toBe(queryWithParser('pod', format));
+      expect(getParserFromFieldsFiltersMock).toHaveBeenCalled();
+      expect(getParserForFieldMock).not.toHaveBeenCalled();
+      expect(getDetectedFieldsFrameMock).not.toHaveBeenCalled();
     });
 
-    it('does not append a parser format when there are no field filters', () => {
+    it('does not append a parser format for structured metadata', () => {
+      setup({ filterCount: 1, parser: 'structuredMetadata', parserEnabled: true });
+
+      const expr = getLogsVolumeQuery(sceneRef, 'pod');
+
+      expect(expr).toBe(baseQuery('pod'));
+    });
+
+    it('uses field filters instead of detected fields even when a detected fields response is available', () => {
+      setup({ detectedFieldsAvailable: true, filterCount: 1, parser: 'json', parserEnabled: true });
+
+      getLogsVolumeQuery(sceneRef, 'pod');
+
+      expect(getParserFromFieldsFiltersMock).toHaveBeenCalled();
+      expect(getParserForFieldMock).not.toHaveBeenCalled();
+      expect(getDetectedFieldsFrameMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when parsers are enabled and there are no field filters', () => {
+    it('does not append a parser format', () => {
       setup({ filterCount: 0, parser: 'json', parserEnabled: true });
 
-      const expr = getTimeSeriesExpr(sceneRef, 'pod');
+      const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
+      expect(expr).toBe(baseQuery('pod'));
       expect(expr).not.toContain(JSON_FORMAT_EXPR);
+    });
+
+    it('uses the detected field type when the detected fields response is available', () => {
+      setup({
+        detectedFieldsAvailable: true,
+        fieldParser: 'logfmt',
+        filterCount: 0,
+        parser: 'json',
+        parserEnabled: true,
+      });
+
+      const expr = getLogsVolumeQuery(sceneRef, 'pod');
+
+      expect(expr).toBe(baseQuery('pod'));
+      expect(getParserForFieldMock).toHaveBeenCalledWith('pod', sceneRef);
+      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to mixed when the detected field type is missing', () => {
+      setup({ detectedFieldsAvailable: true, filterCount: 0, parser: 'json', parserEnabled: true });
+      getParserForFieldMock.mockReturnValue(undefined);
+
+      const expr = getLogsVolumeQuery(sceneRef, 'pod');
+
+      expect(expr).toBe(baseQuery('pod'));
+      expect(getParserForFieldMock).toHaveBeenCalledWith('pod', sceneRef);
+    });
+
+    it('uses the detected field type for the level selector when the detected fields response is available', () => {
+      setup({
+        detectedFieldsAvailable: true,
+        fieldParser: 'structuredMetadata',
+        filterCount: 0,
+        parser: 'json',
+        parserEnabled: true,
+      });
+
+      getLogsVolumeQuery(sceneRef, LEVEL_VARIABLE_VALUE);
+
+      expect(getParserForFieldMock).toHaveBeenCalledWith(LEVEL_VARIABLE_VALUE, sceneRef);
+      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
+    });
+
+    it('treats the level field as structured metadata when detected fields are unavailable', () => {
+      setup({ detectedFieldsAvailable: false, filterCount: 0, parser: 'json', parserEnabled: true });
+
+      const expr = getLogsVolumeQuery(sceneRef, LEVEL_VARIABLE_VALUE);
+
+      expect(expr).toBe(baseQuery(LEVEL_VARIABLE_VALUE));
+      expect(getParserForFieldMock).not.toHaveBeenCalled();
+      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to mixed when detected fields are unavailable and the field is not the level selector', () => {
+      setup({ detectedFieldsAvailable: false, filterCount: 0, parser: 'json', parserEnabled: true });
+
+      const expr = getLogsVolumeQuery(sceneRef, 'pod');
+
+      expect(expr).toBe(baseQuery('pod'));
+      expect(getParserForFieldMock).not.toHaveBeenCalled();
+      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('getFieldsTagValuesExpression', () => {
+  it('returns the detected levels expression', () => {
+    expect(getFieldsTagValuesExpression(VAR_LEVELS)).toBe(DETECTED_LEVELS_VALUES_EXPR);
+  });
+
+  it('returns the detected fields and metadata expression', () => {
+    expect(getFieldsTagValuesExpression(VAR_FIELDS_AND_METADATA)).toBe(DETECTED_FIELD_AND_METADATA_VALUES_EXPR);
+  });
+
+  it('throws and logs for an unknown variable type', () => {
+    expect(() => getFieldsTagValuesExpression('unknown' as typeof VAR_LEVELS)).toThrow(
+      'Unknown variable type: unknown'
+    );
+    expect(loggerErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+      msg: 'getFieldsTagValuesExpression: Unknown variable type: unknown',
+      variableType: 'unknown',
     });
   });
 });

--- a/src/services/expressions.test.ts
+++ b/src/services/expressions.test.ts
@@ -1,9 +1,10 @@
 import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
 
-import { getFieldsTagValuesExpression, getLogsVolumeQuery } from './expressions';
+import { excludeAggregateByFromLogsVolumeQuery, getFieldsTagValuesExpression, getLogsVolumeQuery } from './expressions';
 import { getParserForField, getParserFromFieldsFilters } from './fields';
 import { logger } from './logger';
-import { getFieldsVariable } from './variableGetters';
+import { renderLogQLFieldFilters, renderLogQLMetadataFilters } from './query';
+import { getFieldsVariable, getMetadataVariable } from './variableGetters';
 import {
   DETECTED_FIELD_AND_METADATA_VALUES_EXPR,
   DETECTED_LEVELS_VALUES_EXPR,
@@ -25,10 +26,17 @@ import {
 jest.mock('./fields');
 jest.mock('./variableGetters');
 jest.mock('./logger');
+jest.mock('./query', () => ({
+  renderLogQLFieldFilters: jest.fn(() => '| cluster="eu"'),
+  renderLogQLMetadataFilters: jest.fn(() => '| namespace="prod"'),
+}));
 
 const getParserFromFieldsFiltersMock = jest.mocked(getParserFromFieldsFilters);
 const getParserForFieldMock = jest.mocked(getParserForField);
 const getFieldsVariableMock = jest.mocked(getFieldsVariable);
+const getMetadataVariableMock = jest.mocked(getMetadataVariable);
+const renderLogQLFieldFiltersMock = jest.mocked(renderLogQLFieldFilters);
+const renderLogQLMetadataFiltersMock = jest.mocked(renderLogQLMetadataFilters);
 const loggerErrorMock = jest.mocked(logger.error);
 
 const sceneRef = {} as SceneObject;
@@ -124,6 +132,63 @@ describe('getLogsVolumeQuery', () => {
       expect(getParserForFieldMock).not.toHaveBeenCalled();
       expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('excludeAggregateByFromLogsVolumeQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    renderLogQLFieldFiltersMock.mockReturnValue('| cluster="eu"');
+    renderLogQLMetadataFiltersMock.mockReturnValue('| namespace="prod"');
+  });
+
+  it('leaves the level query unchanged', () => {
+    const expr = baseQuery(LEVEL_VARIABLE_VALUE);
+
+    expect(excludeAggregateByFromLogsVolumeQuery(expr, LEVEL_VARIABLE_VALUE, sceneRef)).toBe(expr);
+    expect(getParserForFieldMock).not.toHaveBeenCalled();
+    expect(renderLogQLFieldFiltersMock).not.toHaveBeenCalled();
+    expect(renderLogQLMetadataFiltersMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces ${fields} with field filters excluding the grouped-by field', () => {
+    const fieldFilters = [
+      { key: 'pod', operator: '=', value: '{"parser":"logfmt","value":"api-1"}' },
+      { key: 'cluster', operator: '=', value: '{"parser":"logfmt","value":"eu"}' },
+    ];
+    getParserForFieldMock.mockReturnValue('logfmt');
+    getFieldsVariableMock.mockReturnValue({
+      state: { filters: fieldFilters },
+    } as unknown as AdHocFiltersVariable);
+
+    const expr = queryWithParser('pod', LOGS_FORMAT_EXPR);
+    const result = excludeAggregateByFromLogsVolumeQuery(expr, 'pod', sceneRef);
+
+    expect(getParserForFieldMock).toHaveBeenCalledWith('pod', sceneRef);
+    expect(renderLogQLFieldFiltersMock).toHaveBeenCalledWith(fieldFilters, ['pod']);
+    expect(renderLogQLMetadataFiltersMock).not.toHaveBeenCalled();
+    expect(result).toBe(expr.replace(VAR_FIELDS_EXPR, '| cluster="eu"'));
+    expect(result).toContain(VAR_METADATA_EXPR);
+  });
+
+  it('replaces ${metadata} when the grouped-by field is structured metadata', () => {
+    const metadataFilters = [
+      { key: 'cluster', operator: '=', value: 'eu' },
+      { key: 'namespace', operator: '=', value: 'prod' },
+    ];
+    getParserForFieldMock.mockReturnValue('structuredMetadata');
+    getMetadataVariableMock.mockReturnValue({
+      state: { filters: metadataFilters },
+    } as unknown as AdHocFiltersVariable);
+
+    const expr = baseQuery('cluster');
+    const result = excludeAggregateByFromLogsVolumeQuery(expr, 'cluster', sceneRef);
+
+    expect(getParserForFieldMock).toHaveBeenCalledWith('cluster', sceneRef);
+    expect(renderLogQLMetadataFiltersMock).toHaveBeenCalledWith(metadataFilters, ['cluster']);
+    expect(renderLogQLFieldFiltersMock).not.toHaveBeenCalled();
+    expect(result).toBe(expr.replace(VAR_METADATA_EXPR, '| namespace="prod"'));
+    expect(result).toContain(VAR_FIELDS_EXPR);
   });
 });
 

--- a/src/services/expressions.test.ts
+++ b/src/services/expressions.test.ts
@@ -3,7 +3,6 @@ import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
 import { getFieldsTagValuesExpression, getLogsVolumeQuery } from './expressions';
 import { getParserForField, getParserFromFieldsFilters } from './fields';
 import { logger } from './logger';
-import { getParserEnabled } from './parserToggle';
 import { getFieldsVariable } from './variableGetters';
 import {
   DETECTED_FIELD_AND_METADATA_VALUES_EXPR,
@@ -22,21 +21,14 @@ import {
   VAR_METADATA_EXPR,
   VAR_PATTERNS_EXPR,
 } from './variables';
-import { getDetectedFieldsFrame } from 'Components/ServiceScene/ServiceScene';
 
-jest.mock('./parserToggle');
 jest.mock('./fields');
 jest.mock('./variableGetters');
 jest.mock('./logger');
-jest.mock('Components/ServiceScene/ServiceScene', () => ({
-  getDetectedFieldsFrame: jest.fn(),
-}));
 
-const getParserEnabledMock = jest.mocked(getParserEnabled);
 const getParserFromFieldsFiltersMock = jest.mocked(getParserFromFieldsFilters);
 const getParserForFieldMock = jest.mocked(getParserForField);
 const getFieldsVariableMock = jest.mocked(getFieldsVariable);
-const getDetectedFieldsFrameMock = jest.mocked(getDetectedFieldsFrame);
 const loggerErrorMock = jest.mocked(logger.error);
 
 const sceneRef = {} as SceneObject;
@@ -50,21 +42,9 @@ const queryWithParser = (fieldName: string, format: string) =>
 /**
  * Configure the mocked dependencies for a single test case.
  */
-function setup(options: {
-  detectedFieldsAvailable?: boolean;
-  fieldParser?: ParserType;
-  filterCount: number;
-  parser: ParserType;
-  parserEnabled: boolean;
-}) {
-  getParserEnabledMock.mockReturnValue(options.parserEnabled);
+function setup(options: { fieldParser?: ParserType; filterCount: number; parser: ParserType }) {
   getParserFromFieldsFiltersMock.mockReturnValue(options.parser);
   getParserForFieldMock.mockReturnValue(options.fieldParser ?? options.parser);
-  getDetectedFieldsFrameMock.mockReturnValue(
-    options.detectedFieldsAvailable
-      ? ({ fields: [], length: 1 } as ReturnType<typeof getDetectedFieldsFrame>)
-      : undefined
-  );
   getFieldsVariableMock.mockReturnValue({
     state: {
       filters: new Array(options.filterCount).fill({}),
@@ -77,145 +57,70 @@ describe('getLogsVolumeQuery', () => {
     jest.clearAllMocks();
   });
 
-  describe('when parsers are disabled', () => {
-    it.each(['json', 'logfmt', 'mixed', 'structuredMetadata'] as const)(
-      'does not append the %s parser format even when field filters are present',
-      (parser) => {
-        setup({ filterCount: 2, parser, parserEnabled: false });
-
-        const expr = getLogsVolumeQuery(sceneRef, 'pod');
-
-        expect(expr).toBe(baseQuery('pod'));
-        expect(expr).not.toContain(JSON_FORMAT_EXPR);
-        expect(expr).not.toContain(LOGS_FORMAT_EXPR);
-        expect(expr).not.toContain(MIXED_FORMAT_EXPR);
-        expect(expr).not.toContain('| json');
-        expect(expr).not.toContain('| logfmt');
-      }
-    );
-
-    it('produces the same query whether or not field filters exist', () => {
-      setup({ filterCount: 0, parser: 'json', parserEnabled: false });
-      const exprWithoutFilters = getLogsVolumeQuery(sceneRef, 'pod');
-
-      setup({ filterCount: 5, parser: 'json', parserEnabled: false });
-      const exprWithFilters = getLogsVolumeQuery(sceneRef, 'pod');
-
-      expect(exprWithFilters).toBe(exprWithoutFilters);
-      expect(exprWithoutFilters).toBe(baseQuery('pod'));
-    });
-
-    it('does not append a parser format when aggregating by the level selector', () => {
-      setup({ filterCount: 2, parser: 'json', parserEnabled: false });
-
-      const expr = getLogsVolumeQuery(sceneRef, LEVEL_VARIABLE_VALUE);
-
-      expect(expr).toBe(baseQuery(LEVEL_VARIABLE_VALUE));
-    });
-  });
-
-  describe('when parsers are enabled and field filters are present', () => {
+  describe('when field filters are present', () => {
     it.each([
       ['json', JSON_FORMAT_EXPR],
       ['logfmt', LOGS_FORMAT_EXPR],
       ['mixed', MIXED_FORMAT_EXPR],
     ] as const)('appends the %s parser format', (parser, format) => {
-      setup({ filterCount: 1, parser, parserEnabled: true });
+      setup({ filterCount: 1, parser });
 
       const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
       expect(expr).toBe(queryWithParser('pod', format));
       expect(getParserFromFieldsFiltersMock).toHaveBeenCalled();
       expect(getParserForFieldMock).not.toHaveBeenCalled();
-      expect(getDetectedFieldsFrameMock).not.toHaveBeenCalled();
     });
 
     it('does not append a parser format for structured metadata', () => {
-      setup({ filterCount: 1, parser: 'structuredMetadata', parserEnabled: true });
+      setup({ filterCount: 1, parser: 'structuredMetadata' });
 
       const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
       expect(expr).toBe(baseQuery('pod'));
-    });
-
-    it('uses field filters instead of detected fields even when a detected fields response is available', () => {
-      setup({ detectedFieldsAvailable: true, filterCount: 1, parser: 'json', parserEnabled: true });
-
-      getLogsVolumeQuery(sceneRef, 'pod');
-
-      expect(getParserFromFieldsFiltersMock).toHaveBeenCalled();
-      expect(getParserForFieldMock).not.toHaveBeenCalled();
-      expect(getDetectedFieldsFrameMock).not.toHaveBeenCalled();
     });
   });
 
-  describe('when parsers are enabled and there are no field filters', () => {
-    it('does not append a parser format', () => {
-      setup({ filterCount: 0, parser: 'json', parserEnabled: true });
+  describe('when there are no field filters', () => {
+    it.each([
+      ['json', JSON_FORMAT_EXPR],
+      ['logfmt', LOGS_FORMAT_EXPR],
+      ['mixed', MIXED_FORMAT_EXPR],
+    ] as const)('appends the %s parser from the detected field type', (fieldParser, format) => {
+      setup({ fieldParser, filterCount: 0, parser: 'json' });
 
       const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
-      expect(expr).toBe(baseQuery('pod'));
-      expect(expr).not.toContain(JSON_FORMAT_EXPR);
+      expect(expr).toBe(queryWithParser('pod', format));
+      expect(getParserForFieldMock).toHaveBeenCalledWith('pod', sceneRef);
+      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
     });
 
-    it('uses the detected field type when the detected fields response is available', () => {
-      setup({
-        detectedFieldsAvailable: true,
-        fieldParser: 'logfmt',
-        filterCount: 0,
-        parser: 'json',
-        parserEnabled: true,
-      });
+    it('does not append a parser format when the detected field type is structured metadata', () => {
+      setup({ fieldParser: 'structuredMetadata', filterCount: 0, parser: 'json' });
 
       const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
       expect(expr).toBe(baseQuery('pod'));
       expect(getParserForFieldMock).toHaveBeenCalledWith('pod', sceneRef);
-      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
     });
 
     it('falls back to mixed when the detected field type is missing', () => {
-      setup({ detectedFieldsAvailable: true, filterCount: 0, parser: 'json', parserEnabled: true });
+      setup({ filterCount: 0, parser: 'json' });
       getParserForFieldMock.mockReturnValue(undefined);
 
       const expr = getLogsVolumeQuery(sceneRef, 'pod');
 
-      expect(expr).toBe(baseQuery('pod'));
+      expect(expr).toBe(queryWithParser('pod', MIXED_FORMAT_EXPR));
       expect(getParserForFieldMock).toHaveBeenCalledWith('pod', sceneRef);
     });
 
-    it('uses the detected field type for the level selector when the detected fields response is available', () => {
-      setup({
-        detectedFieldsAvailable: true,
-        fieldParser: 'structuredMetadata',
-        filterCount: 0,
-        parser: 'json',
-        parserEnabled: true,
-      });
-
-      getLogsVolumeQuery(sceneRef, LEVEL_VARIABLE_VALUE);
-
-      expect(getParserForFieldMock).toHaveBeenCalledWith(LEVEL_VARIABLE_VALUE, sceneRef);
-      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
-    });
-
-    it('treats the level field as structured metadata when detected fields are unavailable', () => {
-      setup({ detectedFieldsAvailable: false, filterCount: 0, parser: 'json', parserEnabled: true });
+    it('treats the level field as structured metadata without looking up detected fields', () => {
+      setup({ fieldParser: 'json', filterCount: 0, parser: 'json' });
 
       const expr = getLogsVolumeQuery(sceneRef, LEVEL_VARIABLE_VALUE);
 
       expect(expr).toBe(baseQuery(LEVEL_VARIABLE_VALUE));
-      expect(getParserForFieldMock).not.toHaveBeenCalled();
-      expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
-    });
-
-    it('falls back to mixed when detected fields are unavailable and the field is not the level selector', () => {
-      setup({ detectedFieldsAvailable: false, filterCount: 0, parser: 'json', parserEnabled: true });
-
-      const expr = getLogsVolumeQuery(sceneRef, 'pod');
-
-      expect(expr).toBe(baseQuery('pod'));
       expect(getParserForFieldMock).not.toHaveBeenCalled();
       expect(getParserFromFieldsFiltersMock).not.toHaveBeenCalled();
     });

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -22,11 +22,10 @@ import {
   VAR_PATTERNS_EXPR,
 } from './variables';
 import type { UIVariableFilterType } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
-import { getDetectedFieldsFrame } from 'Components/ServiceScene/ServiceScene';
 
 /**
- * Crafts count over time query that excludes empty values for stream selector name
- * Will only add parsers if there are filters that require them.
+ * Crafts count over time query for Logs Volume.
+ * Will only add parsers if needed.
  * @param sceneRef
  * @param fieldName - the name of the stream selector we are aggregating by
  */
@@ -34,29 +33,23 @@ export function getLogsVolumeQuery(sceneRef: SceneObject, fieldName: string): st
   const fieldsVariable = getFieldsVariable(sceneRef);
 
   const fieldFilters = fieldsVariable.state.filters;
-  let parser: ParserType;
+  let parser: ParserType = 'mixed';
   if (fieldFilters.length > 0) {
     parser = getParserFromFieldsFilters(fieldsVariable);
-  } else if (getDetectedFieldsFrame(sceneRef)) {
-    parser = getParserForField(fieldName, sceneRef) ?? 'mixed';
-  } else if (fieldName === LEVEL_VARIABLE_VALUE) {
-    parser = 'structuredMetadata';
   } else {
-    parser = 'mixed';
+    parser =
+      fieldName === LEVEL_VARIABLE_VALUE ? 'structuredMetadata' : (getParserForField(fieldName, sceneRef) ?? 'mixed');
   }
 
-  // if we have fields, we also need to add parsers (unless parsers are disabled via the header toggle)
-  if (getParserEnabled() && fieldFilters.length) {
-    if (parser === 'mixed') {
+  switch (parser) {
+    case 'mixed':
       return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${MIXED_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
-    }
-    if (parser === 'json') {
+    case 'json':
       return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${JSON_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
-    }
-    if (parser === 'logfmt') {
+    case 'logfmt':
       return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
-    }
   }
+
   return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
 }
 

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -2,7 +2,6 @@ import { SceneObject } from '@grafana/scenes';
 
 import { getParserForField, getParserFromFieldsFilters } from './fields';
 import { logger } from './logger';
-import { getParserEnabled } from './parserToggle';
 import { renderLogQLFieldFilters, renderLogQLMetadataFilters } from './query';
 import { getFieldsVariable, getMetadataVariable } from './variableGetters';
 import {

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -3,7 +3,8 @@ import { SceneObject } from '@grafana/scenes';
 import { getParserForField, getParserFromFieldsFilters } from './fields';
 import { logger } from './logger';
 import { getParserEnabled } from './parserToggle';
-import { getFieldsVariable } from './variableGetters';
+import { renderLogQLFieldFilters, renderLogQLMetadataFilters } from './query';
+import { getFieldsVariable, getMetadataVariable } from './variableGetters';
 import {
   DETECTED_FIELD_AND_METADATA_VALUES_EXPR,
   DETECTED_LEVELS_VALUES_EXPR,
@@ -51,6 +52,22 @@ export function getLogsVolumeQuery(sceneRef: SceneObject, fieldName: string): st
   }
 
   return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
+}
+
+/**
+ * Drops the grouped-by field from volume interpolation so focusing a series does not re-query.
+ */
+export function excludeAggregateByFromLogsVolumeQuery(expr: string, fieldName: string, sceneRef: SceneObject): string {
+  if (fieldName === LEVEL_VARIABLE_VALUE) {
+    return expr;
+  }
+  if (getParserForField(fieldName, sceneRef) === 'structuredMetadata') {
+    return expr.replace(
+      VAR_METADATA_EXPR,
+      renderLogQLMetadataFilters(getMetadataVariable(sceneRef).state.filters, [fieldName])
+    );
+  }
+  return expr.replace(VAR_FIELDS_EXPR, renderLogQLFieldFilters(getFieldsVariable(sceneRef).state.filters, [fieldName]));
 }
 
 /**

--- a/src/services/expressions.ts
+++ b/src/services/expressions.ts
@@ -1,6 +1,6 @@
 import { SceneObject } from '@grafana/scenes';
 
-import { getParserFromFieldsFilters } from './fields';
+import { getParserForField, getParserFromFieldsFilters } from './fields';
 import { logger } from './logger';
 import { getParserEnabled } from './parserToggle';
 import { getFieldsVariable } from './variableGetters';
@@ -11,6 +11,7 @@ import {
   LEVEL_VARIABLE_VALUE,
   LOGS_FORMAT_EXPR,
   MIXED_FORMAT_EXPR,
+  ParserType,
   VAR_FIELDS_AND_METADATA,
   VAR_FIELDS_EXPR,
   VAR_LABELS_EXPR,
@@ -21,41 +22,42 @@ import {
   VAR_PATTERNS_EXPR,
 } from './variables';
 import type { UIVariableFilterType } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
+import { getDetectedFieldsFrame } from 'Components/ServiceScene/ServiceScene';
 
 /**
  * Crafts count over time query that excludes empty values for stream selector name
  * Will only add parsers if there are filters that require them.
  * @param sceneRef
- * @param streamSelectorName - the name of the stream selector we are aggregating by
- * @param excludeEmpty - if true, the query will exclude empty values for the given streamSelectorName
+ * @param fieldName - the name of the stream selector we are aggregating by
  */
-export function getTimeSeriesExpr(sceneRef: SceneObject, streamSelectorName: string, excludeEmpty = true): string {
+export function getLogsVolumeQuery(sceneRef: SceneObject, fieldName: string): string {
   const fieldsVariable = getFieldsVariable(sceneRef);
 
-  let metadataExpressionToAdd = '';
-  if (excludeEmpty) {
-    // `LEVEL_VARIABLE_VALUE` is a special case where we don't want to add this to the stream selector
-    if (streamSelectorName === LEVEL_VARIABLE_VALUE) {
-      metadataExpressionToAdd = `| ${LEVEL_VARIABLE_VALUE} != ""`;
-    }
-  }
-
   const fieldFilters = fieldsVariable.state.filters;
-  const parser = getParserFromFieldsFilters(fieldsVariable);
+  let parser: ParserType;
+  if (fieldFilters.length > 0) {
+    parser = getParserFromFieldsFilters(fieldsVariable);
+  } else if (getDetectedFieldsFrame(sceneRef)) {
+    parser = getParserForField(fieldName, sceneRef) ?? 'mixed';
+  } else if (fieldName === LEVEL_VARIABLE_VALUE) {
+    parser = 'structuredMetadata';
+  } else {
+    parser = 'mixed';
+  }
 
   // if we have fields, we also need to add parsers (unless parsers are disabled via the header toggle)
   if (getParserEnabled() && fieldFilters.length) {
     if (parser === 'mixed') {
-      return `sum(count_over_time({${VAR_LABELS_EXPR}} ${metadataExpressionToAdd} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${MIXED_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${streamSelectorName})`;
+      return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${MIXED_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
     }
     if (parser === 'json') {
-      return `sum(count_over_time({${VAR_LABELS_EXPR}} ${metadataExpressionToAdd} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${JSON_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${streamSelectorName})`;
+      return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${JSON_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
     }
     if (parser === 'logfmt') {
-      return `sum(count_over_time({${VAR_LABELS_EXPR}} ${metadataExpressionToAdd} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${streamSelectorName})`;
+      return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${LOGS_FORMAT_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
     }
   }
-  return `sum(count_over_time({${VAR_LABELS_EXPR}} ${metadataExpressionToAdd} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${streamSelectorName})`;
+  return `sum(count_over_time({${VAR_LABELS_EXPR}} ${VAR_METADATA_EXPR} ${VAR_PATTERNS_EXPR} ${VAR_LINE_FILTERS_EXPR} ${VAR_FIELDS_EXPR} ${VAR_LINE_FORMAT_EXPR} [$__auto])) by (${fieldName})`;
 }
 
 /**

--- a/src/services/labels.test.ts
+++ b/src/services/labels.test.ts
@@ -1,10 +1,32 @@
 import { VAR_FIELD_NAME } from '@grafana/data';
-import { AdHocFiltersVariable } from '@grafana/scenes';
+import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
 
 import SpyInstance = jest.SpyInstance;
+import { getParserForField } from './fields';
 import { FilterOp } from './filterTypes';
-import { getVisibleFilters } from './labels';
+import { getVisibleFilters, toggleFieldFromFilter } from './labels';
+import { getFieldsAndMetadataVariable } from './variableGetters';
 import { VAR_FIELDS, VAR_LABELS, VAR_METADATA } from './variables';
+import { addToFilters } from 'Components/ServiceScene/Breakdowns/AddToFiltersButton';
+
+jest.mock('./fields', () => ({
+  getParserForField: jest.fn(),
+  getParserFromFieldsFilters: jest.fn(),
+}));
+jest.mock('./variableGetters', () => {
+  const actual = jest.requireActual('./variableGetters');
+  return {
+    ...actual,
+    getFieldsAndMetadataVariable: jest.fn(),
+  };
+});
+jest.mock('Components/ServiceScene/Breakdowns/AddToFiltersButton', () => ({
+  addToFilters: jest.fn(),
+}));
+
+const getParserForFieldMock = jest.mocked(getParserForField);
+const getFieldsAndMetadataVariableMock = jest.mocked(getFieldsAndMetadataVariable);
+const addToFiltersMock = jest.mocked(addToFilters);
 
 describe('getVisibleFilters', () => {
   let logSpy: SpyInstance;
@@ -397,5 +419,77 @@ describe('getVisibleFilters', () => {
       });
       expect(getVisibleFilters('detected_level', ['error'], labelsVariable)).toEqual(['error']);
     });
+  });
+});
+
+describe('toggleFieldFromFilter', () => {
+  const scene = {} as SceneObject;
+
+  function setup(options: {
+    filters?: AdHocFiltersVariable['state']['filters'];
+    parser?: 'logfmt' | 'structuredMetadata';
+  }) {
+    getParserForFieldMock.mockReturnValue(options.parser ?? 'logfmt');
+    getFieldsAndMetadataVariableMock.mockReturnValue({
+      state: { filters: options.filters ?? [] },
+    } as AdHocFiltersVariable);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes a parsed field when there are no filters', () => {
+    setup({ filters: [] });
+
+    expect(toggleFieldFromFilter('pod', 'api-1', scene)).toBe('include');
+    expect(addToFiltersMock).toHaveBeenCalledWith('pod', 'api-1', 'include', scene, VAR_FIELDS);
+  });
+
+  it('includes structured metadata on the metadata variable', () => {
+    setup({ filters: [], parser: 'structuredMetadata' });
+
+    expect(toggleFieldFromFilter('cluster', 'eu', scene)).toBe('include');
+    expect(addToFiltersMock).toHaveBeenCalledWith('cluster', 'eu', 'include', scene, VAR_METADATA);
+  });
+
+  it('toggles an existing inclusive parsed-field filter', () => {
+    setup({
+      filters: [
+        {
+          key: 'pod',
+          operator: FilterOp.Equal,
+          value: JSON.stringify({ parser: 'logfmt', value: 'api-1' }),
+        },
+      ],
+    });
+
+    expect(toggleFieldFromFilter('pod', 'api-1', scene)).toBe('toggle');
+    expect(addToFiltersMock).toHaveBeenCalledWith('pod', 'api-1', 'toggle', scene, VAR_FIELDS);
+  });
+
+  it('includes when a different value is already filtered', () => {
+    setup({
+      filters: [
+        {
+          key: 'pod',
+          operator: FilterOp.Equal,
+          value: JSON.stringify({ parser: 'logfmt', value: 'api-2' }),
+        },
+      ],
+    });
+
+    expect(toggleFieldFromFilter('pod', 'api-1', scene)).toBe('include');
+    expect(addToFiltersMock).toHaveBeenCalledWith('pod', 'api-1', 'include', scene, VAR_FIELDS);
+  });
+
+  it('toggles an existing inclusive metadata filter', () => {
+    setup({
+      filters: [{ key: 'cluster', operator: FilterOp.Equal, value: 'eu' }],
+      parser: 'structuredMetadata',
+    });
+
+    expect(toggleFieldFromFilter('cluster', 'eu', scene)).toBe('toggle');
+    expect(addToFiltersMock).toHaveBeenCalledWith('cluster', 'eu', 'toggle', scene, VAR_METADATA);
   });
 });

--- a/src/services/logsVolume.test.ts
+++ b/src/services/logsVolume.test.ts
@@ -2,12 +2,32 @@ import { AdHocVariableFilter, FieldType, LoadingState, toDataFrame } from '@graf
 import { AdHocFiltersVariable, sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { FilterOp } from './filterTypes';
-import { readLevelsFromCompletedLogsVolumePanel, getLevelsFromLogsVolume, sumLogsVolumeSeries } from './logsVolume';
+import {
+  getLevelsFromLogsVolume,
+  isLogsVolumeByFieldEnabled,
+  readLevelsFromCompletedLogsVolumePanel,
+  sumLogsVolumeSeries,
+} from './logsVolume';
 import { getLevelsVariable } from './variableGetters';
 import { VAR_LEVELS } from './variables';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
+import { getFeatureFlag } from 'featureFlags/openFeature';
 
 jest.mock('./variableGetters');
+jest.mock('featureFlags/openFeature', () => ({
+  getFeatureFlag: jest.fn(() => false),
+}));
+
+describe('isLogsVolumeByFieldEnabled', () => {
+  it('returns the drilldown.logs.logsVolumeByField flag value', () => {
+    jest.mocked(getFeatureFlag).mockReturnValue(true);
+    expect(isLogsVolumeByFieldEnabled()).toBe(true);
+    expect(getFeatureFlag).toHaveBeenCalledWith('drilldown.logs.logsVolumeByField');
+
+    jest.mocked(getFeatureFlag).mockReturnValue(false);
+    expect(isLogsVolumeByFieldEnabled()).toBe(false);
+  });
+});
 
 describe('readLevelsFromCompletedLogsVolumePanel', () => {
   it('returns null when the panel is collapsed', () => {

--- a/src/services/logsVolume.test.ts
+++ b/src/services/logsVolume.test.ts
@@ -80,6 +80,24 @@ describe('readLevelsFromCompletedLogsVolumePanel', () => {
     });
     expect(readLevelsFromCompletedLogsVolumePanel(volume)).toEqual(['error', 'warn']);
   });
+
+  it('returns null when the volume is not aggregated by detected_level', () => {
+    const volume = new LogsVolumePanel({});
+    volume.setState({
+      aggregateBy: 'pod',
+      panel: {
+        state: {
+          collapsed: false,
+          $data: {
+            state: {
+              data: { state: LoadingState.Done, series: [] },
+            },
+          },
+        },
+      } as unknown as LogsVolumePanel['state']['panel'],
+    });
+    expect(readLevelsFromCompletedLogsVolumePanel(volume)).toBeNull();
+  });
 });
 
 describe('getLevelsFromLogsVolume', () => {
@@ -185,5 +203,18 @@ describe('sumLogsVolumeSeries', () => {
   it('returns 0 for empty series', () => {
     setup([]);
     expect(sumLogsVolumeSeries([], scene)).toBe(0);
+  });
+
+  it('sums every series when the volume is not aggregated by detected_level', () => {
+    setup([
+      {
+        key: 'detected_level',
+        operator: FilterOp.Equal,
+        value: 'error',
+      },
+    ]);
+    const volume = new LogsVolumePanel({});
+    volume.setState({ aggregateBy: 'pod' });
+    expect(sumLogsVolumeSeries(series, volume)).toBe(10);
   });
 });

--- a/src/services/logsVolume.ts
+++ b/src/services/logsVolume.ts
@@ -3,6 +3,11 @@ import { sceneGraph, SceneObject } from '@grafana/scenes';
 
 import { getLevelLabelsFromSeries, getVisibleLevels } from './levels';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
+import { getFeatureFlag } from 'featureFlags/openFeature';
+
+export function isLogsVolumeByFieldEnabled(): boolean {
+  return getFeatureFlag('drilldown.logs.logsVolumeByField');
+}
 
 function shouldFilterLogsVolumeByLevel(sceneRef: SceneObject): boolean {
   if (sceneRef instanceof LogsVolumePanel) {

--- a/src/services/logsVolume.ts
+++ b/src/services/logsVolume.ts
@@ -4,19 +4,32 @@ import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { getLevelLabelsFromSeries, getVisibleLevels } from './levels';
 import { LogsVolumePanel } from 'Components/ServiceScene/LogsVolume/LogsVolumePanel';
 
+function shouldFilterLogsVolumeByLevel(sceneRef: SceneObject): boolean {
+  if (sceneRef instanceof LogsVolumePanel) {
+    return sceneRef.isAggregatingByLevel();
+  }
+  return true;
+}
+
 /**
- * Sums volume samples for series that match active level filters.
+ * Sums volume samples. When grouped by detected_level, only series matching active level filters are included.
  */
 export function sumLogsVolumeSeries(series: DataFrame[], sceneRef: SceneObject): number {
-  const levelsByFrame = getLevelLabelsFromSeries(series);
-  const visibleLevels = new Set(getVisibleLevels(levelsByFrame, sceneRef));
+  const filterByLevel = shouldFilterLogsVolumeByLevel(sceneRef);
+  const levelsByFrame = filterByLevel ? getLevelLabelsFromSeries(series) : [];
+  const visibleLevels = filterByLevel ? new Set(getVisibleLevels(levelsByFrame, sceneRef)) : null;
 
   let total = 0;
   for (let i = 0; i < series.length; i++) {
     const frame = series[i];
-    const level = levelsByFrame[i];
-    if (frame == null || level == null || !visibleLevels.has(level)) {
+    if (frame == null) {
       continue;
+    }
+    if (visibleLevels) {
+      const level = levelsByFrame[i];
+      if (level == null || !visibleLevels.has(level)) {
+        continue;
+      }
     }
     const valueField = frame.fields.find((field) => field.type === FieldType.number);
     if (!valueField) {
@@ -35,6 +48,9 @@ export function sumLogsVolumeSeries(series: DataFrame[], sceneRef: SceneObject):
  * Reads distinct detected_level names from a completed logs volume (range) query.
  */
 export function readLevelsFromCompletedLogsVolumePanel(volumePanel: LogsVolumePanel): string[] | null {
+  if (!volumePanel.isAggregatingByLevel()) {
+    return null;
+  }
   const vizPanel = volumePanel.state.panel;
   if (!vizPanel || vizPanel.state.collapsed) {
     return null;

--- a/src/services/panel.ts
+++ b/src/services/panel.ts
@@ -133,9 +133,27 @@ export function setLabelSeriesOverrides(labels: string[], overrideConfig: FieldC
  * WARNING: Overwrites any fieldConfig overrides set in the panel builder!
  */
 export function syncLevelsVisibleSeries(panel: VizPanel, series: DataFrame[], sceneRef: SceneObject) {
-  const focusedLevels = getVisibleLevels(getLevelLabelsFromSeries(series), sceneRef);
+  applyLogsVolumeSeriesVisibility(panel, getVisibleLevels(getLevelLabelsFromSeries(series), sceneRef));
+}
+
+/**
+ * Sets field or metadata series visibility in the logs volume panel.
+ * WARNING: Overwrites any fieldConfig overrides set in the panel builder!
+ */
+export function syncLogsVolumeVisibleSeries(key: string, panel: VizPanel, series: DataFrame[], sceneRef: SceneObject) {
+  const allLabels = getLabelsFromSeries(series);
+  const detectedFieldType = getParserForField(key, sceneRef);
+  const focusedLabels =
+    detectedFieldType === 'structuredMetadata'
+      ? getVisibleMetadata(key, allLabels, sceneRef)
+      : getVisibleFields(key, allLabels, sceneRef);
+
+  applyLogsVolumeSeriesVisibility(panel, focusedLabels);
+}
+
+function applyLogsVolumeSeriesVisibility(panel: VizPanel, focusedLabels: string[]) {
   const config = setLogsVolumeFieldConfigOverrides(FieldConfigBuilders.timeseries()).setOverrides(
-    setLabelSeriesOverrides.bind(null, focusedLevels)
+    setLabelSeriesOverrides.bind(null, focusedLabels)
   );
 
   if (config instanceof FieldConfigBuilder && panel.getPlugin()) {

--- a/src/services/parserToggle.test.ts
+++ b/src/services/parserToggle.test.ts
@@ -8,6 +8,7 @@ import {
   PARSER_ENABLED_LOCALSTORAGE_KEY,
   setParserEnabled,
 } from './parserToggle';
+import { getLogsVolumeAggregateBy, setLogsVolumeOption } from './store';
 import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
 
 jest.mock('@grafana/scenes', () => ({
@@ -162,6 +163,17 @@ describe('setParserEnabled', () => {
 
     setParserEnabled(false, sceneRef);
     expect(clearParserDependentFilters).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears the stored logs volume aggregateBy when disabling', () => {
+    setLogsVolumeOption('aggregateBy', 'caller');
+    expect(getLogsVolumeAggregateBy()).toBe('caller');
+
+    setParserEnabled(true, sceneRef);
+    expect(getLogsVolumeAggregateBy()).toBe('caller');
+
+    setParserEnabled(false, sceneRef);
+    expect(getLogsVolumeAggregateBy()).toBeNull();
   });
 
   test('re-runs parser-dependent queries on the service scene', () => {

--- a/src/services/parserToggle.test.ts
+++ b/src/services/parserToggle.test.ts
@@ -8,8 +8,12 @@ import {
   PARSER_ENABLED_LOCALSTORAGE_KEY,
   setParserEnabled,
 } from './parserToggle';
-import { getLogsVolumeAggregateBy, setLogsVolumeOption } from './store';
+import { setLogsVolumeAggregateBy } from './store';
 import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
+
+jest.mock('./store', () => ({
+  setLogsVolumeAggregateBy: jest.fn(),
+}));
 
 jest.mock('@grafana/scenes', () => ({
   ...jest.requireActual('@grafana/scenes'),
@@ -166,14 +170,11 @@ describe('setParserEnabled', () => {
   });
 
   test('clears the stored logs volume aggregateBy when disabling', () => {
-    setLogsVolumeOption('aggregateBy', 'caller');
-    expect(getLogsVolumeAggregateBy()).toBe('caller');
-
     setParserEnabled(true, sceneRef);
-    expect(getLogsVolumeAggregateBy()).toBe('caller');
+    expect(setLogsVolumeAggregateBy).not.toHaveBeenCalled();
 
     setParserEnabled(false, sceneRef);
-    expect(getLogsVolumeAggregateBy()).toBeNull();
+    expect(setLogsVolumeAggregateBy).toHaveBeenCalledWith(sceneRef, undefined);
   });
 
   test('re-runs parser-dependent queries on the service scene', () => {

--- a/src/services/parserToggle.ts
+++ b/src/services/parserToggle.ts
@@ -1,7 +1,7 @@
 import { sceneGraph, SceneQueryRunner, type SceneObject } from '@grafana/scenes';
 
 import { CustomConstantVariable } from './CustomConstantVariable';
-import { setLogsVolumeOption } from './store';
+import { setLogsVolumeAggregateBy } from './store';
 import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { ServiceScene } from 'Components/ServiceScene/ServiceScene';
@@ -39,7 +39,7 @@ export function setParserEnabled(enabled: boolean, sceneRef: SceneObject): void 
   // to avoid sending invalid queries.
   if (!enabled) {
     indexScene.clearParserDependentFilters();
-    setLogsVolumeOption('aggregateBy', undefined);
+    setLogsVolumeAggregateBy(sceneRef, undefined);
   }
 
   // Re-run the parser-dependent queries so the new setting is applied immediately.

--- a/src/services/parserToggle.ts
+++ b/src/services/parserToggle.ts
@@ -1,6 +1,7 @@
 import { sceneGraph, SceneQueryRunner, type SceneObject } from '@grafana/scenes';
 
 import { CustomConstantVariable } from './CustomConstantVariable';
+import { setLogsVolumeOption } from './store';
 import { JSON_PARSER_SEGMENT, LOGFMT_PARSER_SEGMENT, VAR_JSON_PARSER, VAR_LOGFMT_PARSER } from './variables';
 import { IndexScene } from 'Components/IndexScene/IndexScene';
 import { ServiceScene } from 'Components/ServiceScene/ServiceScene';
@@ -38,6 +39,7 @@ export function setParserEnabled(enabled: boolean, sceneRef: SceneObject): void 
   // to avoid sending invalid queries.
   if (!enabled) {
     indexScene.clearParserDependentFilters();
+    setLogsVolumeOption('aggregateBy', undefined);
   }
 
   // Re-run the parser-dependent queries so the new setting is applied immediately.

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -354,7 +354,7 @@ export function setLogOption(
 
 // Logs volume options
 const LOGS_VOLUME_LOCALSTORAGE_KEY = 'grafana.explore.logs.logsVolume';
-export function setLogsVolumeOption(option: 'collapsed', value: string | undefined) {
+export function setLogsVolumeOption(option: 'aggregateBy' | 'collapsed', value: string | undefined) {
   const key = `${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`;
   if (value === undefined) {
     localStorage.removeItem(key);
@@ -365,6 +365,10 @@ export function setLogsVolumeOption(option: 'collapsed', value: string | undefin
 
 export function getLogsVolumeOption(option: 'collapsed') {
   return Boolean(localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`));
+}
+
+export function getLogsVolumeAggregateBy() {
+  return localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.aggregateBy`);
 }
 
 // Log visualization options

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -354,7 +354,7 @@ export function setLogOption(
 
 // Logs volume options
 const LOGS_VOLUME_LOCALSTORAGE_KEY = 'grafana.explore.logs.logsVolume';
-export function setLogsVolumeOption(option: 'aggregateBy' | 'collapsed', value: string | undefined) {
+export function setLogsVolumeOption(option: 'collapsed', value: string | undefined) {
   const key = `${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`;
   if (value === undefined) {
     localStorage.removeItem(key);
@@ -367,8 +367,21 @@ export function getLogsVolumeOption(option: 'collapsed') {
   return Boolean(localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.${option}`));
 }
 
-export function getLogsVolumeAggregateBy() {
-  return localStorage.getItem(`${LOGS_VOLUME_LOCALSTORAGE_KEY}.aggregateBy`);
+function getLogsVolumeAggregateByKey(sceneRef: SceneObject) {
+  return `${pluginJson.id}.${getExplorationPrefix(sceneRef)}.logsVolume.aggregateBy`;
+}
+
+export function getLogsVolumeAggregateBy(sceneRef: SceneObject) {
+  return localStorage.getItem(getLogsVolumeAggregateByKey(sceneRef));
+}
+
+export function setLogsVolumeAggregateBy(sceneRef: SceneObject, value: string | undefined) {
+  const key = getLogsVolumeAggregateByKey(sceneRef);
+  if (value === undefined) {
+    localStorage.removeItem(key);
+    return;
+  }
+  localStorage.setItem(key, value);
 }
 
 // Log visualization options


### PR DESCRIPTION
Closes https://github.com/grafana/logs-drilldown/issues/1712

This PR adds support to customize the Logs Volume aggregation by other fields.

Demo:

https://github.com/user-attachments/assets/dd034ad5-a29d-43c9-a758-e9fb4d1eb9df

Features:
- Supports all field types except float, duration, and byte.
- Supports parsed fields and structured metadata.
- Stored by exploration.
- Reset if parsers are disabled.
- Focus series and applies filters, like the existing volume by level implementation.

Additional fix:

Fixes a leftover bug after https://github.com/grafana/logs-drilldown/pull/2057, where `maxLines` was being read from the wrong place.

<img width="1407" height="352" alt="Before" src="https://github.com/user-attachments/assets/cf0401dc-c22c-425b-afe4-7c37c117f14e" />

<img width="1415" height="385" alt="After" src="https://github.com/user-attachments/assets/c24faa37-0af3-48d7-8058-40ea3875c19c" />
