### PR TITLE
fix(combineResponses): optimize for time series

### DIFF
--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -587,9 +587,7 @@ describe('mergeFrames', () => {
       ],
     });
   });
-});
 
-describe('mergeFrames', () => {
   it('merges disjoint, interleaved timestamps in sorted order', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
     // metricFrameA: time [3000000, 4000000], metricFrameB: time [1000000, 2000000]

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -240,6 +240,179 @@ describe('combineResponses', () => {
     });
   });
 
+  it('when fields with the same name are present, uses labels to find the right field to combine', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+
+    metricFrameA.fields.push({
+      config: {},
+      labels: {
+        test: 'true',
+      },
+      name: 'Value',
+      type: FieldType.number,
+      values: [9, 8],
+    });
+    metricFrameB.fields.push({
+      config: {},
+      labels: {
+        test: 'true',
+      },
+      name: 'Value',
+      type: FieldType.number,
+      values: [11, 10],
+    });
+
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              labels: {
+                level: 'debug',
+              },
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+            },
+            {
+              config: {},
+              labels: {
+                test: 'true',
+              },
+              name: 'Value',
+              type: 'number',
+              values: [11, 10, 9, 8],
+            },
+          ],
+          length: 4,
+          meta: {
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+            type: 'timeseries-multi',
+          },
+          name: 'A{"level":"debug"}',
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('when fields with the same name are present and labels are not present, falls back to indexes', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+
+    delete metricFrameA.fields[1].labels;
+    delete metricFrameB.fields[1].labels;
+
+    metricFrameA.fields.push({
+      config: {},
+      name: 'Value',
+      type: FieldType.number,
+      values: [9, 8],
+    });
+    metricFrameB.fields.push({
+      config: {},
+      name: 'Value',
+      type: FieldType.number,
+      values: [11, 10],
+    });
+
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1000000, 2000000, 3000000, 4000000],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [6, 7, 5, 4],
+            },
+            {
+              config: {},
+              name: 'Value',
+              type: 'number',
+              values: [11, 10, 9, 8],
+            },
+          ],
+          length: 4,
+          meta: {
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+            type: 'timeseries-multi',
+          },
+          name: 'A',
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('matches same-named fields by labels rather than position when their order differs between dest and source', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+
+    // dest: [Time, Value(debug), Value(error)]
+    metricFrameA.fields.push({
+      config: {},
+      labels: { level: 'error' },
+      name: 'Value',
+      type: FieldType.number,
+      values: [100, 200],
+    });
+
+    // source: same two series, but in the OPPOSITE field order: [Time, Value(error), Value(debug)]
+    metricFrameB.fields = [
+      metricFrameB.fields[0],
+      { config: {}, labels: { level: 'error' }, name: 'Value', type: FieldType.number, values: [1, 2] },
+      { config: {}, labels: { level: 'debug' }, name: 'Value', type: FieldType.number, values: [10, 20] },
+    ];
+
+    mergeFrames(metricFrameA, metricFrameB);
+
+    const debugField = metricFrameA.fields.find((f) => f.labels?.level === 'debug');
+    const errorField = metricFrameA.fields.find((f) => f.labels?.level === 'error');
+
+    // Had this matched positionally instead of by labels, debug (dest.fields[1]) would incorrectly
+    // pair with source.fields[1] (labeled error, values [1, 2]) instead of the actual debug field.
+    expect(debugField?.values).toEqual([10, 20, 5, 4]);
+    expect(errorField?.values).toEqual([1, 2, 100, 200]);
+  });
+
   it('does not combine frames with different refId', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
     metricFrameA.refId = 'A';

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -1,6 +1,6 @@
 import { DataFrame, DataFrameType, DataQueryResponse, FieldType, QueryResultMetaStat } from '@grafana/data';
 
-import { cloneQueryResponse, combineResponses } from './combineResponses';
+import { cloneQueryResponse, combineResponses, mergeFrames } from './combineResponses';
 
 describe('cloneQueryResponse', () => {
   const { logFrameA } = getMockFrames();
@@ -269,149 +269,6 @@ describe('combineResponses', () => {
       data: [metricFrameA, metricFrameB],
     });
   });
-
-  it('when fields with the same name are present, uses labels to find the right field to combine', () => {
-    const { metricFrameA, metricFrameB } = getMockFrames();
-
-    metricFrameA.fields.push({
-      config: {},
-      labels: {
-        test: 'true',
-      },
-      name: 'Value',
-      type: FieldType.number,
-      values: [9, 8],
-    });
-    metricFrameB.fields.push({
-      config: {},
-      labels: {
-        test: 'true',
-      },
-      name: 'Value',
-      type: FieldType.number,
-      values: [11, 10],
-    });
-
-    const responseA: DataQueryResponse = {
-      data: [metricFrameA],
-    };
-    const responseB: DataQueryResponse = {
-      data: [metricFrameB],
-    };
-
-    expect(combineResponses(responseA, responseB)).toEqual({
-      data: [
-        {
-          fields: [
-            {
-              config: {},
-              name: 'Time',
-              type: 'time',
-              values: [1000000, 2000000, 3000000, 4000000],
-            },
-            {
-              config: {},
-              labels: {
-                level: 'debug',
-              },
-              name: 'Value',
-              type: 'number',
-              values: [6, 7, 5, 4],
-            },
-            {
-              config: {},
-              labels: {
-                test: 'true',
-              },
-              name: 'Value',
-              type: 'number',
-              values: [11, 10, 9, 8],
-            },
-          ],
-          length: 4,
-          meta: {
-            stats: [
-              {
-                displayName: 'Summary: total bytes processed',
-                unit: 'decbytes',
-                value: 33,
-              },
-            ],
-            type: 'timeseries-multi',
-          },
-          name: 'A{"level":"debug"}',
-          refId: 'A',
-        },
-      ],
-    });
-  });
-
-  it('when fields with the same name are present and labels are not present, falls back to indexes', () => {
-    const { metricFrameA, metricFrameB } = getMockFrames();
-
-    delete metricFrameA.fields[1].labels;
-    delete metricFrameB.fields[1].labels;
-
-    metricFrameA.fields.push({
-      config: {},
-      name: 'Value',
-      type: FieldType.number,
-      values: [9, 8],
-    });
-    metricFrameB.fields.push({
-      config: {},
-      name: 'Value',
-      type: FieldType.number,
-      values: [11, 10],
-    });
-
-    const responseA: DataQueryResponse = {
-      data: [metricFrameA],
-    };
-    const responseB: DataQueryResponse = {
-      data: [metricFrameB],
-    };
-
-    expect(combineResponses(responseA, responseB)).toEqual({
-      data: [
-        {
-          fields: [
-            {
-              config: {},
-              name: 'Time',
-              type: 'time',
-              values: [1000000, 2000000, 3000000, 4000000],
-            },
-            {
-              config: {},
-              name: 'Value',
-              type: 'number',
-              values: [6, 7, 5, 4],
-            },
-            {
-              config: {},
-              name: 'Value',
-              type: 'number',
-              values: [11, 10, 9, 8],
-            },
-          ],
-          length: 4,
-          meta: {
-            stats: [
-              {
-                displayName: 'Summary: total bytes processed',
-                unit: 'decbytes',
-                value: 33,
-              },
-            ],
-            type: 'timeseries-multi',
-          },
-          name: 'A',
-          refId: 'A',
-        },
-      ],
-    });
-  });
 });
 
 describe('mergeFrames', () => {
@@ -556,6 +413,97 @@ describe('mergeFrames', () => {
         metricFrameC,
       ],
     });
+  });
+});
+
+describe('mergeFrames', () => {
+  it('merges disjoint, interleaved timestamps in sorted order', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    // metricFrameA: time [3000000, 4000000], metricFrameB: time [1000000, 2000000]
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.fields[0].values).toEqual([1000000, 2000000, 3000000, 4000000]);
+    expect(metricFrameA.fields[1].values).toEqual([6, 7, 5, 4]);
+    expect(metricFrameA.length).toBe(4);
+  });
+
+  it('sums values for overlapping timestamps', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameB.fields[0].values = [3000000, 4000000];
+    metricFrameB.fields[1].values = [10, 20];
+
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.fields[0].values).toEqual([3000000, 4000000]);
+    expect(metricFrameA.fields[1].values).toEqual([15, 24]);
+    expect(metricFrameA.length).toBe(2);
+  });
+
+  it('does not introduce undefined entries when dest is longer than source', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.fields[0].values = [1000000, 2000000, 3000000, 4000000, 5000000];
+    metricFrameA.fields[1].values = [1, 2, 3, 4, 5];
+    metricFrameB.fields[0].values = [2500000];
+    metricFrameB.fields[1].values = [100];
+
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.fields[0].values).toEqual([1000000, 2000000, 2500000, 3000000, 4000000, 5000000]);
+    expect(metricFrameA.fields[1].values).toEqual([1, 2, 100, 3, 4, 5]);
+    expect(metricFrameA.fields[0].values).not.toContain(undefined);
+    expect(metricFrameA.fields[1].values).not.toContain(undefined);
+    expect(metricFrameA.length).toBe(6);
+  });
+
+  it('does not introduce undefined entries when source is longer than dest', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.fields[0].values = [2500000];
+    metricFrameA.fields[1].values = [100];
+    metricFrameB.fields[0].values = [1000000, 2000000, 3000000, 4000000, 5000000];
+    metricFrameB.fields[1].values = [1, 2, 3, 4, 5];
+
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.fields[0].values).toEqual([1000000, 2000000, 2500000, 3000000, 4000000, 5000000]);
+    expect(metricFrameA.fields[1].values).toEqual([1, 2, 100, 3, 4, 5]);
+    expect(metricFrameA.fields[0].values).not.toContain(undefined);
+    expect(metricFrameA.fields[1].values).not.toContain(undefined);
+    expect(metricFrameA.length).toBe(6);
+  });
+
+  it('combines stats from both frames', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.meta?.stats).toStrictEqual([
+      { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },
+    ]);
+  });
+
+  it('appends the remaining dest tail in order, even when it lies far beyond the exhausted source range', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.fields[0].values = [10, 20, 100000, 200000, 300000];
+    metricFrameA.fields[1].values = [1, 2, 3, 4, 5];
+    metricFrameB.fields[0].values = [15];
+    metricFrameB.fields[1].values = [99];
+
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.fields[0].values).toEqual([10, 15, 20, 100000, 200000, 300000]);
+    expect(metricFrameA.fields[1].values).toEqual([1, 99, 2, 3, 4, 5]);
+  });
+
+  it('appends the remaining source tail in order, even when it lies far beyond the exhausted dest range', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.fields[0].values = [15];
+    metricFrameA.fields[1].values = [99];
+    metricFrameB.fields[0].values = [10, 20, 100000, 200000, 300000];
+    metricFrameB.fields[1].values = [1, 2, 3, 4, 5];
+
+    mergeFrames(metricFrameA, metricFrameB);
+
+    expect(metricFrameA.fields[0].values).toEqual([10, 15, 20, 100000, 200000, 300000]);
+    expect(metricFrameA.fields[1].values).toEqual([1, 99, 2, 3, 4, 5]);
   });
 });
 

