### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   serialize-javascript: 7.0.6
   strip-ansi: 6.0.1
   js-yaml: 4.3.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   undici: 8.9.0
   protobufjs: 8.6.5
   js-cookie: 3.0.8
@@ -22,14 +22,17 @@ overrides:
   brace-expansion@^5: 5.0.9
   ws@^8: 8.21.0
   ws@>=7.0.0 <7.5.11: 7.5.11
-  qs: 6.15.3
+  qs: 6.16.0
   '@babel/core@<=7.29.0': 7.29.7
   '@opentelemetry/core@<2.8.0': 2.8.0
   tar@<=7.5.20: 7.5.22
   webpack: 5.108.1
   websocket-driver@<0.7.5: 0.7.5
   postcss@<8.5.18: 8.5.23
-  nanoid: 3.3.17
+  nanoid: 3.3.18
+  '@humanfs/node': '>=0.16.8'
+  browserslist: '>=4.28.7'
+  postcss-selector-parser: '>=7.1.3'
 
 importers:
   .:
@@ -1401,14 +1404,19 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@humanfs/core@0.19.1':
+  '@humanfs/core@0.19.2':
     resolution:
-      { integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA== }
+      { integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA== }
     engines: { node: '>=18.18.0' }
 
-  '@humanfs/node@0.16.7':
+  '@humanfs/node@0.16.8':
     resolution:
-      { integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ== }
+      { integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ== }
+    engines: { node: '>=18.18.0' }
+
+  '@humanfs/types@0.15.0':
+    resolution:
+      { integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q== }
     engines: { node: '>=18.18.0' }
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -3570,9 +3578,9 @@ packages:
       { integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA== }
     engines: { node: 18 || 20 || >=22 }
 
-  baseline-browser-mapping@2.10.19:
+  baseline-browser-mapping@2.11.20:
     resolution:
-      { integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g== }
+      { integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw== }
     engines: { node: '>=6.0.0' }
     hasBin: true
 
@@ -3602,9 +3610,9 @@ packages:
     resolution:
       { integrity: sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw== }
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     resolution:
-      { integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg== }
+      { integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA== }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
 
@@ -3654,9 +3662,9 @@ packages:
       { integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA== }
     engines: { node: '>=10' }
 
-  caniuse-lite@1.0.30001788:
+  caniuse-lite@1.0.30001810:
     resolution:
-      { integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ== }
+      { integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg== }
 
   chalk@4.1.2:
     resolution:
@@ -4264,9 +4272,9 @@ packages:
     resolution:
       { integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA== }
 
-  electron-to-chromium@1.5.340:
+  electron-to-chromium@1.5.420:
     resolution:
-      { integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA== }
+      { integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA== }
 
   emittery@0.13.1:
     resolution:
@@ -4501,6 +4509,7 @@ packages:
     resolution:
       { integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ== }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4624,9 +4633,9 @@ packages:
     resolution:
       { integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg== }
 
-  fast-uri@3.1.5:
+  fast-uri@3.1.6:
     resolution:
-      { integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw== }
+      { integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q== }
 
   fast-wrap-ansi@0.2.0:
     resolution:
@@ -6149,9 +6158,9 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.17:
+  nanoid@3.3.18:
     resolution:
-      { integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g== }
+      { integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w== }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
@@ -6207,9 +6216,10 @@ packages:
     resolution:
       { integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw== }
 
-  node-releases@2.0.37:
+  node-releases@2.0.54:
     resolution:
-      { integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg== }
+      { integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ== }
+    engines: { node: '>=18' }
 
   normalize-path@3.0.0:
     resolution:
@@ -6508,9 +6518,9 @@ packages:
     peerDependencies:
       postcss: 8.5.23
 
-  postcss-selector-parser@7.1.1:
+  postcss-selector-parser@7.1.6:
     resolution:
-      { integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg== }
+      { integrity: sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw== }
     engines: { node: '>=4' }
 
   postcss-value-parser@4.2.0:
@@ -6579,9 +6589,9 @@ packages:
     resolution:
       { integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ== }
 
-  qs@6.15.3:
+  qs@6.16.0:
     resolution:
-      { integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A== }
+      { integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA== }
     engines: { node: '>=0.6' }
 
   queue-microtask@1.2.3:
@@ -7912,12 +7922,12 @@ packages:
     resolution:
       { integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg== }
 
-  update-browserslist-db@1.2.3:
+  update-browserslist-db@1.3.2:
     resolution:
-      { integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w== }
+      { integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw== }
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: '>=4.28.7'
 
   uplot@1.6.32:
     resolution:
@@ -8431,7 +8441,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -9624,12 +9634,17 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
+  '@humanfs/core@0.19.2':
     dependencies:
-      '@humanfs/core': 0.19.1
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
       '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -11386,7 +11401,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11580,7 +11595,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.19: {}
+  baseline-browser-mapping@2.11.20: {}
 
   body@5.1.0:
     dependencies:
@@ -11610,13 +11625,13 @@ snapshots:
     dependencies:
       wcwidth: 1.0.1
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.19
-      caniuse-lite: 1.0.30001788
-      electron-to-chromium: 1.5.340
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   bser@2.1.1:
     dependencies:
@@ -11651,7 +11666,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001788: {}
+  caniuse-lite@1.0.30001810: {}
 
   chalk@4.1.2:
     dependencies:
@@ -12154,7 +12169,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.340: {}
+  electron-to-chromium@1.5.420: {}
 
   emittery@0.13.1: {}
 
