### PR TITLE
fix(deps): downgrade react-router-dom to 6.30.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "re2js": "1.4.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "7.18.3",
+    "react-router-dom": "6.30.6",
     "react-table": "7.8.0",
     "rxjs": "7.8.2",
     "semver": "7.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-router-dom: 7.18.3
+  react-router@^6: ^6.30.6
   uuid: 14.0.2
   immutable: 5.1.9
   dompurify: 3.4.14
@@ -68,10 +68,10 @@ importers:
         version: 13.2.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.5(jiti@2.7.0))(js-cookie@3.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/scenes':
         specifier: 8.16.1
-        version: 8.16.1(e3ef56f6543e085775ccc87186834c41)
+        version: 8.16.1(32cf2fce41d88b6363d4ea798afdc072)
       '@grafana/scenes-react':
         specifier: 8.16.1
-        version: 8.16.1(e3ef56f6543e085775ccc87186834c41)
+        version: 8.16.1(32cf2fce41d88b6363d4ea798afdc072)
       '@grafana/schema':
         specifier: 13.2.1
         version: 13.2.1
@@ -121,8 +121,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: 7.18.3
-        version: 7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.30.6
+        version: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table:
         specifier: 7.8.0
         version: 7.8.0(react@18.3.1)
@@ -1443,7 +1443,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 7.18.3
+      react-router-dom: ^6.28.0
       rxjs: ^7.8.1
 
   '@grafana/scenes@8.16.1':
@@ -1458,7 +1458,7 @@ packages:
       '@grafana/ui': '>=11.6'
       react: ^18.0.0
       react-dom: ^18.0.0
-      react-router-dom: 7.18.3
+      react-router-dom: ^6.28.0
       rxjs: ^7.8.1
 
   '@grafana/schema@13.2.1':
@@ -2553,6 +2553,11 @@ packages:
   '@remix-run/router@1.23.3':
     resolution:
       { integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q== }
+    engines: { node: '>=14.0.0' }
+
+  '@remix-run/router@1.23.4':
+    resolution:
+      { integrity: sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q== }
     engines: { node: '>=14.0.0' }
 
   '@rtsao/scc@1.1.0':
@@ -4097,11 +4102,6 @@ packages:
     resolution:
       { integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg== }
 
-  cookie@1.1.1:
-    resolution:
-      { integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ== }
-    engines: { node: '>=18' }
-
   copy-to-clipboard@3.3.3:
     resolution:
       { integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA== }
@@ -5599,6 +5599,10 @@ packages:
     resolution:
       { integrity: sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg== }
 
+  isarray@0.0.1:
+    resolution:
+      { integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ== }
+
   isarray@2.0.5:
     resolution:
       { integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw== }
@@ -6580,6 +6584,10 @@ packages:
       { integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg== }
     engines: { node: 18 || 20 || >=22 }
 
+  path-to-regexp@1.9.0:
+    resolution:
+      { integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g== }
+
   path-type@4.0.0:
     resolution:
       { integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw== }
@@ -6984,33 +6992,34 @@ packages:
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
-      react-router-dom: 7.18.3
+      react-router-dom: 4 || 5
 
-  react-router-dom@7.18.3:
+  react-router-dom@5.3.4:
     resolution:
-      { integrity: sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg== }
-    engines: { node: '>=20.0.0' }
+      { integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ== }
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=15'
 
-  react-router@6.30.4:
+  react-router-dom@6.30.6:
     resolution:
-      { integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA== }
+      { integrity: sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ== }
     engines: { node: '>=14.0.0' }
     peerDependencies:
       react: '>=16.8'
+      react-dom: '>=16.8'
 
-  react-router@7.18.3:
+  react-router@5.3.4:
     resolution:
-      { integrity: sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA== }
-    engines: { node: '>=20.0.0' }
+      { integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA== }
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
+      react: '>=15'
+
+  react-router@6.30.6:
+    resolution:
+      { integrity: sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg== }
+    engines: { node: '>=14.0.0' }
+    peerDependencies:
+      react: '>=16.8'
 
   react-scroll-sync@1.0.2:
     resolution:
@@ -7342,10 +7351,6 @@ packages:
   set-blocking@2.0.0:
     resolution:
       { integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw== }
-
-  set-cookie-parser@2.7.2:
-    resolution:
-      { integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw== }
 
   set-function-length@1.2.2:
     resolution:
@@ -9656,21 +9661,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@grafana/scenes-react@8.16.1(e3ef56f6543e085775ccc87186834c41)':
+  '@grafana/scenes-react@8.16.1(32cf2fce41d88b6363d4ea798afdc072)':
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
       '@grafana/data': 13.2.1(eslint@9.39.5(jiti@2.7.0))(js-cookie@3.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@grafana/e2e-selectors': 13.2.1
       '@grafana/runtime': 13.2.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.5(jiti@2.7.0))(js-cookie@3.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@grafana/scenes': 8.16.1(e3ef56f6543e085775ccc87186834c41)
+      '@grafana/scenes': 8.16.1(32cf2fce41d88b6363d4ea798afdc072)
       '@grafana/schema': 13.2.1
       '@grafana/ui': 13.2.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@types/react@18.3.31)(codemirror@6.0.2)(eslint@9.39.5(jiti@2.7.0))(js-cookie@3.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       lodash: 4.18.1
       lru-cache: 10.4.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router-dom: 7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rxjs: 7.8.2
     transitivePeerDependencies:
@@ -9678,7 +9683,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@grafana/scenes@8.16.1(e3ef56f6543e085775ccc87186834c41)':
+  '@grafana/scenes@8.16.1(32cf2fce41d88b6363d4ea798afdc072)':
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
@@ -9696,7 +9701,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-grid-layout: 1.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer: 1.0.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9781,8 +9786,8 @@ snapshots:
       react-hook-form: 7.72.1(react@18.3.1)
       react-inlinesvg: 4.5.0(react@18.3.1)
       react-loading-skeleton: 3.5.0(react@18.3.1)
-      react-router-dom: 7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom-v5-compat: 6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
+      react-router-dom-v5-compat: 6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1)
       react-select: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table: 7.8.0(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10677,7 +10682,7 @@ snapshots:
 
   '@rc-component/overflow@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@rc-component/resize-observer': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/util': 1.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -10750,7 +10755,7 @@ snapshots:
 
   '@rc-component/virtual-list@1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@rc-component/resize-observer': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/util': 1.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -10822,6 +10827,8 @@ snapshots:
       react-redux: 9.2.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1)
 
   '@remix-run/router@1.23.3': {}
+
+  '@remix-run/router@1.23.4': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -12038,8 +12045,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
-
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
@@ -12355,7 +12360,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
   dompurify@3.4.14:
@@ -13128,7 +13133,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -13462,6 +13467,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   is-window@1.0.2: {}
+
+  isarray@0.0.1: {}
 
   isarray@2.0.5: {}
 
@@ -14450,6 +14457,10 @@ snapshots:
       lru-cache: 11.3.5
       minipass: 7.1.3
 
+  path-to-regexp@1.9.0:
+    dependencies:
+      isarray: 0.0.1
+
   path-type@4.0.0: {}
 
   pbf@4.0.1:
@@ -14781,33 +14792,50 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom-v5-compat@6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  react-router-dom-v5-compat@6.30.4(react-dom@18.3.1(react@18.3.1))(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.3
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
-      react-router-dom: 7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 6.30.6(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
 
-  react-router-dom@7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@5.3.4(react@18.3.1):
     dependencies:
+      '@babel/runtime': 7.29.7
+      history: 4.10.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-router: 5.3.4(react@18.3.1)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+
+  react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 6.30.6(react@18.3.1)
 
-  react-router@6.30.4(react@18.3.1):
+  react-router@5.3.4(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      '@babel/runtime': 7.29.7
+      history: 4.10.1
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      path-to-regexp: 1.9.0
+      prop-types: 15.8.1
       react: 18.3.1
+      react-is: 16.13.1
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
 
-  react-router@7.18.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@6.30.6(react@18.3.1):
     dependencies:
-      cookie: 1.1.1
+      '@remix-run/router': 1.23.4
       react: 18.3.1
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   react-scroll-sync@1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -15024,7 +15052,7 @@ snapshots:
 
   rtl-css-js@1.16.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   run-async@4.0.6: {}
 
@@ -15108,8 +15136,6 @@ snapshots:
   serialize-javascript@7.1.1: {}
 
   set-blocking@2.0.0: {}
-
-  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,17 +37,10 @@ minimumReleaseAgeExclude:
   - protobufjs@8.6.6
 
 overrides:
-  # react-router itself is deliberately not overridden. The 6.30.4 copy comes from
-  # @grafana/ui -> react-router-dom-v5-compat@6.30.4, which imports UNSAFE_useRoutesImpl,
-  # UNSAFE_useRouteId and UNSAFE_logV6DeprecationWarnings — none of which react-router 7
-  # exports. A bare `react-router` override would collapse both majors onto 7.x and break
-  # @grafana/ui at runtime.
-  # The 7.x advisory (GHSA-qwww-vcr4-c8h2, <7.18.2) is fixed below: react-router-dom@7.18.2
-  # pins react-router 7.18.2 exactly, so the core fix arrives transitively.
-  # Still flagged: GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg (>=6.0.0 <7.18.0) match the
-  # 6.30.4 copy. No react-router 6.x release contains the patch, so this needs an upstream
-  # @grafana/ui bump off v5-compat, not an override here.
-  react-router-dom: 7.18.3
+  # v6 to match the router core supplies at runtime (externalized "react-router").
+  # Bumps the react-router-dom-v5-compat transitive copy to the 6.30.6 GHSA-jjmj-jmhj-qwj2
+  # backport without touching @grafana/ui's own v5 + v5-compat pairing.
+  react-router@^6: ^6.30.6
   uuid: 14.0.2
   immutable: 5.1.9
   dompurify: 3.4.14


### PR DESCRIPTION
## Summary 📝

- Downgrade `react-router-dom` from `7.18.3` to `6.30.6` to match the v6 router Grafana core actually supplies to plugins at runtime (the externalized `react-router` module resolves to core's `react-router-dom-v5-compat` → `react-router`), and rescope the pnpm override from a blanket `react-router-dom: 7.18.3` to `react-router@^6: ^6.30.6` — this picks up the GHSA-jjmj-jmhj-qwj2 backport for the `react-router-dom-v5-compat` transitive copy (previously `6.30.4`, in the vulnerable range) without forcing `@grafana/ui`'s own v5 + v5-compat pairing onto v6/v7.

> [!NOTE]
> Core itself (`grafana/grafana`) still ships the vulnerable `react-router@6.30.4` via `react-router-dom-v5-compat` — tracked in grafana/grafana#129933. This PR only fixes what logs-drilldown bundles/pins itself; it doesn't change what's live at runtime until core bumps too.

## Test 🧪

- [x] `pnpm run typecheck` passes
- [x] Targeted tests touching `react-router-dom` usage (`LogExplorationPage`, `Config.test`) pass — 38/38
- [x] Confirmed via `git grep` that no v7-only APIs (`createBrowserRouter`, `RouterProvider`, `ScrollRestoration`, loaders/actions, the `react-router/dom` subpath) are used, so the v6 downgrade is a clean drop-in