--- a/src/services/combineResponses.test.ts
+++ b/src/services/combineResponses.test.ts
@@ -428,7 +428,7 @@ describe('combineResponses', () => {
     });
   });
 
-  it('does not combine frames with different refId', () => {
+  it('does not combine frames with different name', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
     metricFrameA.name = 'A';
     metricFrameB.name = 'B';

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -103,7 +103,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const totalFields = Math.max(dest.fields.length, source.fields.length);
 
   const fieldPairs = dest.fields.map((field, idx) => (field ? findSourceField(field, source.fields, idx) : undefined));
-  const outValues: unknown[][] = dest.fields.map(() => []);
+  const outValues: number[][] = dest.fields.map(() => []);
 
   const emitDest = (j: number) => {
     for (let f = 0; f < totalFields; f++) {

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -1,5 +1,4 @@
 import {
-  closestIdx,
   DataFrame,
   DataFrameType,
   DataQueryResponse,
@@ -87,134 +86,67 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
 }
 
 /**
- * Given two data frames, merge their values. Overlapping values will be added together.
+ * Given two time-series data frames (single time field + single number field),
+ * merge their values with a linear two-pointer merge. Overlapping timestamps are summed.
  */
 export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const destTimeField = dest.fields.find((field) => field.type === FieldType.time);
-  const destIdField = dest.fields.find((field) => field.type === FieldType.string && field.name === 'id');
+  const destValueField = dest.fields.find((field) => field.type === FieldType.number);
   const sourceTimeField = source.fields.find((field) => field.type === FieldType.time);
-  const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
+  const sourceValueField = source.fields.find((field) => field.type === FieldType.number);
 
-  if (!destTimeField || !sourceTimeField) {
+  if (!destTimeField || !sourceTimeField || !destValueField || !sourceValueField) {
     logger.error(new Error(`Time fields not found in the data frames`));
     return;
   }
 
-  const sourceTimeValues = sourceTimeField?.values.slice(0) ?? [];
-  const totalFields = Math.max(dest.fields.length, source.fields.length);
+  const destTime = destTimeField.values;
+  const destValue = destValueField.values;
+  const sourceTime = sourceTimeField.values;
+  const sourceValue = sourceValueField.values;
 
-  for (let i = 0; i < sourceTimeValues.length; i++) {
-    const destIdx = resolveIdx(destTimeField, sourceTimeField, i);
+  const mergedTime: number[] = [];
+  const mergedValues: number[] = [];
 
-    const entryExistsInDest = compareEntries(destTimeField, destIdField, destIdx, sourceTimeField, sourceIdField, i);
+  let i = 0; // source pointer
+  let j = 0; // dest pointer
 
-    for (let f = 0; f < totalFields; f++) {
-      // For now, skip undefined fields that exist in the new frame
-      if (!dest.fields[f]) {
-        continue;
-      }
-      // Index is not reliable when frames have disordered fields, or an extra/missing field, so we find them by name.
-      // If the field has no name, we fallback to the old index version.
-      const sourceField = findSourceField(dest.fields[f], source.fields, f);
-      if (!sourceField) {
-        continue;
-      }
-      // Same value, accumulate
-      if (entryExistsInDest) {
-        if (dest.fields[f].type === FieldType.time) {
-          // Time already exists, skip
-          continue;
-        } else if (dest.fields[f].type === FieldType.number) {
-          // Number, add
-          dest.fields[f].values[destIdx] = (dest.fields[f].values[destIdx] ?? 0) + sourceField.values[i];
-        } else if (dest.fields[f].type === FieldType.other) {
-          // Possibly labels, combine
-          if (typeof sourceField.values[i] === 'object') {
-            dest.fields[f].values[destIdx] = {
-              ...dest.fields[f].values[destIdx],
-              ...sourceField.values[i],
-            };
-          } else if (sourceField.values[i] != null) {
-            dest.fields[f].values[destIdx] = sourceField.values[i];
-          }
-        } else {
-          // Replace value
-          dest.fields[f].values[destIdx] = sourceField.values[i];
-        }
-      } else if (sourceField.values[i] !== undefined) {
-        // Insert in the `destIdx` position
-        dest.fields[f].values.splice(destIdx, 0, sourceField.values[i]);
-        if (sourceField.nanos) {
-          dest.fields[f].nanos = dest.fields[f].nanos ?? new Array(dest.fields[f].values.length - 1).fill(0);
-          dest.fields[f].nanos?.splice(destIdx, 0, sourceField.nanos[i]);
-        }
-      }
+  while (i < sourceTime.length && j < destTime.length) {
+    if (destTime[j] === sourceTime[i]) {
+      mergedTime.push(destTime[j]);
+      mergedValues.push((destValue[j] ?? 0) + (sourceValue[i] ?? 0));
+      i++;
+      j++;
+    } else if (destTime[j] < sourceTime[i]) {
+      mergedTime.push(destTime[j]);
+      mergedValues.push(destValue[j]);
+      j++;
+    } else {
+      mergedTime.push(sourceTime[i]);
+      mergedValues.push(sourceValue[i]);
+      i++;
     }
   }
+  while (j < destTime.length) {
+    mergedTime.push(destTime[j]);
+    mergedValues.push(destValue[j]);
+    j++;
+  }
+  while (i < sourceTime.length) {
+    mergedTime.push(sourceTime[i]);
+    mergedValues.push(sourceValue[i]);
+    i++;
+  }
 
-  dest.length = dest.fields[0].values.length;
+  destTimeField.values = mergedTime;
+  destValueField.values = mergedValues;
+
+  dest.length = mergedTime.length;
 
   dest.meta = {
     ...dest.meta,
     stats: getCombinedMetadataStats(dest.meta?.stats ?? [], source.meta?.stats ?? []),
   };
-}
-
-function resolveIdx(destField: Field, sourceField: Field, index: number) {
-  const idx = closestIdx(sourceField.values[index], destField.values);
-  if (idx < 0) {
-    return 0;
-  }
-  if (sourceField.values[index] === destField.values[idx] && sourceField.nanos != null && destField.nanos != null) {
-    return sourceField.nanos[index] > destField.nanos[idx] ? idx + 1 : idx;
-  }
-  if (sourceField.values[index] > destField.values[idx]) {
-    return idx + 1;
-  }
-  return idx;
-}
-
-function compareEntries(
-  destTimeField: Field,
-  destIdField: Field | undefined,
-  destIndex: number,
-  sourceTimeField: Field,
-  sourceIdField: Field | undefined,
-  sourceIndex: number
-) {
-  const sameTimestamp = compareNsTimestamps(destTimeField, destIndex, sourceTimeField, sourceIndex);
-  if (!sameTimestamp) {
-    return false;
-  }
-  if (destIdField == null || sourceIdField == null) {
-    return true;
-  }
-  // Log frames, check indexes
-  return (
-    destIdField.values[destIndex] !== undefined && destIdField.values[destIndex] === sourceIdField.values[sourceIndex]
-  );
-}
-
-function compareNsTimestamps(destField: Field, destIndex: number, sourceField: Field, sourceIndex: number) {
-  if (destField.nanos && sourceField.nanos) {
-    return (
-      destField.values[destIndex] !== undefined &&
-      destField.values[destIndex] === sourceField.values[sourceIndex] &&
-      destField.nanos[destIndex] !== undefined &&
-      destField.nanos[destIndex] === sourceField.nanos[sourceIndex]
-    );
-  }
-  return destField.values[destIndex] !== undefined && destField.values[destIndex] === sourceField.values[sourceIndex];
-}
-
-function findSourceField(referenceField: Field, sourceFields: Field[], index: number) {
-  const candidates = sourceFields.filter((f) => f.name === referenceField.name);
-
-  if (candidates.length === 1) {
-    return candidates[0];
-  }
-
-  return sourceFields[index];
 }
 
 const TOTAL_BYTES_STAT = 'Summary: total bytes processed';

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -87,11 +87,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
 }
 
 /**
- * Given two time-series data frames, merge their values with a linear two-pointer merge
- * (both time fields are assumed sorted ascending). A frame may carry multiple number fields
- * (e.g. several aggregations disambiguated by labels); each is matched between dest and
- * source by name, then by labels, falling back to positional index. Overlapping timestamps
- * have their number fields summed.
+ * Given two data frames, merge their values. Overlapping values will be added together.
  */
 export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const destTimeField = dest.fields.find((field) => field.type === FieldType.time);
@@ -106,7 +102,6 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const sourceTime = sourceTimeField.values;
   const totalFields = Math.max(dest.fields.length, source.fields.length);
 
-  // Computed once, not per row.
   const fieldPairs = dest.fields.map((field, idx) => (field ? findSourceField(field, source.fields, idx) : undefined));
   const outValues: unknown[][] = dest.fields.map(() => []);
 

--- a/src/services/combineResponses.ts
+++ b/src/services/combineResponses.ts
@@ -6,6 +6,7 @@ import {
   Field,
   FieldType,
   QueryResultMetaStat,
+  shallowCompare,
 } from '@grafana/data';
 
 import { logger } from './logger';
@@ -86,67 +87,115 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
 }
 
 /**
- * Given two time-series data frames (single time field + single number field),
- * merge their values with a linear two-pointer merge. Overlapping timestamps are summed.
+ * Given two time-series data frames, merge their values with a linear two-pointer merge
+ * (both time fields are assumed sorted ascending). A frame may carry multiple number fields
+ * (e.g. several aggregations disambiguated by labels); each is matched between dest and
+ * source by name, then by labels, falling back to positional index. Overlapping timestamps
+ * have their number fields summed.
  */
 export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const destTimeField = dest.fields.find((field) => field.type === FieldType.time);
-  const destValueField = dest.fields.find((field) => field.type === FieldType.number);
   const sourceTimeField = source.fields.find((field) => field.type === FieldType.time);
-  const sourceValueField = source.fields.find((field) => field.type === FieldType.number);
 
-  if (!destTimeField || !sourceTimeField || !destValueField || !sourceValueField) {
+  if (!destTimeField || !sourceTimeField) {
     logger.error(new Error(`Time fields not found in the data frames`));
     return;
   }
 
   const destTime = destTimeField.values;
-  const destValue = destValueField.values;
   const sourceTime = sourceTimeField.values;
-  const sourceValue = sourceValueField.values;
+  const totalFields = Math.max(dest.fields.length, source.fields.length);
 
-  const mergedTime: number[] = [];
-  const mergedValues: number[] = [];
+  // Computed once, not per row.
+  const fieldPairs = dest.fields.map((field, idx) => (field ? findSourceField(field, source.fields, idx) : undefined));
+  const outValues: unknown[][] = dest.fields.map(() => []);
+
+  const emitDest = (j: number) => {
+    for (let f = 0; f < totalFields; f++) {
+      if (!dest.fields[f]) {
+        continue;
+      }
+      outValues[f].push(dest.fields[f].values[j]);
+    }
+  };
+
+  const emitMerged = (j: number, i: number) => {
+    for (let f = 0; f < totalFields; f++) {
+      if (!dest.fields[f]) {
+        continue;
+      }
+      const sourceField = fieldPairs[f];
+      const destVal = dest.fields[f].values[j];
+      let merged = destVal;
+      if (sourceField) {
+        if (dest.fields[f].type === FieldType.number) {
+          merged = (destVal ?? 0) + sourceField.values[i];
+        } else if (dest.fields[f].type !== FieldType.time) {
+          merged = sourceField.values[i] ?? destVal;
+        }
+      }
+      outValues[f].push(merged);
+    }
+  };
+
+  const emitSource = (i: number) => {
+    for (let f = 0; f < totalFields; f++) {
+      if (!dest.fields[f]) {
+        continue;
+      }
+      const sourceField = fieldPairs[f];
+      outValues[f].push(sourceField ? sourceField.values[i] : undefined);
+    }
+  };
 
   let i = 0; // source pointer
   let j = 0; // dest pointer
 
   while (i < sourceTime.length && j < destTime.length) {
     if (destTime[j] === sourceTime[i]) {
-      mergedTime.push(destTime[j]);
-      mergedValues.push((destValue[j] ?? 0) + (sourceValue[i] ?? 0));
+      emitMerged(j, i);
       i++;
       j++;
     } else if (destTime[j] < sourceTime[i]) {
-      mergedTime.push(destTime[j]);
-      mergedValues.push(destValue[j]);
+      emitDest(j);
       j++;
     } else {
-      mergedTime.push(sourceTime[i]);
-      mergedValues.push(sourceValue[i]);
+      emitSource(i);
       i++;
     }
   }
   while (j < destTime.length) {
-    mergedTime.push(destTime[j]);
-    mergedValues.push(destValue[j]);
+    emitDest(j);
     j++;
   }
   while (i < sourceTime.length) {
-    mergedTime.push(sourceTime[i]);
-    mergedValues.push(sourceValue[i]);
+    emitSource(i);
     i++;
   }
 
-  destTimeField.values = mergedTime;
-  destValueField.values = mergedValues;
-
-  dest.length = mergedTime.length;
+  dest.fields.forEach((field, f) => {
+    field.values = outValues[f];
+  });
+  dest.length = dest.fields[0].values.length;
 
   dest.meta = {
     ...dest.meta,
     stats: getCombinedMetadataStats(dest.meta?.stats ?? [], source.meta?.stats ?? []),
   };
+}
+
+function findSourceField(referenceField: Field, sourceFields: Field[], index: number) {
+  const candidates = sourceFields.filter((f) => f.name === referenceField.name);
+
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  if (referenceField.labels) {
+    return candidates.find((candidate) => shallowCompare(referenceField.labels ?? {}, candidate.labels ?? {}));
+  }
+
+  return sourceFields[index];
 }
 
 const TOTAL_BYTES_STAT = 'Summary: total bytes processed';


### PR DESCRIPTION
The original shard query splitting implementation was derived from the Scan query direction from Core Grafana, but only applied to time series, while keeping all the logs-related code intact.

Since then, merging data frames (in particular in the Fields breakdown) became a common source of browser freezes due to the effort required to merge partial responses.

In this PR we're dropping all the logs-related implementation, and using an optimized merge version for time series, where we can assume time and value(s).

The purpose is to finally address this performance issue and be a complement to https://github.com/grafana/logs-drilldown/pull/2071, where we're exposing other Logs Volume aggregation options with potentially high cardinality.

### How to test

- Pick a high-volume source of logs
- Go to the Fields tab
- Enable parsers
- Expectation: the browser should not freeze when dealing with many fields and many series.