@@ -12466,7 +12481,7 @@ snapshots:
       '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
+      '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
@@ -12600,7 +12615,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -14052,7 +14067,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.6
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -14086,7 +14101,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
 
@@ -14321,20 +14336,20 @@ snapshots:
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.23)
       postcss: 8.5.23
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.6
       postcss-value-parser: 4.2.0
 
   postcss-modules-scope@3.2.1(postcss@8.5.23):
     dependencies:
       postcss: 8.5.23
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.6
 
   postcss-modules-values@4.0.0(postcss@8.5.23):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.23)
       postcss: 8.5.23
 
-  postcss-selector-parser@7.1.1:
+  postcss-selector-parser@7.1.6:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -14343,7 +14358,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14390,7 +14405,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -15341,7 +15356,7 @@ snapshots:
       faye-websocket: 0.10.0
       livereload-js: 2.4.0
       object-assign: 4.1.1
-      qs: 6.15.3
+      qs: 6.16.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15551,9 +15566,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -15706,7 +15721,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.1
       es-module-lexer: 2.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,8 +43,8 @@ overrides:
   # The 7.x advisory (GHSA-qwww-vcr4-c8h2, <7.18.2) is fixed below: react-router-dom@7.18.2
   # pins react-router 7.18.2 exactly, so the core fix arrives transitively.
   # Still flagged: GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg (>=6.0.0 <7.18.0) match the
-  # 6.30.4 copy. The react-router 6.x line ends at 6.30.4 — there is no 6.x patch, so this
-  # needs an upstream @grafana/ui bump off v5-compat, not an override here.
+  # 6.30.4 copy. No react-router 6.x release contains the patch, so this needs an upstream
+  # @grafana/ui bump off v5-compat, not an override here.
   react-router-dom: 7.18.2
   uuid: 14.0.1
   immutable: 5.1.8
@@ -53,7 +53,7 @@ overrides:
   strip-ansi: 6.0.1
   js-yaml: 4.3.1
   # Security patches for transitive vulnerabilities (pnpm audit)
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   undici: 8.9.0
   protobufjs: 8.6.5
   js-cookie: 3.0.8
@@ -67,11 +67,14 @@ overrides:
   'brace-expansion@^5': 5.0.9
   'ws@^8': 8.21.0
   'ws@>=7.0.0 <7.5.11': 7.5.11
-  qs: 6.15.3
+  qs: 6.16.0
   '@babel/core@<=7.29.0': 7.29.7
   '@opentelemetry/core@<2.8.0': 2.8.0
   tar@<=7.5.20: 7.5.22
   webpack: 5.108.1
   'websocket-driver@<0.7.5': 0.7.5
   'postcss@<8.5.18': 8.5.23
-  nanoid: 3.3.17
+  nanoid: 3.3.18
+  '@humanfs/node': '>=0.16.8'
+  browserslist: '>=4.28.7'
+  postcss-selector-parser: '>=7.1.3'


### PR DESCRIPTION
## Summary

Remediates the installable pnpm audit findings by updating validated pnpm overrides and the lockfile.

### Package changes

- `fast-uri`: override `3.1.5` -> `3.1.6`
- `qs`: override `6.15.3` -> `6.16.0`
- `@humanfs/node`: add override `>=0.16.8`; resolved `0.16.7` -> `0.16.8`
- `nanoid`: override `3.3.17` -> `3.3.18`
- `browserslist`: add override `>=4.28.7`; resolved `4.28.2` -> `4.28.8`
- `postcss-selector-parser`: add override `>=7.1.3`; resolved `7.1.1` -> `7.1.6`

All proposed versions were checked with `npm view <package>@<version> version` and `npm view <package>@<version> peerDependencies` before applying the overrides.

## Validation

- `pnpm install --no-frozen-lockfile` — passed, including supply-chain policy verification
- `pnpm install --frozen-lockfile` — passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed with 41 existing deprecation warnings
- `pnpm run test:ci` — passed (73 suites, 833 tests)
- `pnpm run build` — passed
- `pnpm audit` — exits 1 with 2 moderate vulnerabilities remaining; 0 low, 0 high, 0 critical
- CI E2E matrix — passed on Grafana 11.6.16, 12.1.10, 12.3.11, 13.0.8, 13.2.1, and nightly

## React Router v8 experiment

The metrics-drilldown alignment was tested locally: direct `react-router@^8.3.0` and `react-router-dom@^7.18.1`, a bare `react-router@^8.3.0` override, and `react-router-dom@^6` overridden to `^7.18.1`. Installation and build/typecheck passed, and `pnpm audit` became clean, but the experiment was reverted because `pnpm run test:ci` failed 59 suites when Jest loaded React Router 8's ESM-only files through `@grafana/scenes` and `react-router-dom-v5-compat`. A runtime-focused CJS load also failed because React Router 8 imports React 19's `useOptimistic` while this plugin uses React 18.3.1. React Router 8.3.x declares `react` and `react-dom >=19.2.7`, so retaining the override would be an unsupported compatibility risk rather than a safe remediation.

## Known remaining

- `GHSA-wrjc-x8rr-h8h6` — `react-router@6.30.4`: patched only in `>=7.18.0`; the vulnerable copy comes from `@grafana/ui -> react-router-dom-v5-compat@6.30.4`, and forcing it to a newer core is incompatible with the v5-compat dependency path and this plugin's React/Jest runtime. Requires an upstream `@grafana/ui` migration off v5-compat.
- `GHSA-337j-9hxr-rhxg` — `react-router@6.30.4`: same unpatchable 6.x dependency path and major-version incompatibility; requires the upstream migration.
