### PR TITLE
chore(featureFlags): add local-only toggle overrides for GoFF flags

### DIFF
--- a/src/featureFlags/openFeature.test.ts
+++ b/src/featureFlags/openFeature.test.ts
@@ -150,6 +150,68 @@ describe('evaluateFeatureFlag', () => {
 
     config.featureToggles.queryLibrary = false;
   });
+
+  describe('featureToggle override for local dev', () => {
+    afterEach(() => {
+      const { config } = require('@grafana/runtime');
+      delete config.featureToggles.logsVolumeByField;
+    });
+
+    it('short-circuits to the enabled dev feature toggle without consulting the OpenFeature client', async () => {
+      const { config } = require('@grafana/runtime');
+      config.featureToggles.logsVolumeByField = true;
+
+      const result = await evaluateFeatureFlag('drilldown.logs.logsVolumeByField');
+
+      expect(result).toBe(true);
+      expect(getBooleanValue).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits to the disabled dev feature toggle without consulting the OpenFeature client', async () => {
+      const { config } = require('@grafana/runtime');
+      config.featureToggles.logsVolumeByField = false;
+
+      const result = await evaluateFeatureFlag('drilldown.logs.logsVolumeByField');
+
+      expect(result).toBe(false);
+      expect(getBooleanValue).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the OpenFeature client when the dev feature toggle is unset', async () => {
+      getBooleanValue.mockReturnValue(true);
+
+      const result = await evaluateFeatureFlag('drilldown.logs.logsVolumeByField');
+
+      expect(getBooleanValue).toHaveBeenCalledWith('drilldown.logs.logsVolumeByField', false);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('featureToggle override for kgAnnotationsInLokiExplore', () => {
+    afterEach(() => {
+      const { config } = require('@grafana/runtime');
+      delete config.featureToggles.kgAnnotationsInLokiExplore;
+    });
+
+    it('short-circuits to the enabled dev feature toggle without consulting the OpenFeature client', async () => {
+      const { config } = require('@grafana/runtime');
+      config.featureToggles.kgAnnotationsInLokiExplore = true;
+
+      const result = await evaluateFeatureFlag('drilldown.logs.kgAnnotationsInLokiExplore');
+
+      expect(result).toBe(true);
+      expect(getBooleanValue).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the OpenFeature client when the dev feature toggle is unset', async () => {
+      getBooleanValue.mockReturnValue(true);
+
+      const result = await evaluateFeatureFlag('drilldown.logs.kgAnnotationsInLokiExplore');
+
+      expect(getBooleanValue).toHaveBeenCalledWith('drilldown.logs.kgAnnotationsInLokiExplore', false);
+      expect(result).toBe(true);
+    });
+  });
 });
 
 describe('initOpenFeatureProvider', () => {

--- a/src/featureFlags/openFeature.ts
+++ b/src/featureFlags/openFeature.ts
@@ -32,6 +32,8 @@ type ValueTypeMap = {
  * ```
  */
 type CoreFeatureFlag<VT extends keyof ValueTypeMap> = {
+  /** Local-only `GF_FEATURE_TOGGLES_ENABLE` name that overrides this flag, bypassing GoFF entirely. */
+  featureToggle?: string;
   reason: string;
   value: ValueTypeMap[VT];
   valueType: VT;
@@ -57,6 +59,8 @@ type ExperimentFeatureFlag<
   Values extends ReadonlyArray<ValueTypeMap[VT]> = ReadonlyArray<ValueTypeMap[VT]>,
 > = {
   defaultValue: Values[number];
+  /** Local-only `GF_FEATURE_TOGGLES_ENABLE` name that overrides this flag, bypassing GoFF entirely. */
+  featureToggle?: string;
   trackingKey?: string;
   values: Values;
   valueType: VT;
@@ -128,12 +132,14 @@ const goffFeatureFlags = {
     value: false,
     reason: 'static provider evaluation result',
     variant: 'default',
+    featureToggle: 'kgAnnotationsInLokiExplore',
   },
   'drilldown.logs.logsVolumeByField': {
     valueType: 'boolean',
     value: false,
     reason: 'static provider evaluation result',
     variant: 'default',
+    featureToggle: 'logsVolumeByField',
   },
   logsTablePanelNG: {
     valueType: 'boolean',
@@ -303,16 +309,28 @@ function getConfigToggleFallback(flagName: string): boolean | undefined {
   if (flagName === 'exploreLogsShardSplitting') {
     return config.featureToggles.exploreLogsShardSplitting;
   }
-  if (
-    flagName === 'drilldown.logs.kgAnnotationsInLokiExplore' &&
-    'kgAnnotationsInLokiExplore' in config.featureToggles
-  ) {
-    return Boolean(config.featureToggles.kgAnnotationsInLokiExplore);
-  }
   if (flagName === 'logsTablePanelNG') {
     return config.featureToggles.logsTablePanelNG;
   }
   return undefined;
+}
+
+// Maps a `featureToggle` boolean override to the flag's real value type, or undefined if the toggle isn't set.
+function resolveFeatureToggleOverride<T extends FeatureFlagName>(flagDef: FeatureFlag): FlagValue<T> | undefined {
+  if (!('featureToggle' in flagDef) || !flagDef.featureToggle) {
+    return undefined;
+  }
+
+  const toggle = (config.featureToggles as Record<string, boolean | undefined>)[flagDef.featureToggle];
+  if (toggle === undefined) {
+    return undefined;
+  }
+
+  if (flagDef.valueType === 'string') {
+    return (toggle ? 'treatment' : 'control') as FlagValue<T>;
+  }
+
+  return toggle as FlagValue<T>;
 }
 
 /**
@@ -322,6 +340,11 @@ function getConfigToggleFallback(flagName: string): boolean | undefined {
  * @returns The value of the feature flag.
  */
 export async function evaluateFeatureFlag<T extends keyof typeof goffFeatureFlags>(flagName: T): Promise<FlagValue<T>> {
+  const override = resolveFeatureToggleOverride<T>(goffFeatureFlags[flagName] as FeatureFlag);
+  if (override !== undefined) {
+    return override;
+  }
+
   try {
     const client = OpenFeature.getClient(OPEN_FEATURE_DOMAIN);
     await waitForClientReady(client);


### PR DESCRIPTION
## Summary 📝

- Adds an optional `featureToggle` name to GoFF flag definitions in `src/featureFlags/openFeature.ts`; when the named toggle is set via `GF_FEATURE_TOGGLES_ENABLE`, evaluation short-circuits before calling GoFF/OpenFeature — mirrors the local-override pattern used in `metrics-drilldown`.
- Wires this up for `drilldown.logs.logsVolumeByField` and `drilldown.logs.kgAnnotationsInLokiExplore`, and removes the latter's now-redundant error-path fallback in `getConfigToggleFallback` (it only fired on GoFF errors and had no real core-toggle equivalent).

## Test 🧪

- [x] `pnpm typecheck` passes
- [x] `npx jest src/featureFlags/openFeature.test.ts` passes (12/12), including new coverage for the enabled/disabled override short-circuit and fallthrough-to-GoFF behavior for both flags
- [x] `eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)